### PR TITLE
feat: add ATHF MCP server (v0.11.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,17 +25,17 @@ This repository contains threat hunting investigations using the LOCK pattern (L
 
 ### ✅ ALWAYS Use CLI For
 
-| Task Category | CLI Command | ❌ Never Use |
-|---------------|-------------|-------------- |
-| **Hunt creation** | `athf hunt new --non-interactive` | Write tool, Edit tool |
-| **Investigation creation** | `athf investigate new --non-interactive` | Write tool, Edit tool |
-| **Research execution** | `athf research new --topic "..."` | Manual web search, Write tool |
-| **Hypothesis generation** | `athf agent run hypothesis-generator --threat-intel "..."` | Manual hypothesis drafting |
-| **Duplicate checking** | `athf similar "keywords"` | Grep, manual search |
-| **Context loading** | `athf context --hunt H-XXXX` | Multiple Read operations |
-| **Coverage analysis** | `athf hunt coverage` | Manual ATT&CK counting |
-| **Hunt validation** | `athf hunt validate H-XXXX` | Manual YAML parsing |
-| **Hunt search** | `athf hunt search "keyword"` | Grep, manual file search |
+| Task Category              | CLI Command                                                | ❌ Never Use                   |
+| -------------------------- | ---------------------------------------------------------- | ----------------------------- |
+| **Hunt creation**          | `athf hunt new --non-interactive`                          | Write tool, Edit tool         |
+| **Investigation creation** | `athf investigate new --non-interactive`                   | Write tool, Edit tool         |
+| **Research execution**     | `athf research new --topic "..."`                          | Manual web search, Write tool |
+| **Hypothesis generation**  | `athf agent run hypothesis-generator --threat-intel "..."` | Manual hypothesis drafting    |
+| **Duplicate checking**     | `athf similar "keywords"`                                  | Grep, manual search           |
+| **Context loading**        | `athf context --hunt H-XXXX`                               | Multiple Read operations      |
+| **Coverage analysis**      | `athf hunt coverage`                                       | Manual ATT&CK counting        |
+| **Hunt validation**        | `athf hunt validate H-XXXX`                                | Manual YAML parsing           |
+| **Hunt search**            | `athf hunt search "keyword"`                               | Grep, manual file search      |
 
 ### 🎯 CLI-First Policy
 
@@ -98,6 +98,7 @@ athf/                           # CLI source code
 │       └── hunt_researcher.py       # Pre-hunt research agent
 ├── commands/                   # CLI commands
 │   ├── agent.py                # Agent management
+│   ├── attack.py               # ATT&CK data management (STIX)
 │   ├── context.py              # Context export for AI
 │   ├── env.py                  # Virtual environment setup
 │   ├── hunt.py                 # Hunt management commands
@@ -106,7 +107,7 @@ athf/                           # CLI source code
 │   ├── research.py             # Research management
 │   └── similar.py              # Semantic search
 ├── core/                       # Core functionality
-│   ├── attack_matrix.py        # MITRE ATT&CK coverage
+│   ├── attack_matrix.py        # MITRE ATT&CK coverage (STIX provider + fallback)
 │   ├── hunt_manager.py         # Hunt lifecycle management
 │   ├── hunt_parser.py          # Hunt file parser
 │   ├── investigation_parser.py # Investigation parser
@@ -413,6 +414,12 @@ athf research view R-0001             # View specific research
 athf research search "credential access"  # Search research documents
 athf research stats                   # Show research metrics
 
+# ATT&CK data management (optional: pip install 'athf[attack]')
+athf attack update                    # Download/refresh STIX data
+athf attack status                    # Show provider type, version, cache info
+athf attack lookup T1003.001          # Look up technique metadata
+athf attack techniques credential-access  # List techniques for a tactic
+
 # Similarity search
 athf similar "LSASS dumping"          # Find similar hunts by query
 athf similar --hunt H-0001            # Find hunts similar to H-0001
@@ -596,6 +603,7 @@ ATHF includes bundled hunting knowledge files to inform hunt hypotheses and quer
 - Automated hypothesis generation (`athf agent run hypothesis-generator`) - **NEW**
 - Automated hunt research (`athf agent run hunt-researcher`) - **NEW**
 - ATT&CK coverage analysis (`athf hunt coverage`)
+- **ATT&CK STIX data** (`athf attack update/status/lookup/techniques`) - live technique metadata - **NEW**
 - Context loading optimization (`athf context`)
 - Session tracking (`athf session`)
 - MCP integrations (Notion, GitHub, custom tools)

--- a/README.md
+++ b/README.md
@@ -185,6 +185,28 @@ athf hunt coverage                  # MITRE ATT&CK coverage
 athf research stats                 # Research metrics
 ```
 
+### MCP Server (NEW in v0.11.0)
+
+```bash
+# Install MCP dependencies
+pip install 'athf[mcp]'
+
+# Start MCP server (for Claude Code, Copilot, Cursor, etc.)
+athf mcp serve --workspace /path/to/hunts
+```
+
+Configure in `~/.claude/mcp-servers.json`:
+```json
+{
+  "athf": {
+    "command": "athf-mcp",
+    "args": ["--workspace", "/path/to/hunts"]
+  }
+}
+```
+
+Exposes 14 tools: hunt management, semantic search, ATT&CK coverage, research, and AI-powered hypothesis generation — all accessible directly from your AI coding assistant.
+
 **Full documentation:** [CLI Reference](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/blob/main/docs/CLI_REFERENCE.md)
 
 ## 📺 See It In Action

--- a/README.md
+++ b/README.md
@@ -221,12 +221,14 @@ Configure in `~/.claude/mcp-servers.json`:
 {
   "athf": {
     "command": "athf-mcp",
-    "args": ["--workspace", "/path/to/hunts"]
+    "env": { "ATHF_WORKSPACE": "/path/to/your/hunts" }
   }
 }
 ```
 
-Exposes 14 tools: hunt management, semantic search, ATT&CK coverage, research, and AI-powered hypothesis generation — all accessible directly from your AI coding assistant.
+The standalone `athf-mcp` entry point auto-detects your workspace from cwd or `ATHF_WORKSPACE` env var. Use `athf mcp serve --workspace /path` for explicit paths.
+
+Exposes 17 tools: hunt management, semantic search, ATT&CK coverage, research, investigations, and AI-powered hypothesis generation — all accessible directly from your AI coding assistant.
 
 **Full documentation:** [CLI Reference](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/blob/main/docs/CLI_REFERENCE.md)
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ athf hunt coverage                  # MITRE ATT&CK coverage
 athf research stats                 # Research metrics
 ```
 
+### ATT&CK Data Management (NEW in v0.11.0)
+
+```bash
+# Install STIX support (optional)
+pip install 'athf[attack]'
+
+# Download live ATT&CK data (835+ techniques with full metadata)
+athf attack update
+
+# Check provider status
+athf attack status
+
+# Look up technique metadata
+athf attack lookup T1003.001
+
+# List techniques for a tactic
+athf attack techniques credential-access
+```
+
+Without `mitreattack-python`, ATHF uses a hardcoded v14 fallback (14 tactics, approximate counts). With it, you get full technique metadata: platforms, data sources, sub-techniques, and accurate counts.
+
 ### MCP Server (NEW in v0.11.0)
 
 ```bash

--- a/athf/cli.py
+++ b/athf/cli.py
@@ -10,7 +10,7 @@ from rich.console import Console
 load_dotenv()
 
 from athf.__version__ import __version__  # noqa: E402
-from athf.commands import context, env, hunt, init, investigate, research, similar, splunk  # noqa: E402
+from athf.commands import attack, context, env, hunt, init, investigate, research, similar, splunk  # noqa: E402
 from athf.commands.agent import agent  # noqa: E402
 from athf.commands.mcp import mcp  # noqa: E402
 from athf.plugin_system import PluginRegistry  # noqa: E402
@@ -88,6 +88,7 @@ cli.add_command(init)
 cli.add_command(hunt)
 cli.add_command(investigate)
 cli.add_command(research)
+cli.add_command(attack)
 
 # Phase 1 commands (env, context, similar)
 cli.add_command(env)

--- a/athf/cli.py
+++ b/athf/cli.py
@@ -12,6 +12,7 @@ load_dotenv()
 from athf.__version__ import __version__  # noqa: E402
 from athf.commands import context, env, hunt, init, investigate, research, similar, splunk  # noqa: E402
 from athf.commands.agent import agent  # noqa: E402
+from athf.commands.mcp import mcp  # noqa: E402
 from athf.plugin_system import PluginRegistry  # noqa: E402
 
 console = Console()
@@ -95,6 +96,9 @@ cli.add_command(similar)
 
 # Agent commands
 cli.add_command(agent)
+
+# MCP server command
+cli.add_command(mcp)
 
 # Integration commands (optional, requires additional dependencies)
 if splunk is not None:

--- a/athf/commands/__init__.py
+++ b/athf/commands/__init__.py
@@ -1,5 +1,6 @@
 """ATHF CLI commands (base commands only)."""
 
+from athf.commands.attack import attack
 from athf.commands.context import context
 from athf.commands.env import env
 from athf.commands.hunt import hunt
@@ -15,6 +16,7 @@ except ImportError:
     splunk = None  # type: ignore[assignment]
 
 __all__ = [
+    "attack",
     "init",
     "hunt",
     "investigate",

--- a/athf/commands/attack.py
+++ b/athf/commands/attack.py
@@ -1,0 +1,249 @@
+"""ATT&CK data management commands."""
+
+import time
+from typing import TYPE_CHECKING
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+if TYPE_CHECKING:
+    from athf.core.attack_matrix import TechniqueInfo
+
+console = Console()
+
+
+@click.group()
+def attack() -> None:
+    """Manage MITRE ATT&CK data.
+
+    \b
+    Commands for downloading, inspecting, and querying ATT&CK
+    technique data via the STIX framework.
+
+    \b
+    Quick Start:
+      athf attack update       Download/refresh STIX data
+      athf attack status       Show provider info and cache age
+      athf attack lookup T1003 Look up technique metadata
+    """
+
+
+@attack.command()
+@click.option("--force", is_flag=True, help="Re-download even if cache exists")
+def update(force: bool) -> None:
+    """Download or refresh ATT&CK STIX data.
+
+    Downloads the Enterprise ATT&CK STIX bundle from the official
+    MITRE repository and caches it locally.
+
+    \b
+    Examples:
+      athf attack update
+      athf attack update --force
+    """
+    try:
+        from mitreattack.stix20 import MitreAttackData
+    except ImportError:
+        console.print("[red]Error: mitreattack-python is not installed.[/red]")
+        console.print("[dim]Install it with: pip install 'athf[attack]'[/dim]")
+        raise click.Abort()
+
+    from athf.core.attack_matrix import _get_stix_file_path, reset_provider
+
+    stix_path = _get_stix_file_path()
+
+    if stix_path.exists() and not force:
+        age_days = int((time.time() - stix_path.stat().st_mtime) / 86400)
+        console.print(f"[yellow]STIX data already exists (age: {age_days}d).[/yellow]")
+        console.print("[dim]Use --force to re-download.[/dim]")
+        return
+
+    # Ensure cache directory exists
+    stix_path.parent.mkdir(parents=True, exist_ok=True)
+
+    console.print("[cyan]Downloading ATT&CK Enterprise STIX data...[/cyan]")
+    console.print(f"[dim]Cache location: {stix_path}[/dim]")
+
+    try:
+        MitreAttackData.stix_store_to_file(
+            "enterprise-attack",
+            str(stix_path),
+        )
+        # Reset provider so it picks up the new data
+        reset_provider()
+        console.print("[green]ATT&CK STIX data downloaded successfully.[/green]")
+
+        # Show summary
+        from athf.core.attack_matrix import get_attack_version, is_using_stix
+
+        if is_using_stix():
+            console.print(f"[dim]Version: {get_attack_version()}[/dim]")
+    except Exception as e:
+        console.print(f"[red]Error downloading STIX data: {e}[/red]")
+        raise click.Abort()
+
+
+@attack.command()
+def status() -> None:
+    """Show ATT&CK data provider status.
+
+    Displays the active provider type, ATT&CK version,
+    technique counts, and cache file details.
+
+    \b
+    Example:
+      athf attack status
+    """
+    from athf.core.attack_matrix import (
+        _get_stix_file_path,
+        get_attack_version,
+        get_sorted_tactics,
+        is_using_stix,
+    )
+
+    console.print("\n[bold]ATT&CK Data Status[/bold]\n")
+
+    provider_type = "STIX (mitreattack-python)" if is_using_stix() else "Fallback (hardcoded v14)"
+    console.print(f"  [cyan]Provider:[/cyan]  {provider_type}")
+    console.print(f"  [cyan]Version:[/cyan]   {get_attack_version()}")
+    console.print(f"  [cyan]Tactics:[/cyan]   {len(get_sorted_tactics())}")
+
+    # Show cache info
+    stix_path = _get_stix_file_path()
+    if stix_path.exists():
+        size_mb = stix_path.stat().st_size / (1024 * 1024)
+        age_days = int((time.time() - stix_path.stat().st_mtime) / 86400)
+        console.print(f"  [cyan]Cache:[/cyan]     {stix_path}")
+        console.print(f"  [cyan]Size:[/cyan]      {size_mb:.1f} MB")
+        console.print(f"  [cyan]Age:[/cyan]       {age_days} days")
+    else:
+        console.print(f"  [cyan]Cache:[/cyan]     Not found ({stix_path})")
+        console.print("[dim]  Run 'athf attack update' to download STIX data.[/dim]")
+
+    # Check if mitreattack-python is installed
+    try:
+        import mitreattack  # noqa: F401
+        console.print("  [cyan]Library:[/cyan]   mitreattack-python installed")
+    except ImportError:
+        console.print("  [cyan]Library:[/cyan]   [yellow]mitreattack-python not installed[/yellow]")
+        console.print("[dim]  Install with: pip install 'athf[attack]'[/dim]")
+
+    console.print()
+
+
+def _display_technique_fields(tech: "TechniqueInfo") -> None:
+    """Print technique metadata fields to the console."""
+    if tech.get("url"):
+        console.print(f"  [cyan]URL:[/cyan]           {tech['url']}")
+    if tech.get("platforms"):
+        console.print(f"  [cyan]Platforms:[/cyan]     {', '.join(tech['platforms'])}")
+    if tech.get("tactic_shortnames"):
+        console.print(f"  [cyan]Tactics:[/cyan]       {', '.join(tech['tactic_shortnames'])}")
+    if tech.get("data_sources"):
+        console.print(f"  [cyan]Data Sources:[/cyan]  {', '.join(tech['data_sources'][:5])}")
+        if len(tech.get("data_sources", [])) > 5:
+            console.print(f"                 [dim]... and {len(tech['data_sources']) - 5} more[/dim]")
+    is_sub = tech.get("is_subtechnique", False)
+    console.print(f"  [cyan]Type:[/cyan]          {'Sub-technique' if is_sub else 'Technique'}")
+    if is_sub and tech.get("parent_id"):
+        console.print(f"  [cyan]Parent:[/cyan]        {tech['parent_id']}")
+    if tech.get("description"):
+        desc = tech["description"]
+        if len(desc) > 300:
+            desc = desc[:300] + "..."
+        console.print(f"\n  [dim]{desc}[/dim]")
+
+
+@attack.command()
+@click.argument("technique_id")
+def lookup(technique_id: str) -> None:
+    """Look up an ATT&CK technique by ID.
+
+    Shows technique metadata including name, platforms,
+    data sources, tactics, and sub-techniques.
+
+    \b
+    Examples:
+      athf attack lookup T1003
+      athf attack lookup T1003.001
+    """
+    from athf.core.attack_matrix import get_sub_techniques, get_technique, is_using_stix
+
+    if not is_using_stix():
+        console.print("[yellow]STIX data not available. Technique lookup requires STIX.[/yellow]")
+        console.print("[dim]Install and update: pip install 'athf[attack]' && athf attack update[/dim]")
+        return
+
+    tech = get_technique(technique_id)
+    if tech is None:
+        console.print(f"[yellow]Technique {technique_id} not found.[/yellow]")
+        return
+
+    console.print(f"\n[bold]{tech.get('id', '')} - {tech.get('name', '')}[/bold]\n")
+    _display_technique_fields(tech)
+
+    # Show sub-techniques if this is a parent
+    if not tech.get("is_subtechnique", False):
+        subs = get_sub_techniques(technique_id)
+        if subs:
+            console.print(f"\n  [bold]Sub-techniques ({len(subs)}):[/bold]")
+            for sub in subs:
+                console.print(f"    {sub.get('id', '')} - {sub.get('name', '')}")
+
+    console.print()
+
+
+@attack.command()
+@click.argument("tactic_key")
+def techniques(tactic_key: str) -> None:
+    """List techniques for a tactic.
+
+    Shows all techniques mapped to the specified tactic key
+    (e.g., credential-access, lateral-movement).
+
+    \b
+    Examples:
+      athf attack techniques credential-access
+      athf attack techniques lateral-movement
+    """
+    from athf.core.attack_matrix import (
+        get_tactic_display_name,
+        get_techniques_for_tactic,
+        is_using_stix,
+    )
+
+    if not is_using_stix():
+        console.print("[yellow]STIX data not available. Technique listing requires STIX.[/yellow]")
+        console.print("[dim]Install and update: pip install 'athf[attack]' && athf attack update[/dim]")
+        return
+
+    techs = get_techniques_for_tactic(tactic_key)
+    if not techs:
+        console.print(f"[yellow]No techniques found for tactic '{tactic_key}'.[/yellow]")
+        console.print("[dim]Use a tactic shortname like: credential-access, lateral-movement[/dim]")
+        return
+
+    display_name = get_tactic_display_name(tactic_key)
+    console.print(f"\n[bold]{display_name}[/bold] ({len(techs)} techniques)\n")
+
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("ID", style="white", width=12)
+    table.add_column("Name", style="white")
+    table.add_column("Sub?", style="dim", width=4)
+    table.add_column("Platforms", style="dim")
+
+    for tech in techs:
+        is_sub = "Yes" if tech.get("is_subtechnique", False) else ""
+        platforms = ", ".join(tech.get("platforms", [])[:3])
+        if len(tech.get("platforms", [])) > 3:
+            platforms += "..."
+        table.add_row(
+            tech.get("id", ""),
+            tech.get("name", ""),
+            is_sub,
+            platforms,
+        )
+
+    console.print(table)
+    console.print()

--- a/athf/commands/mcp.py
+++ b/athf/commands/mcp.py
@@ -29,6 +29,6 @@ def serve(workspace: str) -> None:
         from athf.mcp.server import main as mcp_main
     except ImportError:
         click.echo("Error: MCP dependencies not installed. Install with: pip install 'athf[mcp]'", err=True)
-        raise SystemExit(1)
+        raise SystemExit(1) from None
 
     mcp_main(workspace_path=workspace)

--- a/athf/commands/mcp.py
+++ b/athf/commands/mcp.py
@@ -1,0 +1,34 @@
+"""MCP server CLI command."""
+
+import click
+
+
+@click.group()
+def mcp() -> None:
+    """MCP server for AI assistant integration."""
+
+
+@mcp.command()
+@click.option("--workspace", default=None, help="Explicit workspace path (auto-detected if not set)")
+def serve(workspace: str) -> None:
+    """Start the ATHF MCP server (stdio transport).
+
+    This exposes ATHF operations as MCP tools that AI assistants
+    (Claude Code, Copilot, Cursor, etc.) can call directly.
+
+    \b
+    Configuration for Claude Code (~/.claude/mcp-servers.json):
+      {
+        "athf": {
+          "command": "athf-mcp",
+          "args": ["--workspace", "/path/to/hunts"]
+        }
+      }
+    """
+    try:
+        from athf.mcp.server import main as mcp_main
+    except ImportError:
+        click.echo("Error: MCP dependencies not installed. Install with: pip install 'athf[mcp]'", err=True)
+        raise SystemExit(1)
+
+    mcp_main(workspace_path=workspace)

--- a/athf/core/attack_matrix.py
+++ b/athf/core/attack_matrix.py
@@ -1,11 +1,28 @@
-"""MITRE ATT&CK Matrix reference data.
+"""MITRE ATT&CK Matrix reference data with optional STIX integration.
 
-This module contains reference data for the MITRE ATT&CK Enterprise matrix,
-including tactic ordering and technique counts.
+This module provides ATT&CK tactic and technique data through a provider
+abstraction. When mitreattack-python is installed, it uses live STIX data
+(835+ techniques with full metadata). Otherwise, it falls back to a
+hardcoded dictionary of 14 tactics with approximate counts.
+
+Backward compatible: ATTACK_TACTICS, TOTAL_TECHNIQUES, and all existing
+functions continue to work identically via module-level __getattr__.
 """
 
-from typing import Dict, List, TypedDict
+import json
+import logging
+import os
+import time
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TypedDict
 
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Type definitions
+# ---------------------------------------------------------------------------
 
 class TacticInfo(TypedDict):
     """Type definition for tactic information."""
@@ -15,9 +32,25 @@ class TacticInfo(TypedDict):
     order: int
 
 
-# MITRE ATT&CK Enterprise Matrix v14 (January 2024)
-# Approximate technique counts per tactic (includes sub-techniques)
-ATTACK_TACTICS: Dict[str, TacticInfo] = {
+class TechniqueInfo(TypedDict, total=False):
+    """Type definition for technique metadata from STIX data."""
+
+    id: str
+    name: str
+    description: str
+    platforms: List[str]
+    data_sources: List[str]
+    tactic_shortnames: List[str]
+    is_subtechnique: bool
+    parent_id: Optional[str]
+    url: str
+
+
+# ---------------------------------------------------------------------------
+# Fallback data (MITRE ATT&CK Enterprise Matrix v14, January 2024)
+# ---------------------------------------------------------------------------
+
+_FALLBACK_TACTICS: Dict[str, TacticInfo] = {
     "reconnaissance": {
         "name": "Reconnaissance",
         "technique_count": 10,
@@ -90,9 +123,336 @@ ATTACK_TACTICS: Dict[str, TacticInfo] = {
     },
 }
 
-# Total techniques across all tactics
-TOTAL_TECHNIQUES = sum(tactic["technique_count"] for tactic in ATTACK_TACTICS.values())
 
+# ---------------------------------------------------------------------------
+# Provider abstraction
+# ---------------------------------------------------------------------------
+
+class AttackDataProvider(ABC):
+    """Abstract base class for ATT&CK data providers."""
+
+    @abstractmethod
+    def get_tactics(self) -> Dict[str, TacticInfo]:
+        """Return all tactics as {shortname: TacticInfo}."""
+
+    @abstractmethod
+    def get_total_techniques(self) -> int:
+        """Return the total number of techniques across all tactics."""
+
+    @abstractmethod
+    def get_sorted_tactic_keys(self) -> List[str]:
+        """Return tactic keys sorted by ATT&CK matrix order."""
+
+    @abstractmethod
+    def get_technique_by_id(self, technique_id: str) -> Optional[TechniqueInfo]:
+        """Look up a technique by its ATT&CK ID (e.g., 'T1003.001')."""
+
+    @abstractmethod
+    def get_techniques_for_tactic(self, tactic_key: str) -> List[TechniqueInfo]:
+        """Return all techniques mapped to a given tactic."""
+
+    @abstractmethod
+    def get_sub_techniques(self, parent_id: str) -> List[TechniqueInfo]:
+        """Return sub-techniques for a parent technique ID (e.g., 'T1003')."""
+
+    @abstractmethod
+    def get_version(self) -> str:
+        """Return the ATT&CK version string."""
+
+    @abstractmethod
+    def is_stix(self) -> bool:
+        """Return True if backed by live STIX data."""
+
+
+# ---------------------------------------------------------------------------
+# Fallback provider (hardcoded data)
+# ---------------------------------------------------------------------------
+
+class FallbackProvider(AttackDataProvider):
+    """Provider backed by the hardcoded v14 tactic dictionary."""
+
+    def get_tactics(self) -> Dict[str, TacticInfo]:
+        return _FALLBACK_TACTICS
+
+    def get_total_techniques(self) -> int:
+        return sum(t["technique_count"] for t in _FALLBACK_TACTICS.values())
+
+    def get_sorted_tactic_keys(self) -> List[str]:
+        return sorted(_FALLBACK_TACTICS.keys(), key=lambda k: _FALLBACK_TACTICS[k]["order"])
+
+    def get_technique_by_id(self, technique_id: str) -> Optional[TechniqueInfo]:
+        return None
+
+    def get_techniques_for_tactic(self, tactic_key: str) -> List[TechniqueInfo]:
+        return []
+
+    def get_sub_techniques(self, parent_id: str) -> List[TechniqueInfo]:
+        return []
+
+    def get_version(self) -> str:
+        return "v14 (hardcoded fallback)"
+
+    def is_stix(self) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# STIX provider (mitreattack-python)
+# ---------------------------------------------------------------------------
+
+def _get_stix_cache_dir() -> Path:
+    """Return the STIX data cache directory.
+
+    Checks (in order):
+    1. ATHF_STIX_CACHE env var
+    2. {workspace}/.athf/stix-data/ if .athfconfig.yaml exists
+    3. ~/.athf/stix-data/ (global default)
+    """
+    env_path = os.environ.get("ATHF_STIX_CACHE")
+    if env_path:
+        return Path(env_path)
+
+    # Check for workspace-local cache
+    cwd = Path.cwd()
+    if (cwd / ".athfconfig.yaml").exists():
+        return cwd / ".athf" / "stix-data"
+
+    # Global default
+    return Path.home() / ".athf" / "stix-data"
+
+
+def _get_stix_file_path() -> Path:
+    """Return the expected path for the STIX JSON file."""
+    return _get_stix_cache_dir() / "enterprise-attack.json"
+
+
+class StixProvider(AttackDataProvider):
+    """Provider backed by STIX data via mitreattack-python.
+
+    Lazily loads data on first access and caches results in memory.
+    """
+
+    def __init__(self, stix_path: Optional[Path] = None):
+        self._stix_path = stix_path or _get_stix_file_path()
+        self._attack_data: Any = None  # MitreAttackData instance
+        self._tactics_cache: Optional[Dict[str, TacticInfo]] = None
+        self._technique_cache: Optional[Dict[str, TechniqueInfo]] = None
+        self._tactic_techniques_cache: Dict[str, List[TechniqueInfo]] = {}
+
+    def _ensure_loaded(self) -> None:
+        """Lazily load STIX data on first access."""
+        if self._attack_data is not None:
+            return
+
+        from mitreattack.stix20 import MitreAttackData
+
+        if not self._stix_path.exists():
+            raise FileNotFoundError(
+                f"STIX data not found at {self._stix_path}. "
+                "Run 'athf attack update' to download it."
+            )
+
+        logger.debug("Loading STIX data from %s", self._stix_path)
+        self._attack_data = MitreAttackData(str(self._stix_path))
+
+    def _build_tactics(self) -> Dict[str, TacticInfo]:
+        """Build tactic dictionary from STIX data."""
+        self._ensure_loaded()
+
+        tactics: Dict[str, TacticInfo] = {}
+        stix_tactics = self._attack_data.get_tactics(remove_revoked_deprecated=True)
+
+        # Sort by kill chain order (x_mitre_shortname field maps to order)
+        tactic_order = [
+            "reconnaissance", "resource-development", "initial-access",
+            "execution", "persistence", "privilege-escalation",
+            "defense-evasion", "credential-access", "discovery",
+            "lateral-movement", "collection", "command-and-control",
+            "exfiltration", "impact",
+        ]
+        order_map = {k: i + 1 for i, k in enumerate(tactic_order)}
+
+        for stix_tactic in stix_tactics:
+            shortname = stix_tactic.get("x_mitre_shortname", "")
+            if not shortname:
+                continue
+
+            # Count techniques for this tactic
+            techniques = self._attack_data.get_techniques_by_tactic(
+                stix_tactic["id"], "enterprise-attack", remove_revoked_deprecated=True
+            )
+
+            tactics[shortname] = TacticInfo(
+                name=stix_tactic["name"],
+                technique_count=len(techniques),
+                order=order_map.get(shortname, 99),
+            )
+
+        return tactics
+
+    def _build_technique_index(self) -> Dict[str, TechniqueInfo]:
+        """Build technique lookup index from STIX data."""
+        self._ensure_loaded()
+
+        index: Dict[str, TechniqueInfo] = {}
+        techniques = self._attack_data.get_techniques(remove_revoked_deprecated=True)
+
+        for tech in techniques:
+            ext_refs = tech.get("external_references", [])
+            attack_id = ""
+            url = ""
+            for ref in ext_refs:
+                if ref.get("source_name") == "mitre-attack":
+                    attack_id = ref.get("external_id", "")
+                    url = ref.get("url", "")
+                    break
+
+            if not attack_id:
+                continue
+
+            is_sub = tech.get("x_mitre_is_subtechnique", False)
+            parent_id = None
+            if is_sub and "." in attack_id:
+                parent_id = attack_id.split(".")[0]
+
+            # Extract tactic shortnames from kill chain phases
+            tactic_shortnames: List[str] = []
+            for phase in tech.get("kill_chain_phases", []):
+                if phase.get("kill_chain_name") == "mitre-attack":
+                    tactic_shortnames.append(phase["phase_name"])
+
+            # Extract data sources
+            data_sources: List[str] = tech.get("x_mitre_data_sources", [])
+
+            index[attack_id] = TechniqueInfo(
+                id=attack_id,
+                name=tech.get("name", ""),
+                description=tech.get("description", "")[:500],
+                platforms=tech.get("x_mitre_platforms", []),
+                data_sources=data_sources if data_sources else [],
+                tactic_shortnames=tactic_shortnames,
+                is_subtechnique=is_sub,
+                parent_id=parent_id,
+                url=url,
+            )
+
+        return index
+
+    def get_tactics(self) -> Dict[str, TacticInfo]:
+        if self._tactics_cache is None:
+            self._tactics_cache = self._build_tactics()
+        return self._tactics_cache
+
+    def get_total_techniques(self) -> int:
+        return sum(t["technique_count"] for t in self.get_tactics().values())
+
+    def get_sorted_tactic_keys(self) -> List[str]:
+        tactics = self.get_tactics()
+        return sorted(tactics.keys(), key=lambda k: tactics[k]["order"])
+
+    def get_technique_by_id(self, technique_id: str) -> Optional[TechniqueInfo]:
+        if self._technique_cache is None:
+            self._technique_cache = self._build_technique_index()
+        return self._technique_cache.get(technique_id.upper())
+
+    def get_techniques_for_tactic(self, tactic_key: str) -> List[TechniqueInfo]:
+        if tactic_key in self._tactic_techniques_cache:
+            return self._tactic_techniques_cache[tactic_key]
+
+        if self._technique_cache is None:
+            self._technique_cache = self._build_technique_index()
+
+        result = [
+            t for t in self._technique_cache.values()
+            if tactic_key in t.get("tactic_shortnames", [])
+        ]
+        result.sort(key=lambda t: t.get("id", ""))
+        self._tactic_techniques_cache[tactic_key] = result
+        return result
+
+    def get_sub_techniques(self, parent_id: str) -> List[TechniqueInfo]:
+        if self._technique_cache is None:
+            self._technique_cache = self._build_technique_index()
+
+        parent = parent_id.upper()
+        return sorted(
+            [t for t in self._technique_cache.values() if t.get("parent_id") == parent],
+            key=lambda t: t.get("id", ""),
+        )
+
+    def get_version(self) -> str:
+        self._ensure_loaded()
+        # Try to extract version from STIX bundle
+        try:
+            with open(str(self._stix_path), "r") as f:
+                bundle = json.load(f)
+            for obj in bundle.get("objects", []):
+                if obj.get("type") == "x-mitre-collection":
+                    version = obj.get("x_mitre_version", "")
+                    if version:
+                        return f"v{version} (STIX)"
+        except Exception:
+            pass
+
+        # Fallback: use file modification time
+        mtime = self._stix_path.stat().st_mtime
+        age_days = int((time.time() - mtime) / 86400)
+        return f"STIX (downloaded {age_days}d ago)"
+
+    def is_stix(self) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Provider singleton
+# ---------------------------------------------------------------------------
+
+_provider: Optional[AttackDataProvider] = None
+
+
+def _get_provider() -> AttackDataProvider:
+    """Get or create the singleton ATT&CK data provider.
+
+    Auto-selects StixProvider if mitreattack-python is installed AND
+    cached STIX data exists, otherwise falls back to FallbackProvider.
+    """
+    global _provider
+    if _provider is not None:
+        return _provider
+
+    try:
+        import mitreattack.stix20  # noqa: F401
+        stix_path = _get_stix_file_path()
+        if stix_path.exists():
+            _provider = StixProvider(stix_path)
+            logger.debug("Using STIX provider: %s", stix_path)
+        else:
+            logger.debug(
+                "mitreattack-python installed but no STIX data at %s. "
+                "Run 'athf attack update' to download. Using fallback.",
+                stix_path,
+            )
+            _provider = FallbackProvider()
+    except ImportError:
+        logger.debug("mitreattack-python not installed. Using fallback provider.")
+        _provider = FallbackProvider()
+
+    return _provider
+
+
+def reset_provider(provider: Optional[AttackDataProvider] = None) -> None:
+    """Reset the provider singleton (for testing or after update).
+
+    Args:
+        provider: Optional specific provider to use. If None, auto-selects.
+    """
+    global _provider
+    _provider = provider
+
+
+# ---------------------------------------------------------------------------
+# Original public API (backward compatible)
+# ---------------------------------------------------------------------------
 
 def get_tactic_display_name(tactic_key: str) -> str:
     """Get the display name for a tactic key.
@@ -103,8 +463,9 @@ def get_tactic_display_name(tactic_key: str) -> str:
     Returns:
         Display name (e.g., "Credential Access")
     """
-    if tactic_key in ATTACK_TACTICS:
-        return ATTACK_TACTICS[tactic_key]["name"]
+    tactics = _get_provider().get_tactics()
+    if tactic_key in tactics:
+        return tactics[tactic_key]["name"]
     return tactic_key.replace("-", " ").title()
 
 
@@ -117,8 +478,9 @@ def get_tactic_technique_count(tactic_key: str) -> int:
     Returns:
         Total technique count for the tactic
     """
-    if tactic_key in ATTACK_TACTICS:
-        return ATTACK_TACTICS[tactic_key]["technique_count"]
+    tactics = _get_provider().get_tactics()
+    if tactic_key in tactics:
+        return tactics[tactic_key]["technique_count"]
     return 0
 
 
@@ -128,4 +490,67 @@ def get_sorted_tactics() -> List[str]:
     Returns:
         List of tactic keys in matrix order
     """
-    return sorted(ATTACK_TACTICS.keys(), key=lambda k: ATTACK_TACTICS[k]["order"])
+    return _get_provider().get_sorted_tactic_keys()
+
+
+# ---------------------------------------------------------------------------
+# New public API
+# ---------------------------------------------------------------------------
+
+def get_technique(technique_id: str) -> Optional[TechniqueInfo]:
+    """Look up a technique by ATT&CK ID.
+
+    Args:
+        technique_id: ATT&CK technique ID (e.g., "T1003.001")
+
+    Returns:
+        TechniqueInfo dict or None if not found / using fallback provider.
+    """
+    return _get_provider().get_technique_by_id(technique_id)
+
+
+def get_techniques_for_tactic(tactic_key: str) -> List[TechniqueInfo]:
+    """Get all techniques mapped to a tactic.
+
+    Args:
+        tactic_key: Tactic shortname (e.g., "credential-access")
+
+    Returns:
+        List of TechniqueInfo dicts. Empty if using fallback provider.
+    """
+    return _get_provider().get_techniques_for_tactic(tactic_key)
+
+
+def get_sub_techniques(parent_id: str) -> List[TechniqueInfo]:
+    """Get sub-techniques for a parent technique.
+
+    Args:
+        parent_id: Parent technique ID (e.g., "T1003")
+
+    Returns:
+        List of TechniqueInfo dicts. Empty if using fallback provider.
+    """
+    return _get_provider().get_sub_techniques(parent_id)
+
+
+def get_attack_version() -> str:
+    """Get the ATT&CK data version string."""
+    return _get_provider().get_version()
+
+
+def is_using_stix() -> bool:
+    """Check if using live STIX data."""
+    return _get_provider().is_stix()
+
+
+# ---------------------------------------------------------------------------
+# Module-level __getattr__ (PEP 562) for backward compatibility
+# ---------------------------------------------------------------------------
+
+def __getattr__(name: str) -> Any:
+    """Support 'from athf.core.attack_matrix import ATTACK_TACTICS'."""
+    if name == "ATTACK_TACTICS":
+        return _get_provider().get_tactics()
+    if name == "TOTAL_TECHNIQUES":
+        return _get_provider().get_total_techniques()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/athf/data/docs/CHANGELOG.md
+++ b/athf/data/docs/CHANGELOG.md
@@ -241,4 +241,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ATHF is a framework to internalize, not a platform to extend. However, if you've adapted ATHF in interesting ways or have feedback, we'd love to hear about it in [GitHub Discussions](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/discussions).
 
-For more on the philosophy, see [USING_ATHF.md](../USING_ATHF.md).
+For more on the philosophy, see [USING_ATHF.md](../../../USING_ATHF.md).

--- a/athf/data/docs/CHANGELOG.md
+++ b/athf/data/docs/CHANGELOG.md
@@ -5,25 +5,62 @@ All notable changes to the Agentic Threat Hunting Framework (ATHF) will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0] - Unreleased
 
 ### Added
-- None
+- **MCP Server** — Expose ATHF operations as MCP tools for AI assistants (Claude Code, Copilot, Cursor)
+  - 14 tools: hunt list/search/get/stats/coverage/validate/new, similar, context, research list/view/search/stats, investigate list/search, agent hypothesis/researcher
+  - `athf mcp serve` CLI command and `athf-mcp` standalone entry point
+  - Auto-detect workspace from cwd or `ATHF_WORKSPACE` env var
+  - Install with: `pip install 'athf[mcp]'`
+
+## [0.10.0] - 2026-03-16
+
+### Added
+- **Model-agnostic LLM provider abstraction** — Replace hardcoded AWS Bedrock with support for Claude, GPT, Gemini, Ollama, and any OpenAI-compatible endpoint
+  - `athf/core/llm_provider.py` with 4 providers (LiteLLM, Bedrock, Ollama, OpenAI-compatible)
+  - Auto-detection from environment variables with layered config resolution
+  - Cost tracker with fuzzy model name matching (`athf/core/cost_tracker.py`)
+  - Validation-retry loop for agent self-correction on malformed LLM output
+- **Parallel research** — Skills 1-4 run concurrently via ThreadPoolExecutor (~4x faster)
 
 ### Changed
-- None
+- Updated docs (CLI_REFERENCE, DOCKER.md, docker-compose.yml) for multi-provider support
+- All agent code now uses provider abstraction instead of direct Bedrock calls
 
-### Deprecated
-- None
-
-### Removed
-- None
+## [0.7.1] - 2026-02-06
 
 ### Fixed
-- None
+- **Documentation Links** - Fixed invalid `athf/data/` path prefixes in AGENTS.md ([#9](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/issues/9))
+  - Removed 11 incorrect path references
+  - All documentation links now point to correct repository structure
+- **Environment Directory Filtering** - Added directory filtering for hunt management ([#8](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/issues/8))
+  - `athf hunt list` now displays environment column (test/production)
+  - Added `--directory` filter option to `athf hunt list` command
+  - Added `--directory` filter option to `athf hunt search` command
+  - Updated CLI documentation in CLI_REFERENCE.md and README.md
 
-### Security
-- None
+## [0.6.0] - 2026-01-27
+
+### Added
+- **Investigation Auto-Linking** - Automatic investigation frontmatter update when promoting to hunt ([#7](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/issues/7))
+  - `athf investigate promote` now automatically adds hunt ID to investigation's `related_hunts` field
+  - Provides visibility into which investigations have been promoted
+  - Prevents duplicate hunt IDs with duplicate check logic
+  - Graceful error handling with warning messages if frontmatter update fails
+- **Path Validation** - Enhanced security for file operations
+  - Added path traversal protection in investigation commands (new, validate, promote)
+  - Validates all file paths are within expected directories before operations
+
+### Fixed
+- **Version Reporting** - Corrected version display ([#6](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/issues/6))
+  - Fixed `athf --version` showing 0.4.0 instead of current release version
+  - Updated `athf/__version__.py` to accurately reflect release version
+
+## [0.5.2] - 2026-01-XX
+
+### Fixed
+- Documentation corrections for CLI parameters
 
 ## [0.4.0] - 2026-01-14
 
@@ -196,4 +233,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ATHF is a framework to internalize, not a platform to extend. However, if you've adapted ATHF in interesting ways or have feedback, we'd love to hear about it in [GitHub Discussions](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/discussions).
 
-For more on the philosophy, see [USING_ATHF.md](../../../USING_ATHF.md).
+For more on the philosophy, see [USING_ATHF.md](../USING_ATHF.md).

--- a/athf/data/docs/CHANGELOG.md
+++ b/athf/data/docs/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `athf mcp serve` CLI command and `athf-mcp` standalone entry point
   - Auto-detect workspace from cwd or `ATHF_WORKSPACE` env var
   - Install with: `pip install 'athf[mcp]'`
+- **ATT&CK STIX Integration** — Replace hardcoded ATT&CK dictionary with live STIX data via `mitreattack-python`
+  - Provider abstraction: `StixProvider` (835+ techniques with full metadata) and `FallbackProvider` (hardcoded v14)
+  - Auto-selects STIX when `mitreattack-python` is installed and data is cached; graceful fallback otherwise
+  - New CLI commands: `athf attack update`, `athf attack status`, `athf attack lookup`, `athf attack techniques`
+  - Technique metadata: platforms, data sources, tactics, sub-techniques, descriptions, URLs
+  - STIX cache: configurable via `ATHF_STIX_CACHE` env var, workspace-local, or `~/.athf/stix-data/`
+  - Fully backward compatible — existing `ATTACK_TACTICS`, `TOTAL_TECHNIQUES`, and all functions work identically
+  - Install with: `pip install 'athf[attack]'`
 
 ## [0.10.0] - 2026-03-16
 

--- a/athf/data/integrations/MCP_CATALOG.md
+++ b/athf/data/integrations/MCP_CATALOG.md
@@ -14,12 +14,12 @@ pip install 'athf[mcp]'
 {
   "athf": {
     "command": "athf-mcp",
-    "args": ["--workspace", "/path/to/your/hunts"]
+    "env": { "ATHF_WORKSPACE": "/path/to/your/hunts" }
   }
 }
 ```
 
-**Available tools (14):**
+**Available tools (17):**
 
 | Tool | Description |
 |------|-------------|

--- a/athf/data/integrations/MCP_CATALOG.md
+++ b/athf/data/integrations/MCP_CATALOG.md
@@ -1,6 +1,53 @@
 # MCP Catalog for Threat Hunting
 
-You'll need to **do your own research** to find MCP servers for your organization's security tools. This catalog walks through **Splunk as an example** to demonstrate the process of integrating an MCP server with Claude Code for threat hunting workflows.
+## ATHF MCP Server (Built-in)
+
+ATHF includes its own MCP server that exposes hunting operations as tools for any AI assistant.
+
+**Install:**
+```bash
+pip install 'athf[mcp]'
+```
+
+**Configure for Claude Code** (`~/.claude/mcp-servers.json`):
+```json
+{
+  "athf": {
+    "command": "athf-mcp",
+    "args": ["--workspace", "/path/to/your/hunts"]
+  }
+}
+```
+
+**Available tools (14):**
+
+| Tool | Description |
+|------|-------------|
+| `athf_hunt_list` | List/filter hunts by status, tactic, technique, platform |
+| `athf_hunt_search` | Full-text search across hunt files |
+| `athf_hunt_get` | Get full details of a specific hunt |
+| `athf_hunt_stats` | Hunt metrics (total, TP/FP, success rate) |
+| `athf_hunt_coverage` | MITRE ATT&CK coverage analysis |
+| `athf_hunt_validate` | Validate hunt file structure |
+| `athf_hunt_new` | Create a new hunt with LOCK structure |
+| `athf_similar` | Semantic similarity search (TF-IDF) |
+| `athf_context` | AI-optimized context bundle (environment + hunts + knowledge) |
+| `athf_research_list` | List research documents |
+| `athf_research_view` | View specific research document |
+| `athf_research_search` | Search research documents |
+| `athf_research_stats` | Research metrics |
+| `athf_investigate_list` | List investigations |
+| `athf_investigate_search` | Search investigations |
+| `athf_agent_run_hypothesis` | Generate hypothesis from threat intel (LLM-powered) |
+| `athf_agent_run_researcher` | Deep 5-skill pre-hunt research (LLM-powered) |
+
+**Works with:** Claude Code, GitHub Copilot, Cursor, Windsurf, or any MCP-compatible client.
+
+---
+
+## External MCP Servers
+
+You'll need to **do your own research** to find MCP servers for your organization's security tools. The section below walks through **Splunk as an example** to demonstrate the process of integrating an external MCP server with Claude Code for threat hunting workflows.
 
 ## Splunk Integration Walkthrough
 

--- a/athf/mcp/__init__.py
+++ b/athf/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""ATHF MCP Server — expose hunting operations as MCP tools."""

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -11,10 +11,6 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
-from mcp.server.fastmcp import FastMCP
-
-from athf.mcp.utils import find_workspace, load_workspace_config
-
 logger = logging.getLogger(__name__)
 
 # Global workspace path — set during server startup
@@ -33,7 +29,7 @@ def _json_result(data: Any) -> str:
     return json.dumps(data, indent=2, default=str)
 
 
-def create_server(workspace_path: Optional[str] = None) -> FastMCP:
+def create_server(workspace_path: Optional[str] = None) -> "FastMCP":  # type: ignore[name-defined]  # noqa: F821
     """Create and configure the ATHF MCP server.
 
     Args:
@@ -42,6 +38,15 @@ def create_server(workspace_path: Optional[str] = None) -> FastMCP:
     Returns:
         Configured FastMCP server instance.
     """
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError:
+        raise ImportError(
+            "MCP dependencies not installed. Install with: pip install 'athf[mcp]'"
+        ) from None
+
+    from athf.mcp.utils import find_workspace, load_workspace_config
+
     global _workspace
     _workspace = find_workspace(workspace_path)
     load_workspace_config(_workspace)
@@ -52,7 +57,7 @@ def create_server(workspace_path: Optional[str] = None) -> FastMCP:
             "ATHF (Agentic Threat Hunting Framework) server. "
             "Provides threat hunting operations: search hunts, check ATT&CK coverage, "
             "find similar hunts, create new hunts, run AI-powered research, and more. "
-            "Workspace: {}".format(_workspace)
+            f"Workspace: {_workspace}"
         ),
     )
 
@@ -71,6 +76,12 @@ def create_server(workspace_path: Optional[str] = None) -> FastMCP:
 
     logger.info("ATHF MCP server initialized with workspace: %s", _workspace)
     return mcp
+
+
+def reset_server() -> None:
+    """Reset global server state (for testing)."""
+    global _workspace
+    _workspace = None
 
 
 def main(workspace_path: Optional[str] = None) -> None:

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -44,7 +44,7 @@ def create_server(workspace_path: Optional[str] = None) -> FastMCP:
     """
     global _workspace
     _workspace = find_workspace(workspace_path)
-    config = load_workspace_config(_workspace)
+    load_workspace_config(_workspace)
 
     mcp = FastMCP(
         name="athf",

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -1,0 +1,79 @@
+"""ATHF MCP Server — expose threat hunting operations as MCP tools.
+
+Usage:
+    athf mcp serve                    # auto-detect workspace
+    athf mcp serve --workspace /path  # explicit workspace
+    athf-mcp                          # standalone entry point
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from athf.mcp.utils import find_workspace, load_workspace_config
+
+logger = logging.getLogger(__name__)
+
+# Global workspace path — set during server startup
+_workspace: Optional[Path] = None
+
+
+def get_workspace() -> Path:
+    """Return the current workspace path."""
+    if _workspace is None:
+        raise RuntimeError("ATHF MCP server not initialized. Call create_server() first.")
+    return _workspace
+
+
+def _json_result(data: Any) -> str:
+    """Serialize a result to JSON string for MCP tool output."""
+    return json.dumps(data, indent=2, default=str)
+
+
+def create_server(workspace_path: Optional[str] = None) -> FastMCP:
+    """Create and configure the ATHF MCP server.
+
+    Args:
+        workspace_path: Explicit workspace path (optional).
+
+    Returns:
+        Configured FastMCP server instance.
+    """
+    global _workspace
+    _workspace = find_workspace(workspace_path)
+    config = load_workspace_config(_workspace)
+
+    mcp = FastMCP(
+        name="athf",
+        instructions=(
+            "ATHF (Agentic Threat Hunting Framework) server. "
+            "Provides threat hunting operations: search hunts, check ATT&CK coverage, "
+            "find similar hunts, create new hunts, run AI-powered research, and more. "
+            "Workspace: {}".format(_workspace)
+        ),
+    )
+
+    # Register all tool modules
+    from athf.mcp.tools.hunt_tools import register_hunt_tools
+    from athf.mcp.tools.search_tools import register_search_tools
+    from athf.mcp.tools.research_tools import register_research_tools
+    from athf.mcp.tools.investigate_tools import register_investigate_tools
+    from athf.mcp.tools.agent_tools import register_agent_tools
+
+    register_hunt_tools(mcp)
+    register_search_tools(mcp)
+    register_research_tools(mcp)
+    register_investigate_tools(mcp)
+    register_agent_tools(mcp)
+
+    logger.info("ATHF MCP server initialized with workspace: %s", _workspace)
+    return mcp
+
+
+def main(workspace_path: Optional[str] = None) -> None:
+    """Entry point for running the MCP server via stdio."""
+    server = create_server(workspace_path)
+    server.run(transport="stdio")

--- a/athf/mcp/tools/__init__.py
+++ b/athf/mcp/tools/__init__.py
@@ -1,0 +1,1 @@
+"""MCP tool implementations for ATHF operations."""

--- a/athf/mcp/tools/agent_tools.py
+++ b/athf/mcp/tools/agent_tools.py
@@ -1,13 +1,14 @@
 """AI agent MCP tools (hypothesis generation, research)."""
 
+import logging
 from typing import Optional
-
-from mcp.server.fastmcp import FastMCP
 
 from athf.mcp.server import get_workspace, _json_result
 
+logger = logging.getLogger(__name__)
 
-def register_agent_tools(mcp: FastMCP) -> None:
+
+def register_agent_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined]  # noqa: F821
     """Register AI agent MCP tools."""
 
     @mcp.tool(
@@ -103,6 +104,7 @@ def register_agent_tools(mcp: FastMCP) -> None:
             topic=topic,
             mitre_technique=technique,
             depth=depth,
+            web_search_enabled=use_web_search,
         )
 
         result = agent.execute(input_data)
@@ -115,27 +117,27 @@ def register_agent_tools(mcp: FastMCP) -> None:
 
         # Build a report from the skill outputs
         report_parts = [
-            "# {topic} Research\n".format(topic=topic),
-            "## System Research\n{}\n".format(output.system_research.summary),
-            "## Adversary Tradecraft\n{}\n".format(output.adversary_tradecraft.summary),
-            "## Telemetry Mapping\n{}\n".format(output.telemetry_mapping.summary),
-            "## Related Work\n{}\n".format(output.related_work.summary),
-            "## Synthesis\n{}\n".format(output.synthesis.summary),
+            f"# {topic} Research\n",
+            f"## System Research\n{output.system_research.summary}\n",
+            f"## Adversary Tradecraft\n{output.adversary_tradecraft.summary}\n",
+            f"## Telemetry Mapping\n{output.telemetry_mapping.summary}\n",
+            f"## Related Work\n{output.related_work.summary}\n",
+            f"## Synthesis\n{output.synthesis.summary}\n",
         ]
         if output.recommended_hypothesis:
-            report_parts.append("## Recommended Hypothesis\n{}\n".format(output.recommended_hypothesis))
+            report_parts.append(f"## Recommended Hypothesis\n{output.recommended_hypothesis}\n")
 
         full_report = "\n".join(report_parts)
 
-        # Save research file
+        # Save research file — use agent's research_id if available, else generate
         from athf.core.research_manager import ResearchManager
 
         rm = ResearchManager(research_dir=workspace / "research")
-        rid = rm.get_next_research_id()
+        rid = getattr(output, "research_id", None) or rm.get_next_research_id()
 
         frontmatter = {
             "research_id": rid,
-            "title": "{} Research".format(topic),
+            "title": f"{topic} Research",
             "topic": topic,
             "technique": technique or "",
             "depth": depth,

--- a/athf/mcp/tools/agent_tools.py
+++ b/athf/mcp/tools/agent_tools.py
@@ -41,11 +41,20 @@ def register_agent_tools(mcp: FastMCP) -> None:
             if doc:
                 research = rm.extract_research_context(doc)
 
+        # Load past hunts and environment context from workspace
+        from athf.core.hunt_manager import HuntManager
+
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        past_hunts = manager.list_hunts()
+
+        env_file = workspace / "environment.md"
+        environment = {"environment_md": env_file.read_text(encoding="utf-8")} if env_file.exists() else {}
+
         agent = HypothesisGeneratorAgent(llm_enabled=use_llm)
         input_data = HypothesisGenerationInput(
             threat_intel=threat_intel,
-            past_hunts=[],
-            environment={},
+            past_hunts=past_hunts,
+            environment=environment,
             research=research,
         )
 

--- a/athf/mcp/tools/agent_tools.py
+++ b/athf/mcp/tools/agent_tools.py
@@ -1,0 +1,151 @@
+"""AI agent MCP tools (hypothesis generation, research)."""
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from athf.mcp.server import get_workspace, _json_result
+
+
+def register_agent_tools(mcp: FastMCP) -> None:
+    """Register AI agent MCP tools."""
+
+    @mcp.tool(
+        name="athf_agent_run_hypothesis",
+        description=(
+            "Generate a threat hunting hypothesis from threat intelligence. "
+            "Uses an LLM to produce a structured hypothesis with MITRE techniques, "
+            "data sources, and ABLE framework scoping. "
+            "Requires an LLM provider to be configured (falls back to template-based output without one)."
+        ),
+    )
+    def agent_run_hypothesis(
+        threat_intel: str,
+        research_id: Optional[str] = None,
+        use_llm: bool = True,
+    ) -> str:
+        from athf.agents.llm.hypothesis_generator import (
+            HypothesisGeneratorAgent,
+            HypothesisGenerationInput,
+        )
+
+        workspace = get_workspace()
+
+        # Load research context if provided
+        research = None
+        if research_id:
+            from athf.core.research_manager import ResearchManager
+
+            rm = ResearchManager(research_dir=workspace / "research")
+            doc = rm.get_research(research_id)
+            if doc:
+                research = rm.extract_research_context(doc)
+
+        agent = HypothesisGeneratorAgent(llm_enabled=use_llm)
+        input_data = HypothesisGenerationInput(
+            threat_intel=threat_intel,
+            past_hunts=[],
+            environment={},
+            research=research,
+        )
+
+        result = agent.execute(input_data)
+        if not result.success:
+            return _json_result({"error": result.error or "Hypothesis generation failed"})
+
+        output = result.data
+        if output is None:
+            return _json_result({"error": "No output from hypothesis generator"})
+
+        return _json_result({
+            "hypothesis": output.hypothesis,
+            "mitre_techniques": output.mitre_techniques,
+            "data_sources": output.data_sources,
+            "justification": output.justification,
+            "metadata": result.metadata,
+        })
+
+    @mcp.tool(
+        name="athf_agent_run_researcher",
+        description=(
+            "Conduct deep pre-hunt research on a topic using the 5-skill methodology: "
+            "System Internals, Adversary Tradecraft, Telemetry Mapping, Historical Analysis, "
+            "and Synthesis. Uses web search (Tavily) and LLM analysis. "
+            "Creates a research document (R-XXXX.md) in the workspace."
+        ),
+    )
+    def agent_run_researcher(
+        topic: str,
+        technique: Optional[str] = None,
+        depth: str = "advanced",
+        use_web_search: bool = True,
+        use_llm: bool = True,
+    ) -> str:
+        import os
+
+        from athf.agents.llm.hunt_researcher import HuntResearcherAgent, ResearchInput
+
+        workspace = get_workspace()
+
+        tavily_key = os.environ.get("TAVILY_API_KEY") if use_web_search else None
+
+        agent = HuntResearcherAgent(llm_enabled=use_llm, tavily_api_key=tavily_key)
+        input_data = ResearchInput(
+            topic=topic,
+            mitre_technique=technique,
+            depth=depth,
+        )
+
+        result = agent.execute(input_data)
+        if not result.success:
+            return _json_result({"error": result.error or "Research failed"})
+
+        output = result.data
+        if output is None:
+            return _json_result({"error": "No output from researcher"})
+
+        # Build a report from the skill outputs
+        report_parts = [
+            "# {topic} Research\n".format(topic=topic),
+            "## System Research\n{}\n".format(output.system_research.summary),
+            "## Adversary Tradecraft\n{}\n".format(output.adversary_tradecraft.summary),
+            "## Telemetry Mapping\n{}\n".format(output.telemetry_mapping.summary),
+            "## Related Work\n{}\n".format(output.related_work.summary),
+            "## Synthesis\n{}\n".format(output.synthesis.summary),
+        ]
+        if output.recommended_hypothesis:
+            report_parts.append("## Recommended Hypothesis\n{}\n".format(output.recommended_hypothesis))
+
+        full_report = "\n".join(report_parts)
+
+        # Save research file
+        from athf.core.research_manager import ResearchManager
+
+        rm = ResearchManager(research_dir=workspace / "research")
+        rid = rm.get_next_research_id()
+
+        frontmatter = {
+            "research_id": rid,
+            "title": "{} Research".format(topic),
+            "topic": topic,
+            "technique": technique or "",
+            "depth": depth,
+            "status": "completed",
+        }
+
+        file_path = rm.create_research_file(
+            research_id=rid,
+            topic=topic,
+            content=full_report,
+            frontmatter=frontmatter,
+        )
+
+        return _json_result({
+            "research_id": rid,
+            "file_path": str(file_path),
+            "topic": topic,
+            "depth": depth,
+            "recommended_hypothesis": output.recommended_hypothesis,
+            "gaps_identified": output.gaps_identified,
+            "metadata": result.metadata,
+        })

--- a/athf/mcp/tools/hunt_tools.py
+++ b/athf/mcp/tools/hunt_tools.py
@@ -2,12 +2,10 @@
 
 from typing import Optional
 
-from mcp.server.fastmcp import FastMCP
-
 from athf.mcp.server import get_workspace, _json_result
 
 
-def register_hunt_tools(mcp: FastMCP) -> None:
+def register_hunt_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined]  # noqa: F821
     """Register all hunt-related MCP tools."""
 
     @mcp.tool(
@@ -53,7 +51,7 @@ def register_hunt_tools(mcp: FastMCP) -> None:
         manager = HuntManager(hunts_dir=workspace / "hunts")
         hunt = manager.get_hunt(hunt_id)
         if hunt is None:
-            return _json_result({"error": "Hunt not found: {}".format(hunt_id)})
+            return _json_result({"error": f"Hunt not found: {hunt_id}"})
         return _json_result(hunt)
 
     @mcp.tool(
@@ -87,7 +85,7 @@ def register_hunt_tools(mcp: FastMCP) -> None:
             tactic_lower = tactic.lower().replace(" ", "-")
             tactic_data = coverage.get("by_tactic", {}).get(tactic_lower)
             if tactic_data is None:
-                return _json_result({"error": "Unknown tactic: {}".format(tactic)})
+                return _json_result({"error": f"Unknown tactic: {tactic}"})
             return _json_result({"tactic": tactic_lower, **tactic_data})
 
         return _json_result(coverage)
@@ -105,7 +103,7 @@ def register_hunt_tools(mcp: FastMCP) -> None:
         manager = HuntManager(hunts_dir=workspace / "hunts")
         hunt_file = manager.find_hunt_file(hunt_id)
         if hunt_file is None:
-            return _json_result({"valid": False, "error": "Hunt not found: {}".format(hunt_id)})
+            return _json_result({"valid": False, "error": f"Hunt not found: {hunt_id}"})
 
         is_valid, errors = validate_hunt_file(hunt_file)
         return _json_result({"valid": is_valid, "hunt_id": hunt_id, "errors": errors})
@@ -164,11 +162,17 @@ def register_hunt_tools(mcp: FastMCP) -> None:
         from datetime import datetime
 
         now = datetime.now()
-        quarter = "Q{}".format((now.month - 1) // 3 + 1)
+        quarter = f"Q{(now.month - 1) // 3 + 1}"
         hunt_dir = workspace / "hunts" / "production" / str(now.year) / quarter
         hunt_dir.mkdir(parents=True, exist_ok=True)
-        hunt_file = hunt_dir / "{}.md".format(hunt_id)
-        hunt_file.write_text(content, encoding="utf-8")
+        hunt_file = hunt_dir / f"{hunt_id}.md"
+
+        # Atomic exclusive create to prevent TOCTOU race
+        try:
+            with open(str(hunt_file), "x", encoding="utf-8") as fh:
+                fh.write(content)
+        except FileExistsError:
+            return _json_result({"error": f"Hunt file already exists: {hunt_file}"})
 
         return _json_result({
             "hunt_id": hunt_id,

--- a/athf/mcp/tools/hunt_tools.py
+++ b/athf/mcp/tools/hunt_tools.py
@@ -161,7 +161,13 @@ def register_hunt_tools(mcp: FastMCP) -> None:
             spawned_from=research_id,
         )
 
-        hunt_file = manager.hunts_dir / "{}.md".format(hunt_id)
+        from datetime import datetime
+
+        now = datetime.now()
+        quarter = "Q{}".format((now.month - 1) // 3 + 1)
+        hunt_dir = workspace / "hunts" / "production" / str(now.year) / quarter
+        hunt_dir.mkdir(parents=True, exist_ok=True)
+        hunt_file = hunt_dir / "{}.md".format(hunt_id)
         hunt_file.write_text(content, encoding="utf-8")
 
         return _json_result({

--- a/athf/mcp/tools/hunt_tools.py
+++ b/athf/mcp/tools/hunt_tools.py
@@ -1,0 +1,172 @@
+"""Hunt management MCP tools."""
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from athf.mcp.server import get_workspace, _json_result
+
+
+def register_hunt_tools(mcp: FastMCP) -> None:
+    """Register all hunt-related MCP tools."""
+
+    @mcp.tool(
+        name="athf_hunt_list",
+        description=(
+            "List threat hunts with optional filters. "
+            "Returns hunt metadata including ID, title, status, technique, tactic, and platform."
+        ),
+    )
+    def hunt_list(
+        status: Optional[str] = None,
+        tactic: Optional[str] = None,
+        technique: Optional[str] = None,
+        platform: Optional[str] = None,
+    ) -> str:
+        from athf.core.hunt_manager import HuntManager
+
+        workspace = get_workspace()
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        hunts = manager.list_hunts(status=status, tactic=tactic, technique=technique, platform=platform)
+        return _json_result({"count": len(hunts), "hunts": hunts})
+
+    @mcp.tool(
+        name="athf_hunt_search",
+        description="Full-text search across all hunt files. Returns matching hunts with relevance context.",
+    )
+    def hunt_search(query: str) -> str:
+        from athf.core.hunt_manager import HuntManager
+
+        workspace = get_workspace()
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        results = manager.search_hunts(query)
+        return _json_result({"count": len(results), "results": results})
+
+    @mcp.tool(
+        name="athf_hunt_get",
+        description="Get full details of a specific hunt by ID (e.g., H-0001). Returns frontmatter, content, and LOCK sections.",
+    )
+    def hunt_get(hunt_id: str) -> str:
+        from athf.core.hunt_manager import HuntManager
+
+        workspace = get_workspace()
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        hunt = manager.get_hunt(hunt_id)
+        if hunt is None:
+            return _json_result({"error": "Hunt not found: {}".format(hunt_id)})
+        return _json_result(hunt)
+
+    @mcp.tool(
+        name="athf_hunt_stats",
+        description="Get hunt statistics: total hunts, status breakdown, true/false positive counts, and success rate.",
+    )
+    def hunt_stats() -> str:
+        from athf.core.hunt_manager import HuntManager
+
+        workspace = get_workspace()
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        stats = manager.calculate_stats()
+        return _json_result(stats)
+
+    @mcp.tool(
+        name="athf_hunt_coverage",
+        description=(
+            "Analyze MITRE ATT&CK coverage across all hunts. "
+            "Optionally filter by tactic (e.g., 'credential-access'). "
+            "Returns covered techniques, gaps, and coverage percentage."
+        ),
+    )
+    def hunt_coverage(tactic: Optional[str] = None) -> str:
+        from athf.core.hunt_manager import HuntManager
+
+        workspace = get_workspace()
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        coverage = manager.calculate_attack_coverage()
+
+        if tactic:
+            tactic_lower = tactic.lower().replace(" ", "-")
+            tactic_data = coverage.get("by_tactic", {}).get(tactic_lower)
+            if tactic_data is None:
+                return _json_result({"error": "Unknown tactic: {}".format(tactic)})
+            return _json_result({"tactic": tactic_lower, **tactic_data})
+
+        return _json_result(coverage)
+
+    @mcp.tool(
+        name="athf_hunt_validate",
+        description="Validate a hunt file's structure and YAML frontmatter. Returns validation errors if any.",
+    )
+    def hunt_validate(hunt_id: str) -> str:
+        from athf.core.hunt_parser import validate_hunt_file
+
+        workspace = get_workspace()
+        from athf.core.hunt_manager import HuntManager
+
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        hunt_file = manager.find_hunt_file(hunt_id)
+        if hunt_file is None:
+            return _json_result({"valid": False, "error": "Hunt not found: {}".format(hunt_id)})
+
+        is_valid, errors = validate_hunt_file(hunt_file)
+        return _json_result({"valid": is_valid, "hunt_id": hunt_id, "errors": errors})
+
+    @mcp.tool(
+        name="athf_hunt_new",
+        description=(
+            "Create a new hunt file with LOCK structure. "
+            "Requires at minimum a title and MITRE technique ID (e.g., T1003.001). "
+            "Returns the created hunt ID and file path."
+        ),
+    )
+    def hunt_new(
+        title: str,
+        technique: str,
+        tactic: Optional[str] = None,
+        platform: Optional[str] = None,
+        data_source: Optional[str] = None,
+        hypothesis: Optional[str] = None,
+        threat_context: Optional[str] = None,
+        actor: Optional[str] = None,
+        behavior: Optional[str] = None,
+        location: Optional[str] = None,
+        evidence: Optional[str] = None,
+        hunter: str = "AI Assistant",
+        research_id: Optional[str] = None,
+    ) -> str:
+        from athf.core.hunt_manager import HuntManager
+        from athf.core.template_engine import render_hunt_template
+
+        workspace = get_workspace()
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        hunt_id = manager.get_next_hunt_id()
+
+        tactics_list = [tactic] if tactic else None
+        platform_list = [platform] if platform else None
+        data_source_list = [data_source] if data_source else None
+
+        content = render_hunt_template(
+            hunt_id=hunt_id,
+            title=title,
+            technique=technique,
+            tactics=tactics_list,
+            platform=platform_list,
+            data_sources=data_source_list,
+            hypothesis=hypothesis,
+            threat_context=threat_context,
+            actor=actor,
+            behavior=behavior,
+            location=location,
+            evidence=evidence,
+            hunter=hunter,
+            spawned_from=research_id,
+        )
+
+        hunt_file = manager.hunts_dir / "{}.md".format(hunt_id)
+        hunt_file.write_text(content, encoding="utf-8")
+
+        return _json_result({
+            "hunt_id": hunt_id,
+            "file_path": str(hunt_file),
+            "title": title,
+            "technique": technique,
+        })

--- a/athf/mcp/tools/investigate_tools.py
+++ b/athf/mcp/tools/investigate_tools.py
@@ -1,13 +1,14 @@
 """Investigation management MCP tools."""
 
+import logging
 from typing import Optional
-
-from mcp.server.fastmcp import FastMCP
 
 from athf.mcp.server import get_workspace, _json_result
 
+logger = logging.getLogger(__name__)
 
-def register_investigate_tools(mcp: FastMCP) -> None:
+
+def register_investigate_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined]  # noqa: F821
     """Register all investigation-related MCP tools."""
 
     @mcp.tool(
@@ -17,12 +18,12 @@ def register_investigate_tools(mcp: FastMCP) -> None:
     def investigate_list(
         investigation_type: Optional[str] = None,
     ) -> str:
+        from athf.core.investigation_parser import parse_investigation_file
+
         workspace = get_workspace()
         inv_dir = workspace / "investigations"
         if not inv_dir.exists():
             return _json_result({"count": 0, "investigations": []})
-
-        from athf.core.investigation_parser import parse_investigation_file
 
         results = []
         for f in sorted(inv_dir.rglob("*.md")):
@@ -40,7 +41,8 @@ def register_investigate_tools(mcp: FastMCP) -> None:
                     "status": fm.get("status", ""),
                     "tags": fm.get("tags", []),
                 })
-            except Exception:
+            except Exception as e:
+                logger.debug("Skipping %s: %s", f.name, e)
                 continue
 
         return _json_result({"count": len(results), "investigations": results})
@@ -50,6 +52,8 @@ def register_investigate_tools(mcp: FastMCP) -> None:
         description="Full-text search across investigation files.",
     )
     def investigate_search(query: str) -> str:
+        from athf.core.investigation_parser import parse_investigation_file
+
         workspace = get_workspace()
         inv_dir = workspace / "investigations"
         if not inv_dir.exists():
@@ -63,8 +67,6 @@ def register_investigate_tools(mcp: FastMCP) -> None:
             try:
                 content = f.read_text(encoding="utf-8")
                 if query_lower in content.lower():
-                    from athf.core.investigation_parser import parse_investigation_file
-
                     parsed = parse_investigation_file(f)
                     fm = parsed.get("frontmatter", {})
                     results.append({
@@ -73,7 +75,8 @@ def register_investigate_tools(mcp: FastMCP) -> None:
                         "type": fm.get("type", ""),
                         "status": fm.get("status", ""),
                     })
-            except Exception:
+            except Exception as e:
+                logger.debug("Skipping %s: %s", f.name, e)
                 continue
 
         return _json_result({"count": len(results), "results": results})

--- a/athf/mcp/tools/investigate_tools.py
+++ b/athf/mcp/tools/investigate_tools.py
@@ -1,0 +1,79 @@
+"""Investigation management MCP tools."""
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from athf.mcp.server import get_workspace, _json_result
+
+
+def register_investigate_tools(mcp: FastMCP) -> None:
+    """Register all investigation-related MCP tools."""
+
+    @mcp.tool(
+        name="athf_investigate_list",
+        description="List investigations with optional type filter (finding, exploration, triage, validation).",
+    )
+    def investigate_list(
+        investigation_type: Optional[str] = None,
+    ) -> str:
+        workspace = get_workspace()
+        inv_dir = workspace / "investigations"
+        if not inv_dir.exists():
+            return _json_result({"count": 0, "investigations": []})
+
+        from athf.core.investigation_parser import parse_investigation_file
+
+        results = []
+        for f in sorted(inv_dir.rglob("*.md")):
+            if f.name in {"README.md", "AGENTS.md"}:
+                continue
+            try:
+                parsed = parse_investigation_file(f)
+                fm = parsed.get("frontmatter", {})
+                if investigation_type and fm.get("type", "").lower() != investigation_type.lower():
+                    continue
+                results.append({
+                    "investigation_id": fm.get("investigation_id", f.stem),
+                    "title": fm.get("title", ""),
+                    "type": fm.get("type", ""),
+                    "status": fm.get("status", ""),
+                    "tags": fm.get("tags", []),
+                })
+            except Exception:
+                continue
+
+        return _json_result({"count": len(results), "investigations": results})
+
+    @mcp.tool(
+        name="athf_investigate_search",
+        description="Full-text search across investigation files.",
+    )
+    def investigate_search(query: str) -> str:
+        workspace = get_workspace()
+        inv_dir = workspace / "investigations"
+        if not inv_dir.exists():
+            return _json_result({"count": 0, "results": []})
+
+        query_lower = query.lower()
+        results = []
+        for f in sorted(inv_dir.rglob("*.md")):
+            if f.name in {"README.md", "AGENTS.md"}:
+                continue
+            try:
+                content = f.read_text(encoding="utf-8")
+                if query_lower in content.lower():
+                    from athf.core.investigation_parser import parse_investigation_file
+
+                    parsed = parse_investigation_file(f)
+                    fm = parsed.get("frontmatter", {})
+                    results.append({
+                        "investigation_id": fm.get("investigation_id", f.stem),
+                        "title": fm.get("title", ""),
+                        "type": fm.get("type", ""),
+                        "status": fm.get("status", ""),
+                    })
+            except Exception:
+                continue
+
+        return _json_result({"count": len(results), "results": results})

--- a/athf/mcp/tools/research_tools.py
+++ b/athf/mcp/tools/research_tools.py
@@ -2,12 +2,10 @@
 
 from typing import Optional
 
-from mcp.server.fastmcp import FastMCP
-
 from athf.mcp.server import get_workspace, _json_result
 
 
-def register_research_tools(mcp: FastMCP) -> None:
+def register_research_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined]  # noqa: F821
     """Register all research-related MCP tools."""
 
     @mcp.tool(
@@ -36,7 +34,7 @@ def register_research_tools(mcp: FastMCP) -> None:
         manager = ResearchManager(research_dir=workspace / "research")
         doc = manager.get_research(research_id)
         if doc is None:
-            return _json_result({"error": "Research not found: {}".format(research_id)})
+            return _json_result({"error": f"Research not found: {research_id}"})
         return _json_result(doc)
 
     @mcp.tool(

--- a/athf/mcp/tools/research_tools.py
+++ b/athf/mcp/tools/research_tools.py
@@ -1,0 +1,64 @@
+"""Research management MCP tools."""
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from athf.mcp.server import get_workspace, _json_result
+
+
+def register_research_tools(mcp: FastMCP) -> None:
+    """Register all research-related MCP tools."""
+
+    @mcp.tool(
+        name="athf_research_list",
+        description="List research documents with optional filters by status or technique.",
+    )
+    def research_list(
+        status: Optional[str] = None,
+        technique: Optional[str] = None,
+    ) -> str:
+        from athf.core.research_manager import ResearchManager
+
+        workspace = get_workspace()
+        manager = ResearchManager(research_dir=workspace / "research")
+        results = manager.list_research(status=status, technique=technique)
+        return _json_result({"count": len(results), "research": results})
+
+    @mcp.tool(
+        name="athf_research_view",
+        description="View a specific research document by ID (e.g., R-0001). Returns full content and metadata.",
+    )
+    def research_view(research_id: str) -> str:
+        from athf.core.research_manager import ResearchManager
+
+        workspace = get_workspace()
+        manager = ResearchManager(research_dir=workspace / "research")
+        doc = manager.get_research(research_id)
+        if doc is None:
+            return _json_result({"error": "Research not found: {}".format(research_id)})
+        return _json_result(doc)
+
+    @mcp.tool(
+        name="athf_research_search",
+        description="Full-text search across research documents.",
+    )
+    def research_search(query: str) -> str:
+        from athf.core.research_manager import ResearchManager
+
+        workspace = get_workspace()
+        manager = ResearchManager(research_dir=workspace / "research")
+        results = manager.search_research(query)
+        return _json_result({"count": len(results), "results": results})
+
+    @mcp.tool(
+        name="athf_research_stats",
+        description="Get research metrics: total documents, completion rate, cost, and duration stats.",
+    )
+    def research_stats() -> str:
+        from athf.core.research_manager import ResearchManager
+
+        workspace = get_workspace()
+        manager = ResearchManager(research_dir=workspace / "research")
+        stats = manager.calculate_stats()
+        return _json_result(stats)

--- a/athf/mcp/tools/search_tools.py
+++ b/athf/mcp/tools/search_tools.py
@@ -1,13 +1,14 @@
 """Search and context MCP tools (similar, context)."""
 
+import logging
 from typing import Any, Dict, Optional
-
-from mcp.server.fastmcp import FastMCP
 
 from athf.mcp.server import get_workspace, _json_result
 
+logger = logging.getLogger(__name__)
 
-def register_search_tools(mcp: FastMCP) -> None:
+
+def register_search_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined]  # noqa: F821
     """Register search-related MCP tools."""
 
     @mcp.tool(
@@ -65,7 +66,8 @@ def register_search_tools(mcp: FastMCP) -> None:
                     "technique": fm.get("technique", ""),
                     "status": fm.get("status", ""),
                 })
-            except Exception:
+            except Exception as e:
+                logger.debug("Skipping %s: %s", f.name, e)
                 continue
 
         if not corpus_texts:
@@ -75,7 +77,7 @@ def register_search_tools(mcp: FastMCP) -> None:
         if hunt_id:
             hunt = manager.get_hunt(hunt_id)
             if hunt is None:
-                return _json_result({"error": "Hunt not found: {}".format(hunt_id)})
+                return _json_result({"error": f"Hunt not found: {hunt_id}"})
             fm = hunt.get("frontmatter", {})
             query_text = " ".join([fm.get("title", ""), fm.get("technique", ""), hunt.get("content", "")])
         else:
@@ -135,7 +137,7 @@ def register_search_tools(mcp: FastMCP) -> None:
             if hunt:
                 result["hunt"] = hunt
             else:
-                result["hunt_error"] = "Hunt not found: {}".format(hunt_id)
+                result["hunt_error"] = f"Hunt not found: {hunt_id}"
         else:
             hunts = manager.list_hunts(tactic=tactic, platform=platform)
             result["hunts"] = hunts

--- a/athf/mcp/tools/search_tools.py
+++ b/athf/mcp/tools/search_tools.py
@@ -1,0 +1,152 @@
+"""Search and context MCP tools (similar, context)."""
+
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from athf.mcp.server import get_workspace, _json_result
+
+
+def register_search_tools(mcp: FastMCP) -> None:
+    """Register search-related MCP tools."""
+
+    @mcp.tool(
+        name="athf_similar",
+        description=(
+            "Find hunts semantically similar to a query or to an existing hunt. "
+            "Uses TF-IDF + cosine similarity. Scores: >=0.50 very similar, "
+            "0.30-0.49 related, <0.30 weak match. "
+            "IMPORTANT: Use this before creating new hunts to avoid duplicates."
+        ),
+    )
+    def similar(
+        query: Optional[str] = None,
+        hunt_id: Optional[str] = None,
+        limit: int = 10,
+        threshold: float = 0.1,
+    ) -> str:
+        if not query and not hunt_id:
+            return _json_result({"error": "Provide either 'query' text or 'hunt_id' to search."})
+
+        workspace = get_workspace()
+        from athf.core.hunt_manager import HuntManager
+
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+        hunt_files = manager.find_all_hunt_files()
+
+        if not hunt_files:
+            return _json_result({"count": 0, "results": [], "message": "No hunts found in workspace."})
+
+        try:
+            from sklearn.feature_extraction.text import TfidfVectorizer
+            from sklearn.metrics.pairwise import cosine_similarity
+        except ImportError:
+            return _json_result({"error": "scikit-learn is required for similarity search. Install with: pip install 'athf[similarity]'"})
+
+        # Build corpus
+        from athf.core.hunt_parser import parse_hunt_file
+
+        corpus_texts = []
+        corpus_hunts = []
+        for f in hunt_files:
+            try:
+                parsed = parse_hunt_file(f)
+                fm = parsed.get("frontmatter", {})
+                text_parts = [
+                    fm.get("title", ""),
+                    fm.get("technique", ""),
+                    " ".join(fm.get("tactic", []) if isinstance(fm.get("tactic"), list) else [str(fm.get("tactic", ""))]),
+                    parsed.get("content", ""),
+                ]
+                corpus_texts.append(" ".join(str(p) for p in text_parts))
+                corpus_hunts.append({
+                    "hunt_id": fm.get("hunt_id", f.stem),
+                    "title": fm.get("title", ""),
+                    "technique": fm.get("technique", ""),
+                    "status": fm.get("status", ""),
+                })
+            except Exception:
+                continue
+
+        if not corpus_texts:
+            return _json_result({"count": 0, "results": []})
+
+        # Build query text
+        if hunt_id:
+            hunt = manager.get_hunt(hunt_id)
+            if hunt is None:
+                return _json_result({"error": "Hunt not found: {}".format(hunt_id)})
+            fm = hunt.get("frontmatter", {})
+            query_text = " ".join([fm.get("title", ""), fm.get("technique", ""), hunt.get("content", "")])
+        else:
+            query_text = query or ""
+
+        # TF-IDF similarity
+        vectorizer = TfidfVectorizer(stop_words="english", max_features=5000)
+        tfidf_matrix = vectorizer.fit_transform(corpus_texts + [query_text])
+        query_vec = tfidf_matrix[-1]
+        corpus_matrix = tfidf_matrix[:-1]
+        similarities = cosine_similarity(query_vec, corpus_matrix).flatten()
+
+        # Rank and filter
+        results = []
+        for idx, score in enumerate(similarities):
+            if score >= threshold:
+                entry = corpus_hunts[idx].copy()
+                entry["similarity_score"] = round(float(score), 4)
+                results.append(entry)
+
+        results.sort(key=lambda x: x["similarity_score"], reverse=True)
+        results = results[:limit]
+
+        return _json_result({"count": len(results), "results": results})
+
+    @mcp.tool(
+        name="athf_context",
+        description=(
+            "Load AI-optimized context bundle for a hunt, tactic, or platform. "
+            "Combines environment.md, past hunts, and domain knowledge into one structured output. "
+            "Use this before generating queries or hypotheses to reduce context-loading overhead."
+        ),
+    )
+    def context(
+        hunt_id: Optional[str] = None,
+        tactic: Optional[str] = None,
+        platform: Optional[str] = None,
+    ) -> str:
+        if not hunt_id and not tactic and not platform:
+            return _json_result({"error": "Provide at least one filter: hunt_id, tactic, or platform."})
+
+        workspace = get_workspace()
+        result: Dict[str, Any] = {}
+
+        # Load environment.md
+        env_file = workspace / "environment.md"
+        if env_file.exists():
+            result["environment"] = env_file.read_text(encoding="utf-8")
+
+        # Load hunts matching filters
+        from athf.core.hunt_manager import HuntManager
+
+        manager = HuntManager(hunts_dir=workspace / "hunts")
+
+        if hunt_id:
+            hunt = manager.get_hunt(hunt_id)
+            if hunt:
+                result["hunt"] = hunt
+            else:
+                result["hunt_error"] = "Hunt not found: {}".format(hunt_id)
+        else:
+            hunts = manager.list_hunts(tactic=tactic, platform=platform)
+            result["hunts"] = hunts
+            result["hunt_count"] = len(hunts)
+
+        # Load domain knowledge if tactic specified
+        if tactic:
+            knowledge_dir = workspace / "knowledge" / "domains"
+            if knowledge_dir.is_dir():
+                for f in knowledge_dir.glob("*.md"):
+                    if tactic.replace("-", " ") in f.stem.replace("-", " "):
+                        result.setdefault("domain_knowledge", {})[f.stem] = f.read_text(encoding="utf-8")
+
+        return _json_result(result)

--- a/athf/mcp/tools/search_tools.py
+++ b/athf/mcp/tools/search_tools.py
@@ -55,7 +55,7 @@ def register_search_tools(mcp: FastMCP) -> None:
                 text_parts = [
                     fm.get("title", ""),
                     fm.get("technique", ""),
-                    " ".join(fm.get("tactic", []) if isinstance(fm.get("tactic"), list) else [str(fm.get("tactic", ""))]),
+                    " ".join(fm.get("tactics", []) if isinstance(fm.get("tactics"), list) else [str(fm.get("tactics", ""))]),
                     parsed.get("content", ""),
                 ]
                 corpus_texts.append(" ".join(str(p) for p in text_parts))

--- a/athf/mcp/utils.py
+++ b/athf/mcp/utils.py
@@ -22,18 +22,20 @@ def find_workspace(explicit_path: Optional[str] = None) -> Path:
         Path to the workspace root.
 
     Raises:
-        FileNotFoundError: If no workspace can be found.
+        FileNotFoundError: If no workspace can be found or path lacks ATHF structure.
     """
     if explicit_path:
         p = Path(explicit_path)
-        if p.is_dir():
-            return p
-        raise FileNotFoundError("Workspace path does not exist: {}".format(explicit_path))
+        if not p.is_dir():
+            raise FileNotFoundError(f"Workspace path does not exist: {explicit_path}")
+        _validate_workspace(p)
+        return p
 
     env_path = os.environ.get("ATHF_WORKSPACE")
     if env_path:
         p = Path(env_path)
         if p.is_dir():
+            _validate_workspace(p)
             return p
 
     # Walk up from cwd
@@ -46,6 +48,21 @@ def find_workspace(explicit_path: Optional[str] = None) -> Path:
 
     raise FileNotFoundError(
         "No ATHF workspace found. Set ATHF_WORKSPACE or run from within an ATHF workspace."
+    )
+
+
+def _validate_workspace(path: Path) -> None:
+    """Validate that a directory looks like an ATHF workspace.
+
+    Raises FileNotFoundError if neither .athfconfig.yaml nor config/.athfconfig.yaml exists.
+    """
+    if (path / ".athfconfig.yaml").exists():
+        return
+    if (path / "config" / ".athfconfig.yaml").exists():
+        return
+    raise FileNotFoundError(
+        f"Not an ATHF workspace: {path} (missing .athfconfig.yaml). "
+        "Run 'athf init' to initialize."
     )
 
 

--- a/athf/mcp/utils.py
+++ b/athf/mcp/utils.py
@@ -1,0 +1,66 @@
+"""Utility functions for the ATHF MCP server."""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+def find_workspace(explicit_path: Optional[str] = None) -> Path:
+    """Find the ATHF workspace root directory.
+
+    Resolution order:
+    1. Explicit path argument
+    2. ATHF_WORKSPACE environment variable
+    3. Walk up from cwd looking for .athfconfig.yaml
+
+    Args:
+        explicit_path: Explicitly provided workspace path.
+
+    Returns:
+        Path to the workspace root.
+
+    Raises:
+        FileNotFoundError: If no workspace can be found.
+    """
+    if explicit_path:
+        p = Path(explicit_path)
+        if p.is_dir():
+            return p
+        raise FileNotFoundError("Workspace path does not exist: {}".format(explicit_path))
+
+    env_path = os.environ.get("ATHF_WORKSPACE")
+    if env_path:
+        p = Path(env_path)
+        if p.is_dir():
+            return p
+
+    # Walk up from cwd
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".athfconfig.yaml").exists():
+            return parent
+        if (parent / "config" / ".athfconfig.yaml").exists():
+            return parent
+
+    raise FileNotFoundError(
+        "No ATHF workspace found. Set ATHF_WORKSPACE or run from within an ATHF workspace."
+    )
+
+
+def load_workspace_config(workspace: Path) -> dict:
+    """Load .athfconfig.yaml from workspace.
+
+    Args:
+        workspace: Workspace root path.
+
+    Returns:
+        Config dict (empty dict if file not found).
+    """
+    for candidate in [workspace / ".athfconfig.yaml", workspace / "config" / ".athfconfig.yaml"]:
+        if candidate.is_file():
+            with open(str(candidate), "r") as fh:
+                data = yaml.safe_load(fh)
+                return data if isinstance(data, dict) else {}
+    return {}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,25 +5,28 @@ All notable changes to the Agentic Threat Hunting Framework (ATHF) will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0] - Unreleased
 
 ### Added
-- None
+- **MCP Server** — Expose ATHF operations as MCP tools for AI assistants (Claude Code, Copilot, Cursor)
+  - 14 tools: hunt list/search/get/stats/coverage/validate/new, similar, context, research list/view/search/stats, investigate list/search, agent hypothesis/researcher
+  - `athf mcp serve` CLI command and `athf-mcp` standalone entry point
+  - Auto-detect workspace from cwd or `ATHF_WORKSPACE` env var
+  - Install with: `pip install 'athf[mcp]'`
+
+## [0.10.0] - 2026-03-16
+
+### Added
+- **Model-agnostic LLM provider abstraction** — Replace hardcoded AWS Bedrock with support for Claude, GPT, Gemini, Ollama, and any OpenAI-compatible endpoint
+  - `athf/core/llm_provider.py` with 4 providers (LiteLLM, Bedrock, Ollama, OpenAI-compatible)
+  - Auto-detection from environment variables with layered config resolution
+  - Cost tracker with fuzzy model name matching (`athf/core/cost_tracker.py`)
+  - Validation-retry loop for agent self-correction on malformed LLM output
+- **Parallel research** — Skills 1-4 run concurrently via ThreadPoolExecutor (~4x faster)
 
 ### Changed
-- None
-
-### Deprecated
-- None
-
-### Removed
-- None
-
-### Fixed
-- None
-
-### Security
-- None
+- Updated docs (CLI_REFERENCE, DOCKER.md, docker-compose.yml) for multi-provider support
+- All agent code now uses provider abstraction instead of direct Bedrock calls
 
 ## [0.7.1] - 2026-02-06
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `athf mcp serve` CLI command and `athf-mcp` standalone entry point
   - Auto-detect workspace from cwd or `ATHF_WORKSPACE` env var
   - Install with: `pip install 'athf[mcp]'`
+- **ATT&CK STIX Integration** — Replace hardcoded ATT&CK dictionary with live STIX data via `mitreattack-python`
+  - Provider abstraction: `StixProvider` (835+ techniques with full metadata) and `FallbackProvider` (hardcoded v14)
+  - Auto-selects STIX when `mitreattack-python` is installed and data is cached; graceful fallback otherwise
+  - New CLI commands: `athf attack update`, `athf attack status`, `athf attack lookup`, `athf attack techniques`
+  - Technique metadata: platforms, data sources, tactics, sub-techniques, descriptions, URLs
+  - STIX cache: configurable via `ATHF_STIX_CACHE` env var, workspace-local, or `~/.athf/stix-data/`
+  - Fully backward compatible — existing `ATTACK_TACTICS`, `TOTAL_TECHNIQUES`, and all functions work identically
+  - Install with: `pip install 'athf[attack]'`
 
 ## [0.10.0] - 2026-03-16
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -21,6 +21,10 @@ Complete reference for all `athf` command-line interface commands.
 | [`athf hunt stats`](#athf-hunt-stats) | Hunt Management | Display hunt statistics and success metrics |
 | [`athf hunt search`](#athf-hunt-search) | Hunt Management | Full-text search across all hunts |
 | [`athf hunt coverage`](#athf-hunt-coverage) | Hunt Management | Display MITRE ATT&CK coverage heatmap |
+| [`athf attack update`](#athf-attack-update) | ATT&CK Data | Download/refresh STIX data from MITRE |
+| [`athf attack status`](#athf-attack-status) | ATT&CK Data | Show provider type, version, and cache info |
+| [`athf attack lookup`](#athf-attack-lookup) | ATT&CK Data | Look up technique metadata by ID |
+| [`athf attack techniques`](#athf-attack-techniques) | ATT&CK Data | List all techniques for a tactic |
 | [`athf hunt execute`](#athf-hunt-execute) | Hunt Management | Execute hunt workflow with agent orchestration |
 | [`athf investigate new`](#athf-investigate-new) | Investigation | Create new investigation file for exploratory work |
 | [`athf investigate list`](#athf-investigate-list) | Investigation | List all investigations with optional filtering |
@@ -2164,6 +2168,206 @@ athf hunt execute H-0013 --dry-run
 
 - `0`: Success
 - `1`: Execution failed
+
+---
+
+## athf attack update
+
+Download or refresh MITRE ATT&CK STIX data for enhanced technique metadata.
+
+### Synopsis
+
+```bash
+athf attack update [OPTIONS]
+```
+
+### Description
+
+Downloads the Enterprise ATT&CK STIX bundle from the official MITRE repository and caches it locally. Once downloaded, ATHF automatically switches from the hardcoded fallback data (14 tactics, approximate counts) to live STIX data (835+ techniques with full metadata including platforms, data sources, and sub-techniques).
+
+**Prerequisites:** Requires `mitreattack-python` — install with `pip install 'athf[attack]'`.
+
+**Cache locations (checked in order):**
+1. `ATHF_STIX_CACHE` environment variable
+2. `{workspace}/.athf/stix-data/` if `.athfconfig.yaml` exists in cwd
+3. `~/.athf/stix-data/` (global default)
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--force` | Flag | False | Re-download even if cache already exists |
+
+### Examples
+
+```bash
+# Download STIX data (first time)
+athf attack update
+
+# Force re-download to get latest version
+athf attack update --force
+```
+
+### Exit Codes
+
+- `0`: Success
+- `1`: mitreattack-python not installed or download failed
+
+---
+
+## athf attack status
+
+Show ATT&CK data provider status and cache information.
+
+### Synopsis
+
+```bash
+athf attack status
+```
+
+### Description
+
+Displays the active data provider (STIX or fallback), ATT&CK version, tactic count, cache file location, size, and age. Useful for verifying that STIX data is loaded and current.
+
+### Examples
+
+```bash
+athf attack status
+```
+
+**Output (with STIX):**
+```
+ATT&CK Data Status
+
+  Provider:  STIX (mitreattack-python)
+  Version:   v16.1 (STIX)
+  Tactics:   14
+  Cache:     /Users/you/.athf/stix-data/enterprise-attack.json
+  Size:      12.3 MB
+  Age:       3 days
+  Library:   mitreattack-python installed
+```
+
+**Output (fallback):**
+```
+ATT&CK Data Status
+
+  Provider:  Fallback (hardcoded v14)
+  Version:   v14 (hardcoded fallback)
+  Tactics:   14
+  Cache:     Not found (/Users/you/.athf/stix-data/enterprise-attack.json)
+  Library:   mitreattack-python not installed
+```
+
+### Exit Codes
+
+- `0`: Success
+
+---
+
+## athf attack lookup
+
+Look up an ATT&CK technique by its ID and display metadata.
+
+### Synopsis
+
+```bash
+athf attack lookup TECHNIQUE_ID
+```
+
+### Description
+
+Shows technique metadata including name, platforms, data sources, tactics, type (technique vs sub-technique), parent technique, description, and sub-techniques. Requires STIX data — run `athf attack update` first.
+
+### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `TECHNIQUE_ID` | String | ATT&CK technique ID (e.g., T1003, T1003.001) |
+
+### Examples
+
+```bash
+# Look up a parent technique
+athf attack lookup T1003
+
+# Look up a sub-technique
+athf attack lookup T1003.001
+```
+
+**Output:**
+```
+T1003.001 - LSASS Memory
+
+  URL:           https://attack.mitre.org/techniques/T1003/001
+  Platforms:     Windows
+  Tactics:       credential-access
+  Data Sources:  Process: OS API Execution, Process: Process Access, ...
+  Type:          Sub-technique
+  Parent:        T1003
+
+  Adversaries may attempt to access credential material stored in ...
+```
+
+### Exit Codes
+
+- `0`: Success (or technique not found with message)
+
+---
+
+## athf attack techniques
+
+List all techniques mapped to a specific ATT&CK tactic.
+
+### Synopsis
+
+```bash
+athf attack techniques TACTIC_KEY
+```
+
+### Description
+
+Displays a table of all techniques (including sub-techniques) for the given tactic, showing ID, name, sub-technique status, and platforms. Requires STIX data — run `athf attack update` first.
+
+### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `TACTIC_KEY` | String | Tactic shortname (e.g., credential-access, lateral-movement) |
+
+### Examples
+
+```bash
+# List credential access techniques
+athf attack techniques credential-access
+
+# List lateral movement techniques
+athf attack techniques lateral-movement
+```
+
+**Output:**
+```
+Credential Access (17 techniques)
+
+┌──────────────┬──────────────────────────────┬──────┬───────────────────┐
+│ ID           │ Name                         │ Sub? │ Platforms         │
+├──────────────┼──────────────────────────────┼──────┼───────────────────┤
+│ T1003        │ OS Credential Dumping        │      │ Windows, Linux... │
+│ T1003.001    │ LSASS Memory                 │ Yes  │ Windows           │
+│ T1003.002    │ Security Account Manager     │ Yes  │ Windows           │
+│ ...          │ ...                          │ ...  │ ...               │
+└──────────────┴──────────────────────────────┴──────┴───────────────────┘
+```
+
+**Valid tactic names:**
+- `reconnaissance`, `resource-development`, `initial-access`, `execution`
+- `persistence`, `privilege-escalation`, `defense-evasion`, `credential-access`
+- `discovery`, `lateral-movement`, `collection`, `command-and-control`
+- `exfiltration`, `impact`
+
+### Exit Codes
+
+- `0`: Success (or no techniques found with message)
 
 ---
 

--- a/integrations/MCP_CATALOG.md
+++ b/integrations/MCP_CATALOG.md
@@ -14,12 +14,12 @@ pip install 'athf[mcp]'
 {
   "athf": {
     "command": "athf-mcp",
-    "args": ["--workspace", "/path/to/your/hunts"]
+    "env": { "ATHF_WORKSPACE": "/path/to/your/hunts" }
   }
 }
 ```
 
-**Available tools (14):**
+**Available tools (17):**
 
 | Tool | Description |
 |------|-------------|

--- a/integrations/MCP_CATALOG.md
+++ b/integrations/MCP_CATALOG.md
@@ -1,6 +1,53 @@
 # MCP Catalog for Threat Hunting
 
-You'll need to **do your own research** to find MCP servers for your organization's security tools. This catalog walks through **Splunk as an example** to demonstrate the process of integrating an MCP server with Claude Code for threat hunting workflows.
+## ATHF MCP Server (Built-in)
+
+ATHF includes its own MCP server that exposes hunting operations as tools for any AI assistant.
+
+**Install:**
+```bash
+pip install 'athf[mcp]'
+```
+
+**Configure for Claude Code** (`~/.claude/mcp-servers.json`):
+```json
+{
+  "athf": {
+    "command": "athf-mcp",
+    "args": ["--workspace", "/path/to/your/hunts"]
+  }
+}
+```
+
+**Available tools (14):**
+
+| Tool | Description |
+|------|-------------|
+| `athf_hunt_list` | List/filter hunts by status, tactic, technique, platform |
+| `athf_hunt_search` | Full-text search across hunt files |
+| `athf_hunt_get` | Get full details of a specific hunt |
+| `athf_hunt_stats` | Hunt metrics (total, TP/FP, success rate) |
+| `athf_hunt_coverage` | MITRE ATT&CK coverage analysis |
+| `athf_hunt_validate` | Validate hunt file structure |
+| `athf_hunt_new` | Create a new hunt with LOCK structure |
+| `athf_similar` | Semantic similarity search (TF-IDF) |
+| `athf_context` | AI-optimized context bundle (environment + hunts + knowledge) |
+| `athf_research_list` | List research documents |
+| `athf_research_view` | View specific research document |
+| `athf_research_search` | Search research documents |
+| `athf_research_stats` | Research metrics |
+| `athf_investigate_list` | List investigations |
+| `athf_investigate_search` | Search investigations |
+| `athf_agent_run_hypothesis` | Generate hypothesis from threat intel (LLM-powered) |
+| `athf_agent_run_researcher` | Deep 5-skill pre-hunt research (LLM-powered) |
+
+**Works with:** Claude Code, GitHub Copilot, Cursor, Windsurf, or any MCP-compatible client.
+
+---
+
+## External MCP Servers
+
+You'll need to **do your own research** to find MCP servers for your organization's security tools. The section below walks through **Splunk as an example** to demonstrate the process of integrating an external MCP server with Claude Code for threat hunting workflows.
 
 ## Splunk Integration Walkthrough
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ bedrock = [
 ollama = [
     "ollama>=0.3.0",
 ]
+attack = [
+    "mitreattack-python>=5.0.0",
+]
 # Convenience: all LLM providers via LiteLLM
 llm = [
     "litellm>=1.30.0",
@@ -105,6 +108,7 @@ all = [
     "requests>=2.25.0",
     "tavily-python>=0.3.0",
     "mcp[cli]>=1.0.0",
+    "mitreattack-python>=5.0.0",
 ]
 
 [project.urls]
@@ -199,6 +203,10 @@ module = [
     "ollama.*",
     "anthropic",
     "anthropic.*",
+    "mitreattack",
+    "mitreattack.*",
+    "stix2",
+    "stix2.*",
     "athf.core.metrics_tracker",
     "mcp",
     "mcp.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-threat-hunting-framework"
-version = "0.10.0"
+version = "0.11.0"
 description = "Agentic Threat Hunting Framework - Memory and AI for threat hunters"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,16 @@ ollama = [
 llm = [
     "litellm>=1.30.0",
 ]
+# MCP server
+mcp = [
+    "mcp[cli]>=1.0.0",
+]
 all = [
     "litellm>=1.30.0",
     "scikit-learn>=1.0.0",
     "requests>=2.25.0",
     "tavily-python>=0.3.0",
+    "mcp[cli]>=1.0.0",
 ]
 
 [project.urls]
@@ -111,9 +116,10 @@ Discussions = "https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/
 
 [project.scripts]
 athf = "athf.cli:main"
+athf-mcp = "athf.mcp.server:main"
 
 [tool.setuptools]
-packages = ["athf", "athf.agents", "athf.agents.llm", "athf.commands", "athf.core", "athf.data", "athf.utils"]
+packages = ["athf", "athf.agents", "athf.agents.llm", "athf.commands", "athf.core", "athf.data", "athf.mcp", "athf.mcp.tools", "athf.utils"]
 
 [tool.setuptools.package-data]
 "athf.data" = [
@@ -194,8 +200,11 @@ module = [
     "anthropic",
     "anthropic.*",
     "athf.core.metrics_tracker",
+    "mcp",
+    "mcp.*",
 ]
 ignore_missing_imports = true
+follow_imports = "skip"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/commands/test_attack.py
+++ b/tests/commands/test_attack.py
@@ -1,0 +1,90 @@
+"""Tests for athf.commands.attack - ATT&CK CLI commands."""
+
+import pytest
+from click.testing import CliRunner
+
+from athf.commands.attack import attack
+
+
+@pytest.mark.unit
+class TestAttackStatus:
+    """Test 'athf attack status' command."""
+
+    def setup_method(self):
+        from athf.core import attack_matrix
+
+        attack_matrix.reset_provider(attack_matrix.FallbackProvider())
+
+    def test_status_shows_provider(self):
+        runner = CliRunner()
+        result = runner.invoke(attack, ["status"])
+        assert result.exit_code == 0
+        assert "Provider" in result.output
+        assert "Fallback" in result.output or "STIX" in result.output
+
+    def test_status_shows_version(self):
+        runner = CliRunner()
+        result = runner.invoke(attack, ["status"])
+        assert result.exit_code == 0
+        assert "Version" in result.output
+
+    def test_status_shows_tactic_count(self):
+        runner = CliRunner()
+        result = runner.invoke(attack, ["status"])
+        assert result.exit_code == 0
+        assert "Tactics" in result.output
+
+
+@pytest.mark.unit
+class TestAttackLookup:
+    """Test 'athf attack lookup' command."""
+
+    def setup_method(self):
+        from athf.core import attack_matrix
+
+        attack_matrix.reset_provider(attack_matrix.FallbackProvider())
+
+    def test_lookup_without_stix_shows_message(self):
+        runner = CliRunner()
+        result = runner.invoke(attack, ["lookup", "T1003"])
+        assert result.exit_code == 0
+        assert "not available" in result.output.lower() or "requires" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAttackTechniques:
+    """Test 'athf attack techniques' command."""
+
+    def setup_method(self):
+        from athf.core import attack_matrix
+
+        attack_matrix.reset_provider(attack_matrix.FallbackProvider())
+
+    def test_techniques_without_stix_shows_message(self):
+        runner = CliRunner()
+        result = runner.invoke(attack, ["techniques", "credential-access"])
+        assert result.exit_code == 0
+        assert "not available" in result.output.lower() or "requires" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAttackUpdate:
+    """Test 'athf attack update' command."""
+
+    def test_update_without_mitreattack_installed(self, monkeypatch):
+        """update should error gracefully when mitreattack-python is not installed."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name.startswith("mitreattack"):
+                raise ImportError("mocked: no mitreattack")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+
+        runner = CliRunner()
+        result = runner.invoke(attack, ["update"])
+        # Should abort (exit code 1) with helpful message
+        assert result.exit_code != 0 or "not installed" in result.output.lower()

--- a/tests/commands/test_similar.py
+++ b/tests/commands/test_similar.py
@@ -8,6 +8,14 @@ from click.testing import CliRunner
 
 from athf.commands.similar import _extract_session_text, _find_similar_hunts, _load_session_data, similar
 
+_has_sklearn = True
+try:
+    import sklearn  # noqa: F401
+except ImportError:
+    _has_sklearn = False
+
+requires_sklearn = pytest.mark.skipif(not _has_sklearn, reason="scikit-learn not installed")
+
 
 class TestSimilarCommand:
     """Tests for similar command."""
@@ -284,6 +292,7 @@ class TestLoadSessionData:
         assert result == []
 
 
+@requires_sklearn
 class TestSessionFoldIntoHunts:
     """Tests that sessions fold into hunt searchable text by default."""
 
@@ -327,6 +336,7 @@ class TestSessionFoldIntoHunts:
         assert results[0]["source"] == "hunt"
 
 
+@requires_sklearn
 class TestSessionsFlag:
     """Tests for --sessions CLI flag."""
 

--- a/tests/core/test_attack_matrix.py
+++ b/tests/core/test_attack_matrix.py
@@ -1,0 +1,285 @@
+"""Tests for athf.core.attack_matrix - ATT&CK data provider abstraction."""
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# FallbackProvider tests (always pass, no optional deps needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFallbackProvider:
+    """Test the hardcoded fallback provider."""
+
+    def test_get_tactics_returns_14(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        tactics = provider.get_tactics()
+        assert len(tactics) == 14
+
+    def test_get_tactics_has_expected_keys(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        tactics = provider.get_tactics()
+        assert "credential-access" in tactics
+        assert "initial-access" in tactics
+        assert "lateral-movement" in tactics
+
+    def test_tactic_info_structure(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        tactics = provider.get_tactics()
+        for key, info in tactics.items():
+            assert "name" in info
+            assert "technique_count" in info
+            assert "order" in info
+            assert isinstance(info["technique_count"], int)
+            assert info["technique_count"] > 0
+
+    def test_get_total_techniques(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        total = provider.get_total_techniques()
+        assert total > 100  # Sanity check: ATT&CK has hundreds of techniques
+
+    def test_get_sorted_tactic_keys(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        keys = provider.get_sorted_tactic_keys()
+        assert len(keys) == 14
+        assert keys[0] == "reconnaissance"
+        assert keys[-1] == "impact"
+
+    def test_technique_by_id_returns_none(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        assert provider.get_technique_by_id("T1003") is None
+
+    def test_techniques_for_tactic_returns_empty(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        assert provider.get_techniques_for_tactic("credential-access") == []
+
+    def test_sub_techniques_returns_empty(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        assert provider.get_sub_techniques("T1003") == []
+
+    def test_version_string(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        assert "fallback" in provider.get_version().lower()
+
+    def test_is_stix_false(self):
+        from athf.core.attack_matrix import FallbackProvider
+
+        provider = FallbackProvider()
+        assert provider.is_stix() is False
+
+
+# ---------------------------------------------------------------------------
+# Module-level backward compatibility tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBackwardCompatibility:
+    """Verify that existing imports and APIs still work."""
+
+    def setup_method(self):
+        """Reset the provider singleton before each test."""
+        from athf.core import attack_matrix
+
+        attack_matrix.reset_provider()
+
+    def test_import_attack_tactics(self):
+        """ATTACK_TACTICS can still be imported via __getattr__."""
+        from athf.core.attack_matrix import ATTACK_TACTICS  # noqa: F811
+
+        assert isinstance(ATTACK_TACTICS, dict)
+        assert len(ATTACK_TACTICS) == 14
+        assert "credential-access" in ATTACK_TACTICS
+
+    def test_import_total_techniques(self):
+        """TOTAL_TECHNIQUES can still be imported via __getattr__."""
+        from athf.core.attack_matrix import TOTAL_TECHNIQUES  # noqa: F811
+
+        assert isinstance(TOTAL_TECHNIQUES, int)
+        assert TOTAL_TECHNIQUES > 100
+
+    def test_get_tactic_display_name(self):
+        from athf.core.attack_matrix import get_tactic_display_name
+
+        assert get_tactic_display_name("credential-access") == "Credential Access"
+
+    def test_get_tactic_display_name_unknown(self):
+        from athf.core.attack_matrix import get_tactic_display_name
+
+        # Unknown tactic should title-case the key
+        assert get_tactic_display_name("unknown-tactic") == "Unknown Tactic"
+
+    def test_get_tactic_technique_count(self):
+        from athf.core.attack_matrix import get_tactic_technique_count
+
+        count = get_tactic_technique_count("credential-access")
+        assert count > 0
+
+    def test_get_tactic_technique_count_unknown(self):
+        from athf.core.attack_matrix import get_tactic_technique_count
+
+        assert get_tactic_technique_count("nonexistent") == 0
+
+    def test_get_sorted_tactics(self):
+        from athf.core.attack_matrix import get_sorted_tactics
+
+        tactics = get_sorted_tactics()
+        assert len(tactics) == 14
+        assert tactics[0] == "reconnaissance"
+
+    def test_attack_tactics_tactic_info_shape(self):
+        """Each tactic in ATTACK_TACTICS has the expected TacticInfo shape."""
+        from athf.core.attack_matrix import ATTACK_TACTICS  # noqa: F811
+
+        for key, info in ATTACK_TACTICS.items():
+            assert isinstance(info["name"], str)
+            assert isinstance(info["technique_count"], int)
+            assert isinstance(info["order"], int)
+
+    def test_getattr_raises_for_unknown(self):
+        """Module __getattr__ raises AttributeError for unknown names."""
+        with pytest.raises(AttributeError, match="no attribute"):
+            from athf.core import attack_matrix
+
+            attack_matrix.__getattr__("NONEXISTENT_THING")
+
+
+# ---------------------------------------------------------------------------
+# Provider selection tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProviderSelection:
+    """Test automatic provider selection logic."""
+
+    def setup_method(self):
+        from athf.core import attack_matrix
+
+        attack_matrix.reset_provider()
+
+    def test_fallback_when_no_mitreattack(self, monkeypatch):
+        """Falls back when mitreattack-python is not importable."""
+        from athf.core import attack_matrix
+
+        attack_matrix.reset_provider()
+
+        original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name.startswith("mitreattack"):
+                raise ImportError("mocked: no mitreattack")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", mock_import)
+
+        # Force re-selection
+        attack_matrix.reset_provider()
+        provider = attack_matrix._get_provider()
+        assert isinstance(provider, attack_matrix.FallbackProvider)
+
+    def test_reset_provider_with_explicit(self):
+        """reset_provider(provider) sets a specific provider."""
+        from athf.core.attack_matrix import FallbackProvider, reset_provider, _get_provider
+
+        custom = FallbackProvider()
+        reset_provider(custom)
+        assert _get_provider() is custom
+
+    def test_reset_provider_none_triggers_auto(self):
+        """reset_provider(None) triggers auto-detection on next access."""
+        from athf.core import attack_matrix
+
+        attack_matrix.reset_provider(None)
+        # _provider should be None, next _get_provider() auto-selects
+        assert attack_matrix._provider is None
+        provider = attack_matrix._get_provider()
+        assert provider is not None
+
+
+# ---------------------------------------------------------------------------
+# New public API tests (fallback provider)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNewPublicAPI:
+    """Test new API functions with fallback provider."""
+
+    def setup_method(self):
+        from athf.core import attack_matrix
+
+        attack_matrix.reset_provider(attack_matrix.FallbackProvider())
+
+    def test_get_technique_returns_none(self):
+        from athf.core.attack_matrix import get_technique
+
+        assert get_technique("T1003") is None
+
+    def test_get_techniques_for_tactic_returns_empty(self):
+        from athf.core.attack_matrix import get_techniques_for_tactic
+
+        assert get_techniques_for_tactic("credential-access") == []
+
+    def test_get_sub_techniques_returns_empty(self):
+        from athf.core.attack_matrix import get_sub_techniques
+
+        assert get_sub_techniques("T1003") == []
+
+    def test_get_attack_version(self):
+        from athf.core.attack_matrix import get_attack_version
+
+        version = get_attack_version()
+        assert "fallback" in version.lower()
+
+    def test_is_using_stix_false(self):
+        from athf.core.attack_matrix import is_using_stix
+
+        assert is_using_stix() is False
+
+
+# ---------------------------------------------------------------------------
+# Cache path tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCachePaths:
+    """Test STIX cache path resolution."""
+
+    def test_env_var_override(self, monkeypatch, tmp_path):
+        from athf.core.attack_matrix import _get_stix_cache_dir
+
+        monkeypatch.setenv("ATHF_STIX_CACHE", str(tmp_path / "custom"))
+        assert _get_stix_cache_dir() == tmp_path / "custom"
+
+    def test_global_default(self, monkeypatch):
+        from athf.core.attack_matrix import _get_stix_cache_dir
+
+        monkeypatch.delenv("ATHF_STIX_CACHE", raising=False)
+        # Ensure no .athfconfig.yaml in cwd
+        monkeypatch.chdir("/tmp")
+        cache_dir = _get_stix_cache_dir()
+        assert "stix-data" in str(cache_dir)

--- a/tests/core/test_attack_matrix.py
+++ b/tests/core/test_attack_matrix.py
@@ -275,11 +275,11 @@ class TestCachePaths:
         monkeypatch.setenv("ATHF_STIX_CACHE", str(tmp_path / "custom"))
         assert _get_stix_cache_dir() == tmp_path / "custom"
 
-    def test_global_default(self, monkeypatch):
+    def test_global_default(self, monkeypatch, tmp_path):
         from athf.core.attack_matrix import _get_stix_cache_dir
 
         monkeypatch.delenv("ATHF_STIX_CACHE", raising=False)
         # Ensure no .athfconfig.yaml in cwd
-        monkeypatch.chdir("/tmp")
+        monkeypatch.chdir(tmp_path)
         cache_dir = _get_stix_cache_dir()
         assert "stix-data" in str(cache_dir)

--- a/tests/mcp/test_hunt_tools.py
+++ b/tests/mcp/test_hunt_tools.py
@@ -89,7 +89,7 @@ def _call_tool(server, tool_name, arguments=None):
         text = content_list[0].text if content_list else ""
         return json.loads(text)
 
-    return asyncio.get_event_loop().run_until_complete(_run())
+    return asyncio.run(_run())
 
 
 class TestHuntList:
@@ -139,11 +139,15 @@ class TestHuntStats:
 class TestHuntCoverage:
     def test_returns_coverage(self, server):
         result = _call_tool(server, "athf_hunt_coverage")
-        assert "by_tactic" in result or "total_techniques" in result
+        assert "by_tactic" in result
+        assert "summary" in result
+        assert result["summary"]["total_techniques"] > 0
+        assert len(result["by_tactic"]) == 14
 
     def test_filter_by_tactic(self, server):
         result = _call_tool(server, "athf_hunt_coverage", {"tactic": "credential-access"})
         assert "error" not in result
+        assert "total_techniques" in result
 
 
 class TestHuntValidate:

--- a/tests/mcp/test_hunt_tools.py
+++ b/tests/mcp/test_hunt_tools.py
@@ -4,6 +4,8 @@ import json
 import pytest
 from pathlib import Path
 
+pytest.importorskip("mcp", reason="MCP optional dependency not installed")
+
 from athf.mcp.server import create_server
 
 

--- a/tests/mcp/test_hunt_tools.py
+++ b/tests/mcp/test_hunt_tools.py
@@ -1,0 +1,167 @@
+"""Tests for hunt MCP tools."""
+
+import json
+import pytest
+from pathlib import Path
+
+from athf.mcp.server import create_server
+
+
+def _setup_workspace(tmp_path):
+    """Create a minimal workspace with sample hunts."""
+    (tmp_path / ".athfconfig.yaml").write_text("workspace_name: test\nhunt_prefix: H-\n")
+    hunts_dir = tmp_path / "hunts"
+    hunts_dir.mkdir()
+    (tmp_path / "research").mkdir()
+    (tmp_path / "investigations").mkdir()
+
+    # Create sample hunt
+    hunt_content = """---
+hunt_id: H-0001
+title: "Kerberoasting Detection"
+technique: T1558.003
+tactics:
+  - credential-access
+platform:
+  - Windows
+status: completed
+result: true_positive
+date: 2026-01-01
+---
+
+# H-0001: Kerberoasting Detection
+
+## Learn
+Kerberoasting allows attackers to request service tickets.
+
+## Observe
+Hypothesis: Adversaries request TGS tickets for service accounts.
+
+## Check
+Query: index=security EventCode=4769 TicketEncryptionType=0x17
+
+## Keep
+Found 3 service accounts with RC4 tickets.
+"""
+    (hunts_dir / "H-0001.md").write_text(hunt_content)
+
+    hunt2_content = """---
+hunt_id: H-0002
+title: "Pass-the-Hash Detection"
+technique: T1550.002
+tactics:
+  - lateral-movement
+platform:
+  - Windows
+status: active
+date: 2026-01-02
+---
+
+# H-0002: Pass-the-Hash Detection
+
+## Learn
+Pass-the-Hash uses stolen NTLM hashes.
+"""
+    (hunts_dir / "H-0002.md").write_text(hunt2_content)
+    return tmp_path
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    return _setup_workspace(tmp_path)
+
+
+@pytest.fixture
+def server(workspace):
+    return create_server(str(workspace))
+
+
+def _call_tool(server, tool_name, arguments=None):
+    """Synchronously call an MCP tool and return parsed JSON."""
+    import asyncio
+
+    async def _run():
+        result = await server.call_tool(tool_name, arguments or {})
+        # call_tool returns (content_list, metadata_dict)
+        content_list = result[0] if isinstance(result, tuple) else result
+        text = content_list[0].text if content_list else ""
+        return json.loads(text)
+
+    return asyncio.get_event_loop().run_until_complete(_run())
+
+
+class TestHuntList:
+    def test_lists_all_hunts(self, server):
+        result = _call_tool(server, "athf_hunt_list")
+        assert result["count"] == 2
+
+    def test_filter_by_status(self, server):
+        result = _call_tool(server, "athf_hunt_list", {"status": "completed"})
+        assert result["count"] == 1
+        assert result["hunts"][0]["hunt_id"] == "H-0001"
+
+    def test_filter_by_tactic(self, server):
+        result = _call_tool(server, "athf_hunt_list", {"tactic": "lateral-movement"})
+        assert result["count"] == 1
+        assert result["hunts"][0]["hunt_id"] == "H-0002"
+
+
+class TestHuntSearch:
+    def test_search_finds_match(self, server):
+        result = _call_tool(server, "athf_hunt_search", {"query": "Kerberoasting"})
+        assert result["count"] >= 1
+
+    def test_search_no_match(self, server):
+        result = _call_tool(server, "athf_hunt_search", {"query": "zzz_nonexistent_zzz"})
+        assert result["count"] == 0
+
+
+class TestHuntGet:
+    def test_get_existing_hunt(self, server):
+        result = _call_tool(server, "athf_hunt_get", {"hunt_id": "H-0001"})
+        assert result["hunt_id"] == "H-0001"
+        assert "frontmatter" in result
+
+    def test_get_nonexistent_hunt(self, server):
+        result = _call_tool(server, "athf_hunt_get", {"hunt_id": "H-9999"})
+        assert "error" in result
+
+
+class TestHuntStats:
+    def test_returns_stats(self, server):
+        result = _call_tool(server, "athf_hunt_stats")
+        assert "total_hunts" in result
+        assert result["total_hunts"] == 2
+
+
+class TestHuntCoverage:
+    def test_returns_coverage(self, server):
+        result = _call_tool(server, "athf_hunt_coverage")
+        assert "by_tactic" in result or "total_techniques" in result
+
+    def test_filter_by_tactic(self, server):
+        result = _call_tool(server, "athf_hunt_coverage", {"tactic": "credential-access"})
+        assert "error" not in result
+
+
+class TestHuntValidate:
+    def test_validate_valid_hunt(self, server):
+        result = _call_tool(server, "athf_hunt_validate", {"hunt_id": "H-0001"})
+        assert result["valid"] is True
+
+    def test_validate_nonexistent(self, server):
+        result = _call_tool(server, "athf_hunt_validate", {"hunt_id": "H-9999"})
+        assert result["valid"] is False
+
+
+class TestHuntNew:
+    def test_creates_hunt(self, server, workspace):
+        result = _call_tool(server, "athf_hunt_new", {
+            "title": "Test Hunt Creation",
+            "technique": "T1059.001",
+        })
+        assert "hunt_id" in result
+        assert result["technique"] == "T1059.001"
+        # Verify file exists
+        hunt_file = Path(result["file_path"])
+        assert hunt_file.exists()

--- a/tests/mcp/test_search_tools.py
+++ b/tests/mcp/test_search_tools.py
@@ -80,7 +80,7 @@ def _call_tool(server, tool_name, arguments=None):
         text = content_list[0].text if content_list else ""
         return json.loads(text)
 
-    return asyncio.get_event_loop().run_until_complete(_run())
+    return asyncio.run(_run())
 
 
 class TestSimilar:

--- a/tests/mcp/test_search_tools.py
+++ b/tests/mcp/test_search_tools.py
@@ -4,6 +4,8 @@ import json
 import pytest
 from pathlib import Path
 
+pytest.importorskip("mcp", reason="MCP optional dependency not installed")
+
 from athf.mcp.server import create_server
 
 

--- a/tests/mcp/test_search_tools.py
+++ b/tests/mcp/test_search_tools.py
@@ -1,0 +1,121 @@
+"""Tests for search MCP tools (similar, context)."""
+
+import json
+import pytest
+from pathlib import Path
+
+from athf.mcp.server import create_server
+
+
+def _setup_workspace(tmp_path):
+    """Create workspace with hunts for search testing."""
+    (tmp_path / ".athfconfig.yaml").write_text("workspace_name: test\n")
+    hunts_dir = tmp_path / "hunts"
+    hunts_dir.mkdir()
+    (tmp_path / "research").mkdir()
+    (tmp_path / "investigations").mkdir()
+
+    hunt_content = """---
+hunt_id: H-0001
+title: "Credential Dumping via LSASS"
+technique: T1003.001
+tactics:
+  - credential-access
+platform:
+  - Windows
+status: completed
+date: 2026-01-01
+---
+
+# H-0001: Credential Dumping via LSASS
+
+## Learn
+LSASS process memory contains credentials.
+"""
+    (hunts_dir / "H-0001.md").write_text(hunt_content)
+
+    hunt2_content = """---
+hunt_id: H-0002
+title: "Lateral Movement via PsExec"
+technique: T1570
+tactics:
+  - lateral-movement
+platform:
+  - Windows
+status: active
+date: 2026-01-02
+---
+
+# H-0002: Lateral Movement via PsExec
+
+## Learn
+PsExec enables remote command execution.
+"""
+    (hunts_dir / "H-0002.md").write_text(hunt2_content)
+
+    # environment.md
+    (tmp_path / "environment.md").write_text("# Environment\nSIEM: Splunk\nEDR: CrowdStrike\n")
+
+    return tmp_path
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    return _setup_workspace(tmp_path)
+
+
+@pytest.fixture
+def server(workspace):
+    return create_server(str(workspace))
+
+
+def _call_tool(server, tool_name, arguments=None):
+    import asyncio
+
+    async def _run():
+        result = await server.call_tool(tool_name, arguments or {})
+        content_list = result[0] if isinstance(result, tuple) else result
+        text = content_list[0].text if content_list else ""
+        return json.loads(text)
+
+    return asyncio.get_event_loop().run_until_complete(_run())
+
+
+class TestSimilar:
+    def test_similar_with_query(self, server):
+        result = _call_tool(server, "athf_similar", {"query": "credential dumping LSASS"})
+        assert result["count"] >= 1
+        assert result["results"][0]["hunt_id"] == "H-0001"
+
+    def test_similar_with_hunt_id(self, server):
+        result = _call_tool(server, "athf_similar", {"hunt_id": "H-0001"})
+        assert result["count"] >= 1
+
+    def test_similar_no_params(self, server):
+        result = _call_tool(server, "athf_similar")
+        assert "error" in result
+
+    def test_similar_threshold(self, server):
+        result = _call_tool(server, "athf_similar", {"query": "credential dumping", "threshold": 0.9})
+        # High threshold may filter out results
+        assert "count" in result
+
+
+class TestContext:
+    def test_context_with_hunt_id(self, server):
+        result = _call_tool(server, "athf_context", {"hunt_id": "H-0001"})
+        assert "hunt" in result
+        assert "environment" in result
+
+    def test_context_with_tactic(self, server):
+        result = _call_tool(server, "athf_context", {"tactic": "credential-access"})
+        assert "hunts" in result
+        assert result["hunt_count"] >= 1
+
+    def test_context_no_params(self, server):
+        result = _call_tool(server, "athf_context")
+        assert "error" in result
+
+    def test_context_includes_environment(self, server):
+        result = _call_tool(server, "athf_context", {"hunt_id": "H-0001"})
+        assert "Splunk" in result["environment"]

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -13,6 +13,7 @@ from athf.mcp.utils import find_workspace, load_workspace_config
 
 class TestFindWorkspace:
     def test_explicit_path(self, tmp_path):
+        (tmp_path / ".athfconfig.yaml").write_text("workspace_name: test\n")
         result = find_workspace(str(tmp_path))
         assert result == tmp_path
 
@@ -21,9 +22,14 @@ class TestFindWorkspace:
             find_workspace("/nonexistent/path/12345")
 
     def test_env_var(self, tmp_path):
+        (tmp_path / ".athfconfig.yaml").write_text("workspace_name: test\n")
         with patch.dict(os.environ, {"ATHF_WORKSPACE": str(tmp_path)}):
             result = find_workspace()
             assert result == tmp_path
+
+    def test_explicit_path_no_config_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="Not an ATHF workspace"):
+            find_workspace(str(tmp_path))
 
     def test_walk_up_finds_config(self, tmp_path):
         config = tmp_path / ".athfconfig.yaml"
@@ -99,7 +105,7 @@ class TestCreateServer:
         async def get_tools():
             return await server.list_tools()
 
-        tools = asyncio.get_event_loop().run_until_complete(get_tools())
+        tools = asyncio.run(get_tools())
         tool_names = [t.name for t in tools]
 
         # Verify key tools from each group are registered

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -6,6 +6,8 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 
+pytest.importorskip("mcp", reason="MCP optional dependency not installed")
+
 from athf.mcp.utils import find_workspace, load_workspace_config
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,0 +1,112 @@
+"""Tests for the ATHF MCP server creation and tool registration."""
+
+import json
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from athf.mcp.utils import find_workspace, load_workspace_config
+
+
+class TestFindWorkspace:
+    def test_explicit_path(self, tmp_path):
+        result = find_workspace(str(tmp_path))
+        assert result == tmp_path
+
+    def test_explicit_path_not_exists(self):
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            find_workspace("/nonexistent/path/12345")
+
+    def test_env_var(self, tmp_path):
+        with patch.dict(os.environ, {"ATHF_WORKSPACE": str(tmp_path)}):
+            result = find_workspace()
+            assert result == tmp_path
+
+    def test_walk_up_finds_config(self, tmp_path):
+        config = tmp_path / ".athfconfig.yaml"
+        config.write_text("workspace_name: test\n")
+        subdir = tmp_path / "hunts" / "2026"
+        subdir.mkdir(parents=True)
+
+        with patch("athf.mcp.utils.Path.cwd", return_value=subdir):
+            result = find_workspace()
+            assert result == tmp_path
+
+    def test_walk_up_finds_config_in_config_dir(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / ".athfconfig.yaml").write_text("workspace_name: test\n")
+
+        with patch("athf.mcp.utils.Path.cwd", return_value=tmp_path):
+            result = find_workspace()
+            assert result == tmp_path
+
+    def test_no_workspace_raises(self, tmp_path):
+        with patch("athf.mcp.utils.Path.cwd", return_value=tmp_path):
+            with pytest.raises(FileNotFoundError, match="No ATHF workspace found"):
+                find_workspace()
+
+
+class TestLoadWorkspaceConfig:
+    def test_loads_config(self, tmp_path):
+        config = tmp_path / ".athfconfig.yaml"
+        config.write_text("workspace_name: test\nsiem: Splunk\n")
+        result = load_workspace_config(tmp_path)
+        assert result["workspace_name"] == "test"
+        assert result["siem"] == "Splunk"
+
+    def test_config_in_config_dir(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / ".athfconfig.yaml").write_text("workspace_name: nested\n")
+        result = load_workspace_config(tmp_path)
+        assert result["workspace_name"] == "nested"
+
+    def test_no_config(self, tmp_path):
+        result = load_workspace_config(tmp_path)
+        assert result == {}
+
+
+class TestCreateServer:
+    def test_creates_server_with_tools(self, tmp_path):
+        # Create minimal workspace
+        (tmp_path / ".athfconfig.yaml").write_text("workspace_name: test\n")
+        (tmp_path / "hunts").mkdir()
+        (tmp_path / "research").mkdir()
+        (tmp_path / "investigations").mkdir()
+
+        from athf.mcp.server import create_server
+
+        server = create_server(str(tmp_path))
+        assert server is not None
+
+    def test_server_registers_all_tool_groups(self, tmp_path):
+        (tmp_path / ".athfconfig.yaml").write_text("workspace_name: test\n")
+        (tmp_path / "hunts").mkdir()
+        (tmp_path / "research").mkdir()
+        (tmp_path / "investigations").mkdir()
+
+        from athf.mcp.server import create_server
+
+        server = create_server(str(tmp_path))
+
+        # Get registered tool names
+        import asyncio
+
+        async def get_tools():
+            return await server.list_tools()
+
+        tools = asyncio.get_event_loop().run_until_complete(get_tools())
+        tool_names = [t.name for t in tools]
+
+        # Verify key tools from each group are registered
+        assert "athf_hunt_list" in tool_names
+        assert "athf_hunt_search" in tool_names
+        assert "athf_hunt_new" in tool_names
+        assert "athf_similar" in tool_names
+        assert "athf_context" in tool_names
+        assert "athf_research_list" in tool_names
+        assert "athf_investigate_list" in tool_names
+        assert "athf_agent_run_hypothesis" in tool_names
+        assert "athf_agent_run_researcher" in tool_names


### PR DESCRIPTION
## Summary

- Add MCP server exposing 14+ ATHF operations as tools for AI assistants (Claude Code, Copilot, Cursor, Windsurf)
- Tools: hunt list/search/get/stats/coverage/validate/new, similar, context, research list/view/search/stats, investigate list/search, agent hypothesis/researcher
- `athf mcp serve` CLI command and `athf-mcp` standalone entry point
- Auto-detect workspace from cwd or `ATHF_WORKSPACE` env var
- Install with: `pip install 'athf[mcp]'`
- Version bump to 0.11.0

## Changes

- **New:** `athf/mcp/` — server, utils, and 5 tool modules (1,200+ lines)
- **New:** `tests/mcp/` — 32 tests covering server, hunt tools, search tools
- **New:** `athf/commands/mcp.py` — CLI subcommand
- **Updated:** pyproject.toml — mcp dependency, entry point, package list
- **Updated:** README.md, CHANGELOG.md, MCP_CATALOG.md — documentation

## Test plan

- [x] 187 tests passing locally
- [x] flake8 clean
- [x] mypy clean
- [ ] CI passes on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in MCP Server exposing 14 threat-hunting tools and live ATT&CK STIX data support (provider + fallback).

* **CLI**
  * New commands: `athf mcp serve`, `athf attack` (update/status/lookup/techniques), and a new `athf-mcp` script.

* **Documentation**
  * README, changelog, CLI reference, and integration docs updated with installation, config samples, and usage guidance.

* **Tests**
  * Added comprehensive test suites for MCP server/tools and ATT&CK commands; optional-test gating for scikit-learn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->