### PR TITLE
fix(hunt): auto-derive tactics from technique when --tactic is omitted

### DIFF
--- a/athf/commands/hunt.py
+++ b/athf/commands/hunt.py
@@ -13,12 +13,30 @@ from rich.console import Console
 from rich.prompt import Prompt
 from rich.table import Table
 
+from athf.core.attack_matrix import get_technique
 from athf.core.hunt_manager import HuntManager
 from athf.core.hunt_parser import validate_hunt_file
 from athf.core.template_engine import render_hunt_template
 from athf.utils.validation import validate_hunt_id, validate_research_id
 
 console = Console()
+
+
+def _default_tactics_for_technique(technique_id: str) -> List[str]:
+    """Best-effort tactic auto-derivation from an ATT&CK technique ID.
+
+    Looks up the technique in the active ATT&CK data provider and returns
+    its tactic shortnames. Returns an empty list if the technique isn't
+    found or the active provider is the hardcoded fallback (which doesn't
+    carry per-technique metadata) — callers should treat that as "no
+    derivation available" and fall back to their own default.
+    """
+    if not technique_id:
+        return []
+    info = get_technique(technique_id)
+    if info:
+        return list(info.get("tactic_shortnames") or [])
+    return []
 
 
 def get_hunt_directory(is_test: bool = False) -> Path:
@@ -226,7 +244,11 @@ def new(
             return
         hunt_title = title
         hunt_technique = technique or "T1005"
-        hunt_tactics = list(tactic) if tactic else ["collection"]
+        if tactic:
+            hunt_tactics = list(tactic)
+        else:
+            derived = _default_tactics_for_technique(hunt_technique)
+            hunt_tactics = derived if derived else ["collection"]
         hunt_platforms = list(platform) if platform else ["Windows"]
         hunt_data_sources = list(data_source) if data_source else ["SIEM", "EDR"]
     else:
@@ -239,10 +261,16 @@ def new(
         # Title
         hunt_title = Prompt.ask("2. Hunt Title", default=title or f"Hunt for {hunt_technique}")
 
-        # Tactics
+        # Tactics — auto-derive from technique when possible, otherwise prompt
+        # with a generic default the user is likely to override anyway.
         console.print("\n3. Primary Tactic(s) (comma-separated):")
         console.print("   Common: [cyan]persistence, credential-access, collection, lateral-movement[/cyan]")
-        tactic_input = Prompt.ask("   Tactics", default=",".join(tactic) if tactic else "collection")
+        if tactic:
+            tactic_default = ",".join(tactic)
+        else:
+            derived = _default_tactics_for_technique(hunt_technique)
+            tactic_default = ",".join(derived) if derived else "collection"
+        tactic_input = Prompt.ask("   Tactics", default=tactic_default)
         hunt_tactics = [t.strip() for t in tactic_input.split(",")]
 
         # Platform

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -262,7 +262,7 @@ class TestHuntNewCommand:
         assert match
         hunt_id = match.group(1)
         content = next((temp_workspace / "hunts").rglob(f"{hunt_id}.md")).read_text()
-        assert "collection" in content
+        assert "tactics: [collection]" in content or "tactics:\n- collection" in content
 
     def test_hunt_new_with_multiple_tactics(self, runner, temp_workspace):
         """Test creating hunt with multiple tactics."""

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -176,6 +176,94 @@ class TestHuntNewCommand:
         # Second hunt should have ID incremented by 1
         assert num2 == num1 + 1, f"Expected {hunt_id_2} to be one more than {hunt_id_1}"
 
+    def test_hunt_new_auto_derives_tactic_from_technique(self, runner, temp_workspace, monkeypatch):
+        """When --tactic is omitted, tactic should be auto-derived from --technique
+        via the ATT&CK provider. With STIX data, T1003.001 must yield
+        credential-access (NOT the legacy hardcoded "collection" default).
+
+        Patches `get_technique` so the test runs without a STIX cache.
+        """
+        import re
+
+        # Patch the provider lookup used by hunt.py. We patch on the
+        # module object directly because `athf.commands.hunt` has a
+        # click Group named `hunt` that shadows attribute-style lookup.
+        import sys
+
+        hunt_mod = sys.modules["athf.commands.hunt"]
+
+        def fake_get_technique(tid):
+            if tid == "T1003.001":
+                return {
+                    "id": "T1003.001",
+                    "name": "LSASS Memory",
+                    "tactic_shortnames": ["credential-access"],
+                }
+            return None
+
+        monkeypatch.setattr(hunt_mod, "get_technique", fake_get_technique)
+
+        runner.invoke(init, ["--non-interactive"])
+
+        result = runner.invoke(
+            hunt,
+            [
+                "new",
+                "--title",
+                "Auto-tactic Hunt",
+                "--technique",
+                "T1003.001",
+                "--non-interactive",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        match = re.search(r"Created (H-\d+)", result.output)
+        assert match, f"Could not find hunt ID in output: {result.output}"
+        hunt_id = match.group(1)
+
+        hunt_files = list((temp_workspace / "hunts").rglob(f"{hunt_id}.md"))
+        assert len(hunt_files) == 1
+        content = hunt_files[0].read_text()
+
+        assert "credential-access" in content, (
+            "Expected auto-derived tactic 'credential-access' in hunt frontmatter; " "got hunt content:\n" + content
+        )
+        # Make sure we did NOT regress to the legacy hardcoded default.
+        assert "tactics: [collection]" not in content
+        assert "tactics:\n- collection" not in content
+
+    def test_hunt_new_falls_back_when_technique_unknown(self, runner, temp_workspace, monkeypatch):
+        """If the provider can't resolve the technique (e.g. fallback provider in
+        use), the legacy default of 'collection' is preserved so existing
+        behavior is unchanged for users without STIX data."""
+        import re
+
+        import sys
+
+        hunt_mod = sys.modules["athf.commands.hunt"]
+        monkeypatch.setattr(hunt_mod, "get_technique", lambda _tid: None)
+
+        runner.invoke(init, ["--non-interactive"])
+        result = runner.invoke(
+            hunt,
+            [
+                "new",
+                "--title",
+                "Fallback Default Hunt",
+                "--technique",
+                "T1003.001",
+                "--non-interactive",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        match = re.search(r"Created (H-\d+)", result.output)
+        assert match
+        hunt_id = match.group(1)
+        content = next((temp_workspace / "hunts").rglob(f"{hunt_id}.md")).read_text()
+        assert "collection" in content
+
     def test_hunt_new_with_multiple_tactics(self, runner, temp_workspace):
         """Test creating hunt with multiple tactics."""
         import re


### PR DESCRIPTION
Closes #27

## Summary

`athf hunt new --technique T1003.001` was writing `tactics: [collection]` to frontmatter regardless of the technique passed. The hardcoded default predates the STIX-aware ATT&CK provider, so the right tactic (`credential-access`) was already known to ATHF — it just wasn't being used. This corrupted `athf hunt coverage` and any downstream analytics that group by tactic.

This PR makes `hunt new` look up the technique in the active provider and use its `tactic_shortnames` when `--tactic` is omitted. The legacy `["collection"]` default is preserved for users on the hardcoded v14 fallback (where per-technique metadata isn't available), so existing behavior is unchanged for anyone who hasn't run `athf attack update`.

The same logic applies to the interactive prompt's default value.

## Verified end-to-end

```
$ athf attack update --force        # main branch (with #573f611 already in)
$ athf hunt new --technique T1003.001 --title X --non-interactive
$ grep tactics: hunts/production/*/Q*/H-*.md
tactics: [credential-access]        # was: [collection]
```

## Tests

- `test_hunt_new_auto_derives_tactic_from_technique` — with mocked STIX provider, T1003.001 → `credential-access` in frontmatter
- `test_hunt_new_falls_back_when_technique_unknown` — when provider returns `None` (fallback provider or unknown technique), legacy default preserved → no behavior change for existing users

Full suite (excluding pre-existing `test_search_tools.py::TestSimilar` failures unrelated to this change which require the `[similarity]` extra): **230 passed, 4 skipped**.

## Test plan checklist

- [x] `pytest tests/test_commands.py::TestHuntNewCommand` — 7/7 pass
- [x] Black + ruff clean (line-length 127)
- [x] Live verification with real STIX data (v19.0)
- [x] Behavior unchanged for users without STIX cache


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `hunt new` now auto-derives applicable ATT&CK tactics from a selected technique when `--tactic` is omitted, streamlining hunt creation and preserving the previous default if derivation fails.

* **Tests**
  * Added tests covering successful tactic auto-derivation and the fallback to the legacy default when technique lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->