### PR TITLE
fix(mcp): tolerate null depth and empty topic in athf_research_new

### DIFF
--- a/athf/__version__.py
+++ b/athf/__version__.py
@@ -1,3 +1,3 @@
 """Version information for ATHF."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/athf/mcp/tools/research_tools.py
+++ b/athf/mcp/tools/research_tools.py
@@ -82,6 +82,8 @@ def register_research_tools(mcp: "FastMCP") -> None:  # type: ignore[name-define
         if not topic or not topic.strip():
             return _json_result({"error": "topic is required and must be a non-empty string"})
 
+        if isinstance(depth, str):
+            depth = depth.strip()
         depth = depth or "advanced"
         if depth not in {"basic", "advanced"}:
             return _json_result({"error": f"depth must be 'basic' or 'advanced' (got {depth!r})"})

--- a/athf/mcp/tools/research_tools.py
+++ b/athf/mcp/tools/research_tools.py
@@ -74,10 +74,17 @@ def register_research_tools(mcp: "FastMCP") -> None:  # type: ignore[name-define
     def research_new(
         topic: str,
         technique: Optional[str] = None,
-        depth: str = "advanced",
+        depth: Optional[str] = "advanced",
     ) -> str:
         from athf.agents.llm.hunt_researcher import HuntResearcherAgent, ResearchInput
         from athf.core.research_manager import ResearchManager
+
+        if not topic or not topic.strip():
+            return _json_result({"error": "topic is required and must be a non-empty string"})
+
+        depth = depth or "advanced"
+        if depth not in {"basic", "advanced"}:
+            return _json_result({"error": f"depth must be 'basic' or 'advanced' (got {depth!r})"})
 
         workspace = get_workspace()
         manager = ResearchManager(research_dir=workspace / "research")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-threat-hunting-framework"
-version = "0.13.0"
+version = "0.13.1"
 description = "Agentic Threat Hunting Framework - Memory and AI for threat hunters"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"


### PR DESCRIPTION
## Why

A Haiku-on-Bedrock MCP client's call to `athf_research_new` failed mid-hunt with a `ZodError` validation error.

Root cause: `depth: str = "advanced"` in the Python signature emits a JSON Schema of `{"type": "string"}` (non-nullable). Pydantic v2 + FastMCP's schema mapping does not widen `str = default` to `anyOf[string, null]`. When a client (any LLM client that emits explicit `null` for unset optionals) sends `depth: null`, Zod-side validation rejects it before the call ever reaches Python.

`technique` was already fine — `Optional[str] = None` correctly emits `anyOf[string, null]`.

## What changed

`athf/mcp/tools/research_tools.py` — `athf_research_new`:

- Widened `depth: str = "advanced"` to `depth: Optional[str] = "advanced"` so the emitted schema is `anyOf[string, null]`.
- Coerce `null`/empty `depth` to `"advanced"` server-side.
- Whitelist `depth` to `{basic, advanced}` and return a clean JSON error for unknown values (was previously failing deep inside the agent).
- Reject empty/whitespace `topic` with a clean JSON error instead of producing an empty research document.

## Verification

Schema before:
```json
"depth": { "type": "string", "default": "advanced" }
```

Schema after:
```json
"depth": { "anyOf": [{"type": "string"}, {"type": "null"}], "default": "advanced" }
```

Smoke tests via `mcp.call_tool('athf_research_new', ...)`:

| Input | Before | After |
| --- | --- | --- |
| `{topic: '', technique: null, depth: null}` | ZodError on `depth` | `{"error": "topic is required..."}` |
| `{topic: 'X', depth: 'bogus'}` | accepted, failed deep | `{"error": "depth must be 'basic' or 'advanced'..."}` |
| `{topic: 'X', technique: null, depth: null}` | ZodError on `depth` | proceeds (depth coerced to 'advanced') |

`pytest -k research` → 19 passed.

## Out of scope

Untracked Docker files (`Dockerfile`, `.dockerignore`, `DOCKER.md`, `docs/hunt-harness-architecture.md`) in the working tree are unrelated and intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for research functionality, with stricter enforcement of topic and depth parameters.
  * Made research depth parameter optional, automatically defaulting to "advanced" mode when not specified.

* **Chores**
  * Version bumped to 0.13.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nebulock-Inc/agentic-threat-hunting-framework/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->