### PR TITLE
feat(mcp): persist generated hypotheses onto research docs

### DIFF
--- a/athf/__version__.py
+++ b/athf/__version__.py
@@ -1,3 +1,3 @@
 """Version information for ATHF."""
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"

--- a/athf/core/research_manager.py
+++ b/athf/core/research_manager.py
@@ -523,6 +523,115 @@ class ResearchManager:
         except Exception:
             return False
 
+    def append_hypothesis(
+        self,
+        research_id: str,
+        hypothesis: str,
+        mitre_techniques: Optional[List[str]] = None,
+        data_sources: Optional[List[str]] = None,
+        justification: Optional[str] = None,
+        expected_observables: Optional[List[str]] = None,
+        known_false_positives: Optional[List[str]] = None,
+        time_range_suggestion: Optional[str] = None,
+    ) -> Optional[Path]:
+        """Append a generated hypothesis to a research document.
+
+        Adds (or replaces) a ``## Generated Hypothesis`` section at the end of
+        the markdown body, and records ``generated_hypothesis`` metadata in the
+        YAML frontmatter for quick lookup. Idempotent: re-running with new
+        content overwrites the prior section in place.
+
+        Args:
+            research_id: Research ID (e.g., R-0001)
+            hypothesis: Hypothesis statement
+            mitre_techniques: Linked MITRE ATT&CK techniques
+            data_sources: Suggested data sources
+            justification: Reasoning the hypothesis is worth hunting
+            expected_observables: What we expect to see in telemetry
+            known_false_positives: Common benign patterns
+            time_range_suggestion: Recommended hunt time window
+
+        Returns:
+            Path to the updated file, or None if research_id not found.
+        """
+        research_data = self.get_research(research_id)
+        if not research_data:
+            return None
+
+        file_path = Path(research_data["file_path"])
+
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read()
+        except OSError:
+            return None
+
+        # Update frontmatter with structured hypothesis metadata
+        new_frontmatter = dict(research_data.get("frontmatter", {}))
+        new_frontmatter["generated_hypothesis"] = {
+            "hypothesis": hypothesis,
+            "mitre_techniques": list(mitre_techniques or []),
+            "data_sources": list(data_sources or []),
+            "generated_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+
+        body = research_data.get("content", "")
+        body = self._strip_generated_hypothesis_section(body)
+        body = body.rstrip()
+
+        section_lines: List[str] = ["", "", "## Generated Hypothesis", "", f"> {hypothesis}", ""]
+        if justification:
+            section_lines.extend(["**Justification:**", "", justification, ""])
+        if mitre_techniques:
+            section_lines.append("**MITRE Techniques:** " + ", ".join(mitre_techniques))
+            section_lines.append("")
+        if data_sources:
+            section_lines.append("**Data Sources:** " + ", ".join(data_sources))
+            section_lines.append("")
+        if expected_observables:
+            section_lines.append("**Expected Observables:**")
+            section_lines.append("")
+            section_lines.extend(f"- {item}" for item in expected_observables)
+            section_lines.append("")
+        if known_false_positives:
+            section_lines.append("**Known False Positives:**")
+            section_lines.append("")
+            section_lines.extend(f"- {item}" for item in known_false_positives)
+            section_lines.append("")
+        if time_range_suggestion:
+            section_lines.append(f"**Time Range:** {time_range_suggestion}")
+            section_lines.append("")
+
+        new_body = body + "\n".join(section_lines).rstrip() + "\n"
+
+        yaml_content = yaml.dump(new_frontmatter, default_flow_style=False, sort_keys=False)
+        new_content = f"---\n{yaml_content}---\n\n{new_body}"
+
+        try:
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(new_content)
+        except OSError:
+            return None
+
+        return file_path
+
+    @staticmethod
+    def _strip_generated_hypothesis_section(body: str) -> str:
+        """Remove an existing ``## Generated Hypothesis`` section if present.
+
+        Args:
+            body: Markdown body (after frontmatter)
+
+        Returns:
+            Body with the section removed (everything from the heading through
+            the next ``## `` heading or end of document).
+        """
+        pattern = re.compile(
+            r"\n##\s+Generated\s+Hypothesis\b.*?(?=\n##\s+(?!#)|\Z)",
+            re.DOTALL | re.IGNORECASE,
+        )
+        return pattern.sub("", body)
+
     def create_research_file(
         self,
         research_id: str,

--- a/athf/core/research_manager.py
+++ b/athf/core/research_manager.py
@@ -1,7 +1,7 @@
 """Manage research files and operations."""
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -572,7 +572,7 @@ class ResearchManager:
             "hypothesis": hypothesis,
             "mitre_techniques": list(mitre_techniques or []),
             "data_sources": list(data_sources or []),
-            "generated_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
 
         body = research_data.get("content", "")

--- a/athf/mcp/tools/agent_tools.py
+++ b/athf/mcp/tools/agent_tools.py
@@ -17,7 +17,13 @@ def register_agent_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined] 
             "Generate a threat hunting hypothesis from threat intelligence. "
             "Uses an LLM to produce a structured hypothesis with MITRE techniques, "
             "data sources, and ABLE framework scoping. "
-            "Requires an LLM provider to be configured (falls back to template-based output without one)."
+            "When research_id is supplied, the hypothesis is appended to that "
+            "research document (R-XXXX) under a ## Generated Hypothesis section "
+            "and the response shrinks to a preview-only payload (id, file_path, "
+            "techniques, sources, ~200-char preview) to keep agent context lean. "
+            "Without research_id, behavior is unchanged: the full hypothesis is "
+            "returned inline. Requires an LLM provider (falls back to "
+            "template-based output without one)."
         ),
     )
     def agent_run_hypothesis(
@@ -29,15 +35,15 @@ def register_agent_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined] 
             HypothesisGeneratorAgent,
             HypothesisGenerationInput,
         )
+        from athf.core.research_manager import ResearchManager
 
         workspace = get_workspace()
+
+        rm = ResearchManager(research_dir=workspace / "research")
 
         # Load research context if provided
         research = None
         if research_id:
-            from athf.core.research_manager import ResearchManager
-
-            rm = ResearchManager(research_dir=workspace / "research")
             doc = rm.get_research(research_id)
             if doc:
                 research = rm.extract_research_context(doc)
@@ -67,11 +73,39 @@ def register_agent_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined] 
         if output is None:
             return _json_result({"error": "No output from hypothesis generator"})
 
+        if research_id and research is not None:
+            file_path = rm.append_hypothesis(
+                research_id=research_id,
+                hypothesis=output.hypothesis,
+                mitre_techniques=output.mitre_techniques,
+                data_sources=output.data_sources,
+                justification=output.justification,
+                expected_observables=output.expected_observables,
+                known_false_positives=output.known_false_positives,
+                time_range_suggestion=output.time_range_suggestion,
+            )
+
+            if file_path is not None:
+                preview = output.hypothesis.strip()
+                if len(preview) > 200:
+                    preview = preview[:197].rstrip() + "..."
+
+                return _json_result({
+                    "research_id": research_id,
+                    "file_path": str(file_path),
+                    "hypothesis_preview": preview,
+                    "mitre_techniques": output.mitre_techniques,
+                    "data_sources": output.data_sources,
+                    "persisted": True,
+                    "metadata": result.metadata,
+                })
+
         return _json_result({
             "hypothesis": output.hypothesis,
             "mitre_techniques": output.mitre_techniques,
             "data_sources": output.data_sources,
             "justification": output.justification,
+            "persisted": False,
             "metadata": result.metadata,
         })
 

--- a/athf/mcp/tools/agent_tools.py
+++ b/athf/mcp/tools/agent_tools.py
@@ -100,6 +100,15 @@ def register_agent_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined] 
                     "metadata": result.metadata,
                 })
 
+            return _json_result({
+                "research_id": research_id,
+                "persisted": False,
+                "error": "persistence_failed",
+                "mitre_techniques": output.mitre_techniques,
+                "data_sources": output.data_sources,
+                "metadata": result.metadata,
+            })
+
         return _json_result({
             "hypothesis": output.hypothesis,
             "mitre_techniques": output.mitre_techniques,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Agentic Threat Hunting Framework (ATHF) will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - Unreleased
+
+### Added
+- **Hypothesis persistence on research docs** — `athf_agent_run_hypothesis` MCP tool now appends generated hypotheses directly onto the source `R-XXXX` research document under a `## Generated Hypothesis` section, with structured metadata in the YAML frontmatter (`generated_hypothesis: { hypothesis, mitre_techniques, data_sources, generated_at }`). When a `research_id` is supplied, the MCP response collapses to a preview-only payload (`research_id`, `file_path`, `mitre_techniques`, `data_sources`, ~200-char preview), reducing inline payload size and helping prevent autocompact thrash on long hunt orchestration conversations.
+- `ResearchManager.append_hypothesis()` — idempotent helper that creates or replaces the `## Generated Hypothesis` section and updates frontmatter.
+
+### Changed
+- `athf_agent_run_hypothesis` MCP response now includes a `persisted` boolean. Without `research_id`, behavior is unchanged (full inline payload, `persisted=false`). With a valid `research_id`, the hypothesis is written to disk and only a preview is returned (`persisted=true`).
+
+### Notes
+- Hunt orchestration conversations are sensitive to large LLM-emitted artifacts. Smaller models with tighter effective working windows (e.g. Haiku-class) can autocompact-thrash when an inline hypothesis is followed by tool calls that re-include it. This release moves the hypothesis to disk so subsequent turns reference it by ID. For hunt orchestration over MCP, prefer Sonnet-class models when available; the persistence pattern reduces the dependency.
+
 ## [0.11.0] - Unreleased
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-threat-hunting-framework"
-version = "0.13.1"
+version = "0.14.0"
 description = "Agentic Threat Hunting Framework - Memory and AI for threat hunters"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"

--- a/tests/core/test_research_manager_hypothesis.py
+++ b/tests/core/test_research_manager_hypothesis.py
@@ -1,0 +1,127 @@
+"""Tests for ResearchManager.append_hypothesis()."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from athf.core.research_manager import ResearchManager, parse_research_file
+
+
+SAMPLE_RESEARCH = textwrap.dedent(
+    """\
+    ---
+    research_id: R-0042
+    topic: Discovery commands post-access reconnaissance
+    mitre_techniques:
+    - T1016
+    - T1082
+    - T1087
+    status: completed
+    depth: advanced
+    linked_hunts: []
+    created_date: '2026-05-22'
+    ---
+
+    # R-0042: Research
+
+    ## 1. System Research
+
+    ### Summary
+    Discovery commands are widely used.
+    """
+)
+
+
+@pytest.fixture()
+def research_dir(tmp_path: Path) -> Path:
+    research_dir = tmp_path / "research"
+    research_dir.mkdir()
+    (research_dir / "R-0042.md").write_text(SAMPLE_RESEARCH, encoding="utf-8")
+    return research_dir
+
+
+def test_append_hypothesis_creates_section(research_dir: Path) -> None:
+    rm = ResearchManager(research_dir=research_dir)
+
+    result = rm.append_hypothesis(
+        research_id="R-0042",
+        hypothesis="Adversaries run native discovery commands post-access.",
+        mitre_techniques=["T1016", "T1082"],
+        data_sources=["EDR process telemetry"],
+        justification="Reconnaissance precedes lateral movement.",
+        expected_observables=["whoami", "ipconfig"],
+        known_false_positives=["Admin scripts"],
+        time_range_suggestion="7 days",
+    )
+
+    assert result is not None
+    contents = result.read_text(encoding="utf-8")
+    assert "## Generated Hypothesis" in contents
+    assert "> Adversaries run native discovery commands post-access." in contents
+    assert "**MITRE Techniques:** T1016, T1082" in contents
+    assert "**Data Sources:** EDR process telemetry" in contents
+    assert "**Time Range:** 7 days" in contents
+    assert "- whoami" in contents
+    assert "- Admin scripts" in contents
+
+
+def test_append_hypothesis_records_frontmatter(research_dir: Path) -> None:
+    rm = ResearchManager(research_dir=research_dir)
+
+    rm.append_hypothesis(
+        research_id="R-0042",
+        hypothesis="Adversaries run native discovery commands post-access.",
+        mitre_techniques=["T1016"],
+        data_sources=["EDR"],
+    )
+
+    parsed = parse_research_file(research_dir / "R-0042.md")
+    fm = parsed["frontmatter"]
+    assert "generated_hypothesis" in fm
+    assert fm["generated_hypothesis"]["hypothesis"].startswith("Adversaries run")
+    assert fm["generated_hypothesis"]["mitre_techniques"] == ["T1016"]
+    assert fm["generated_hypothesis"]["data_sources"] == ["EDR"]
+    assert fm["generated_hypothesis"]["generated_at"]
+    # Pre-existing frontmatter fields are preserved
+    assert fm["research_id"] == "R-0042"
+    assert fm["status"] == "completed"
+
+
+def test_append_hypothesis_is_idempotent(research_dir: Path) -> None:
+    rm = ResearchManager(research_dir=research_dir)
+
+    rm.append_hypothesis(
+        research_id="R-0042",
+        hypothesis="First hypothesis.",
+        mitre_techniques=["T1016"],
+    )
+    rm.append_hypothesis(
+        research_id="R-0042",
+        hypothesis="Replacement hypothesis.",
+        mitre_techniques=["T1082"],
+    )
+
+    contents = (research_dir / "R-0042.md").read_text(encoding="utf-8")
+    assert contents.count("## Generated Hypothesis") == 1
+    assert "Replacement hypothesis." in contents
+    assert "First hypothesis." not in contents
+
+
+def test_append_hypothesis_unknown_id_returns_none(research_dir: Path) -> None:
+    rm = ResearchManager(research_dir=research_dir)
+    assert rm.append_hypothesis(research_id="R-9999", hypothesis="x") is None
+
+
+def test_append_hypothesis_preserves_research_body(research_dir: Path) -> None:
+    rm = ResearchManager(research_dir=research_dir)
+
+    rm.append_hypothesis(
+        research_id="R-0042",
+        hypothesis="Hypothesis.",
+    )
+
+    contents = (research_dir / "R-0042.md").read_text(encoding="utf-8")
+    assert "## 1. System Research" in contents
+    assert "Discovery commands are widely used." in contents


### PR DESCRIPTION
## Why

Long hunt-orchestration conversations were autocompact-thrashing on smaller models. Root cause: `athf_agent_run_hypothesis` returns the full hypothesis (often ~6 KB) inline. When the next turn fires tool calls, the harness re-includes that inline blob in its preamble, the context refills past the limit, and autocompact eventually gives up.

The fix is to write the hypothesis to disk on the way out so subsequent turns can reference it by ID instead of carrying it inline. ATHF already does this for research (`R-XXXX.md`); this PR extends the same pattern to hypotheses.

## What changes

- **`ResearchManager.append_hypothesis()`** — idempotent helper that adds (or replaces) a `## Generated Hypothesis` section on the linked `R-XXXX` doc and records structured metadata in the YAML frontmatter (`generated_hypothesis: { hypothesis, mitre_techniques, data_sources, generated_at }`). Pre-existing frontmatter and body content are preserved.
- **`athf_agent_run_hypothesis` MCP tool** — when `research_id` is supplied, the hypothesis is persisted via `append_hypothesis()` and the MCP response collapses to a preview-only payload:
  ```json
  {
    "research_id": "R-0042",
    "file_path": "...",
    "hypothesis_preview": "Adversaries run native discovery commands…",
    "mitre_techniques": ["T1016", "T1082"],
    "data_sources": ["EDR process telemetry"],
    "persisted": true,
    "metadata": { ... }
  }
  ```
  Without `research_id`, behavior is unchanged — full inline payload with `persisted: false`. Fully back-compatible.
- **Tests** — 5 new unit tests for `append_hypothesis` (creation, frontmatter, idempotency, unknown-id handling, body preservation). All pass.
- **Version** — `0.13.1` → `0.14.0` (new MCP behavior, additive).
- **Changelog** updated.

## Verification

- `pytest tests/core/test_research_manager_hypothesis.py` — **5 passed**
- `pytest tests/agents/test_hypothesis_generator.py tests/core/test_research_manager_extraction.py` — **25 passed** (no regressions)
- 4 pre-existing failures on `main` (env command + similarity tests requiring `scikit-learn`) are unchanged on this branch.

## Notes

This is the first half of a two-part fix. The second half is operational: pin hunt-orchestration MCP conversations to a Sonnet-class model where possible. Persistence reduces the model-size dependency but doesn't fully eliminate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bumped version to 0.14.0.
  * Hypotheses can now be persisted directly to research documents with metadata (hypothesis text, linked techniques, data sources, and timestamps).
  * Hypothesis generation tool returns a preview-only response with confirmation of successful persistence when saving to a research document.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nebulock-Inc/agentic-threat-hunting-framework/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->