### PR TITLE
feat(mcp): adopt envelope-reduction response contract

### DIFF
--- a/athf/__version__.py
+++ b/athf/__version__.py
@@ -1,3 +1,3 @@
 """Version information for ATHF."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/athf/core/envelope.py
+++ b/athf/core/envelope.py
@@ -1,0 +1,163 @@
+"""Envelope-reduction response contract — reference implementation.
+
+See ``docs/envelope-reduction-contract.md`` for the full specification.
+
+The contract gives MCP tools and CLI commands a uniform way to reduce
+the inline-payload size of a tool result by writing the body to disk
+and returning a small reference instead. This module is the canonical
+Python helper.
+
+Usage::
+
+    from athf.core.envelope import build_envelope
+
+    # Gate A — parent artifact (the artifact owns the bytes; envelope
+    # always returned).
+    env = build_envelope(
+        payload=rendered_text,
+        parent_artifact="R-0042",
+        path=str(research_file),
+        metadata={"mitre_techniques": ["T1016"]},
+    )
+
+    # Gate B — byte threshold (small payloads pass through inline).
+    env = build_envelope(
+        payload=rendered_rows,
+        threshold=2048,
+        persist_dir="/tmp/query-results",
+        artifact_name="a1b2c3d4.json",
+        metadata={"row_count": 1000},
+    )
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+_DEFAULT_THRESHOLD = 2048
+_DEFAULT_PREVIEW_CHARS = 200
+
+
+def _serialize(payload: Any) -> str:
+    """Render ``payload`` as the string that would otherwise be the inline body."""
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, (bytes, bytearray)):
+        return payload.decode("utf-8", errors="replace")
+    return json.dumps(payload, default=str)
+
+
+def _make_preview(text: str, max_chars: int = _DEFAULT_PREVIEW_CHARS) -> str:
+    """One-line, ``max_chars``-bounded summary of ``text``."""
+    cleaned = " ".join(text.split())
+    if len(cleaned) <= max_chars:
+        return cleaned
+    return cleaned[: max_chars - 3].rstrip() + "..."
+
+
+def build_envelope(
+    payload: Any,
+    *,
+    threshold: int = _DEFAULT_THRESHOLD,
+    persist_dir: Optional[str] = None,
+    parent_artifact: Optional[str] = None,
+    path: Optional[str] = None,
+    artifact_name: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    preview: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a contract-compliant envelope dict for ``payload``.
+
+    Two persistence gates:
+
+    - **Gate A — parent artifact.** When ``parent_artifact`` is supplied,
+      the envelope always reports ``persisted=True`` and ``path`` is
+      taken from the explicit ``path`` argument (the producer is
+      responsible for the actual write — typically the artifact already
+      exists on disk under its canonical name and this helper just shapes
+      the response).
+    - **Gate B — byte threshold.** When ``parent_artifact`` is omitted,
+      the helper measures the rendered serialization. If it exceeds
+      ``threshold`` bytes and ``persist_dir`` is provided, the helper
+      writes the bytes to ``<persist_dir>/<artifact_name>`` and returns
+      the envelope. Below threshold, the helper returns
+      ``persisted=False`` with an empty ``path``.
+
+    Args:
+        payload: The body that would have been inlined. ``str`` is used
+            as-is; anything else is JSON-serialized via ``default=str``.
+        threshold: Byte threshold for Gate B. Default 2048.
+        persist_dir: Directory to write to when Gate B fires. The
+            directory is created if missing.
+        parent_artifact: Identifier (e.g. ``research_id``) signalling
+            Gate A. When set, ``path`` must also be supplied.
+        path: Absolute path to the artifact on disk. Required for Gate
+            A; ignored for Gate B (which derives the path from
+            ``persist_dir`` + ``artifact_name``).
+        artifact_name: Filename for Gate B. Required when Gate B fires.
+        metadata: Producer-specific extension keys. The contract is
+            opaque to its contents.
+        preview: Optional explicit preview. When omitted, a one-line
+            ~200-char summary of the rendered payload is computed.
+
+    Returns:
+        Dict with the four core contract fields plus ``metadata``:
+
+        ``preview`` (str), ``path`` (str, absolute when persisted),
+        ``persisted`` (bool), ``byte_count`` (int), ``metadata`` (dict).
+
+    Raises:
+        ValueError: when ``parent_artifact`` is set without ``path``,
+            or when Gate B fires without ``persist_dir`` and
+            ``artifact_name``.
+    """
+    rendered = _serialize(payload)
+    byte_count = len(rendered.encode("utf-8"))
+    preview_text = preview if preview is not None else _make_preview(rendered)
+    meta: Dict[str, Any] = dict(metadata) if metadata else {}
+
+    if parent_artifact is not None:
+        if not path:
+            raise ValueError(
+                "build_envelope: parent_artifact requires an explicit path argument"
+            )
+        absolute = str(Path(path).resolve())
+        return {
+            "preview": preview_text,
+            "path": absolute,
+            "persisted": True,
+            "byte_count": byte_count,
+            "metadata": meta,
+        }
+
+    if byte_count <= threshold:
+        return {
+            "preview": preview_text,
+            "path": "",
+            "persisted": False,
+            "byte_count": byte_count,
+            "metadata": meta,
+        }
+
+    if not persist_dir or not artifact_name:
+        raise ValueError(
+            "build_envelope: Gate B fired (byte_count > threshold) but "
+            "persist_dir and artifact_name were not both supplied"
+        )
+
+    persist_path = Path(persist_dir).expanduser()
+    persist_path.mkdir(parents=True, exist_ok=True)
+    artifact_path = persist_path / artifact_name
+    artifact_path.write_text(rendered, encoding="utf-8")
+    absolute = str(artifact_path.resolve())
+
+    return {
+        "preview": preview_text,
+        "path": absolute,
+        "persisted": True,
+        "byte_count": byte_count,
+        "metadata": meta,
+    }

--- a/athf/core/envelope.py
+++ b/athf/core/envelope.py
@@ -149,7 +149,10 @@ def build_envelope(
         )
 
     artifact_rel = Path(artifact_name)
-    if artifact_rel.is_absolute():
+    # Reject anything that looks absolute on ANY platform — including
+    # POSIX paths supplied to a Windows runtime, which Path.is_absolute()
+    # alone would miss because Windows requires a drive letter.
+    if artifact_rel.is_absolute() or artifact_name.startswith(("/", "\\")):
         raise ValueError(
             "build_envelope: artifact_name must be a relative filename"
         )

--- a/athf/core/envelope.py
+++ b/athf/core/envelope.py
@@ -148,11 +148,25 @@ def build_envelope(
             "persist_dir and artifact_name were not both supplied"
         )
 
+    artifact_rel = Path(artifact_name)
+    if artifact_rel.is_absolute():
+        raise ValueError(
+            "build_envelope: artifact_name must be a relative filename"
+        )
+
     persist_path = Path(persist_dir).expanduser()
     persist_path.mkdir(parents=True, exist_ok=True)
-    artifact_path = persist_path / artifact_name
+    persist_path_resolved = persist_path.resolve()
+    artifact_path = (persist_path_resolved / artifact_rel).resolve()
+    try:
+        artifact_path.relative_to(persist_path_resolved)
+    except ValueError:
+        raise ValueError(
+            "build_envelope: artifact_name escapes persist_dir"
+        ) from None
+
     artifact_path.write_text(rendered, encoding="utf-8")
-    absolute = str(artifact_path.resolve())
+    absolute = str(artifact_path)
 
     return {
         "preview": preview_text,

--- a/athf/mcp/tools/agent_tools.py
+++ b/athf/mcp/tools/agent_tools.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Optional
 
+from athf.core.envelope import build_envelope
 from athf.mcp.server import get_workspace, _json_result
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,20 @@ def register_agent_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined] 
                 if len(preview) > 200:
                     preview = preview[:197].rstrip() + "..."
 
+                envelope = build_envelope(
+                    payload=output.hypothesis,
+                    parent_artifact=research_id,
+                    path=str(file_path),
+                    preview=preview,
+                    metadata=result.metadata,
+                )
+
+                # Existing PR #30 shape (research_id, file_path, hypothesis_preview,
+                # mitre_techniques, data_sources, persisted, metadata) is preserved
+                # verbatim; the contract's core fields (preview, path, persisted,
+                # byte_count, metadata) are layered on as a superset. Existing
+                # consumers reading file_path/hypothesis_preview keep working;
+                # contract-aware consumers read path/preview.
                 return _json_result({
                     "research_id": research_id,
                     "file_path": str(file_path),
@@ -97,6 +112,9 @@ def register_agent_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined] 
                     "mitre_techniques": output.mitre_techniques,
                     "data_sources": output.data_sources,
                     "persisted": True,
+                    "preview": envelope["preview"],
+                    "path": envelope["path"],
+                    "byte_count": envelope["byte_count"],
                     "metadata": result.metadata,
                 })
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to the Agentic Threat Hunting Framework (ATHF) will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - Unreleased
+## [0.15.0] - Unreleased
+
+### Added
+- **Envelope-reduction response contract** — formal spec at [docs/envelope-reduction-contract.md](envelope-reduction-contract.md) describing the canonical shape MCP tools and CLI commands use to keep tool-result payloads off the cached prefix. Core fields: `preview`, `path`, `persisted`, `byte_count`, plus a producer-defined `metadata` extension. Two persistence gates: parent-artifact (e.g. `research_id` → write to that artifact) or byte-threshold (default 2048 bytes → write to scratch dir).
+- `athf.core.envelope.build_envelope()` — reference Python implementation. Accepts a payload plus gate parameters and returns a contract-compliant dict. Idempotent; emits absolute paths.
+- `tests/core/test_envelope.py` — full coverage of both gates, the threshold boundary, metadata pass-through, error cases, and idempotent absolute-path output.
+
+### Changed
+- `athf_agent_run_hypothesis` MCP response (PR #30 shape) now carries the contract's core fields (`preview`, `path`, `byte_count`) **in addition to** its existing fields (`research_id`, `file_path`, `hypothesis_preview`, `mitre_techniques`, `data_sources`, `persisted`, `metadata`). PR #30's regression test (`tests/core/test_research_manager_hypothesis.py`) passes unchanged. The shape is now described as a strict superset of the contract.
+
+### Notes
+- The contract names the field shape, not the location of the bytes. Each producer picks its own env var for its scratch dir (this repo uses the existing `ATHF_HUNTS_DIR`; the `athf clickhouse query` CLI in hunt-vault adopts its own `ATHF_QUERY_RESULTS_DIR` separately).
+
+## [0.14.0] - 2026-05-22
 
 ### Added
 - **Hypothesis persistence on research docs** — `athf_agent_run_hypothesis` MCP tool now appends generated hypotheses directly onto the source `R-XXXX` research document under a `## Generated Hypothesis` section, with structured metadata in the YAML frontmatter (`generated_hypothesis: { hypothesis, mitre_techniques, data_sources, generated_at }`). When a `research_id` is supplied, the MCP response collapses to a preview-only payload (`research_id`, `file_path`, `mitre_techniques`, `data_sources`, ~200-char preview), reducing inline payload size and helping prevent autocompact thrash on long hunt orchestration conversations.

--- a/docs/envelope-reduction-contract.md
+++ b/docs/envelope-reduction-contract.md
@@ -1,0 +1,139 @@
+# MCP Envelope-Reduction Response Contract
+
+**Status:** Adopted (v0.15.0)
+**Applies to:** ATHF MCP tools and any cooperating CLI command whose stdout becomes part of an LLM tool result.
+
+## Why this exists
+
+LLM tool calls accumulate: each round, the response payload of the previous call is re-included in the cached prefix that the model re-reads. Large structured payloads (rendered hypotheses, query result rows, hunt bodies) cause the input-token envelope to balloon — eventually crossing the model's effective context window and triggering autocompact-thrash on smaller models (Haiku-class).
+
+The fix is mechanical: when a payload is large *or* has a natural durable home on disk, the producer writes the payload to a file and returns a small reference instead. The agent reads the file on demand using `Read` (a normal file-read tool call), which is cheap and does not pollute the cached prefix the way an inline body does.
+
+This contract specifies the canonical shape of that reference so producers and consumers can interoperate without negotiation.
+
+## Core fields
+
+Every envelope-reduced response contains these four fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `preview` | string | Short, human-readable summary of what was persisted. ~200 chars max. Lets the model state what happened without re-reading the file. |
+| `path` | string | **Absolute** path to the persisted artifact on the filesystem the model can read from. Stable across the session. |
+| `persisted` | bool | `true` when content was written to disk; `false` when the response was returned inline (under threshold + no parent artifact). |
+| `byte_count` | int | Size, in bytes, of the persisted serialization. Lets the consumer reason about cost before reading. |
+
+## Producer-specific extension
+
+A `metadata` object holds producer-defined keys. The contract is opaque to its contents — consumers parse `metadata` only when they recognize the producer.
+
+Examples:
+
+- Research-hypothesis writer:
+  `metadata: { research_id, mitre_techniques, data_sources }`
+- ClickHouse query CLI:
+  `metadata: { row_count, columns, query_hash }`
+
+Producers are encouraged to keep `metadata` flat (one level deep) and JSON-serializable.
+
+## Two persistence gates
+
+Each producer chooses **one** gate:
+
+### Gate A — parent artifact (preferred when one exists)
+
+The producer accepts a parent-artifact identifier (e.g. `research_id` for hypothesis writes). When supplied, the payload is appended/written to that artifact and the response collapses to the envelope shape regardless of size. Without an identifier the producer falls back to inline.
+
+Rationale: artifact-bound writes have a natural home on disk and a stable identity in the session, so the envelope is always an improvement.
+
+### Gate B — byte threshold (preferred for ad-hoc payloads)
+
+When no parent artifact applies, the producer measures the rendered serialization. If `byte_count > threshold`, it persists to its scratch directory and returns the envelope. Below threshold, it returns the payload inline as before.
+
+**Default threshold:** 2048 bytes.
+
+Rationale: small payloads are not the problem and round-tripping them through disk is needless work.
+
+## Persistence directory
+
+Each producer defines its own env var for the scratch directory, with a sensible default:
+
+| Producer | Env var | Default |
+|----------|---------|---------|
+| Hypothesis writer (this repo) | `ATHF_HUNTS_DIR` | `<workspace>/research/` (existing — predates this contract) |
+| `athf clickhouse query` (hunt-vault) | `ATHF_QUERY_RESULTS_DIR` | `./query-results/` |
+
+Producers do **not** share a single env var. The contract names the field (`path`), not the location of the bytes.
+
+**Deployment requirement:** the persistence directory must be reachable at the same absolute path by both the producer (which writes) and the model's `Read` tool (which reads). On EC2 deployments this is automatic; on machines with sandboxed filesystems, operators must mount the directory consistently.
+
+## Backwards compatibility
+
+Producers may include additional fields beyond the four core ones — the contract is a **subset**, not a closed shape. ATHF's `athf_agent_run_hypothesis` MCP tool, for example, returns the canonical envelope plus `research_id`, `file_path` (path mirrored under its legacy name), `hypothesis_preview` (preview mirrored), `mitre_techniques`, `data_sources`, and `metadata`. New consumers should read `path` and `preview`; existing consumers reading `file_path` and `hypothesis_preview` continue to work.
+
+## Examples
+
+### Inline (under threshold, no parent)
+
+```json
+{
+  "hypothesis": "Adversaries run native discovery commands post-access.",
+  "mitre_techniques": ["T1016"],
+  "data_sources": ["EDR process telemetry"],
+  "persisted": false,
+  "preview": "Adversaries run native discovery commands post-access.",
+  "path": "",
+  "byte_count": 0,
+  "metadata": {}
+}
+```
+
+### Persisted (parent artifact supplied)
+
+```json
+{
+  "research_id": "R-0042",
+  "file_path": "/workspace/research/R-0042.md",
+  "hypothesis_preview": "Adversaries run native discovery commands post-access.",
+  "mitre_techniques": ["T1016", "T1082"],
+  "data_sources": ["EDR process telemetry"],
+  "persisted": true,
+  "preview": "Adversaries run native discovery commands post-access.",
+  "path": "/workspace/research/R-0042.md",
+  "byte_count": 4823,
+  "metadata": {"latency_ms": 1240, "model": "claude-sonnet-4-6"}
+}
+```
+
+### Persisted (byte threshold crossed)
+
+```json
+{
+  "preview": "1000 rows from nocsf_unified_events (2025-11-21 18:00 → 19:00 UTC)",
+  "path": "/workspace/query-results/a1b2c3d4.json",
+  "persisted": true,
+  "byte_count": 184293,
+  "metadata": {
+    "row_count": 1000,
+    "columns": ["time", "actor.user.name", "process.name"],
+    "query_hash": "a1b2c3d4e5f6..."
+  }
+}
+```
+
+## Reference implementation
+
+`athf.core.envelope.build_envelope` in this repo is the canonical Python implementation. It accepts:
+
+- `payload` — string (already-serialized) or any JSON-serializable structure
+- `threshold` — bytes; default 2048
+- `persist_dir` — directory to write to when persisting via Gate B
+- `parent_artifact` — when supplied, switches to Gate A and forces persistence
+- `metadata` — producer-specific extension
+
+It returns a dict with the four core fields plus `metadata`, with `path` always absolute when `persisted=true`.
+
+## Out of scope
+
+- Cleanup / GC of the persistence directory. Producers may rotate or operators may sweep — the contract makes no statement.
+- Encryption at rest. Files contain whatever the producer wrote; sensitive content must be handled by the producer's own policy.
+- Cross-producer hash collisions. Each producer chooses its own naming scheme.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-threat-hunting-framework"
-version = "0.14.0"
+version = "0.15.0"
 description = "Agentic Threat Hunting Framework - Memory and AI for threat hunters"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"

--- a/tests/core/test_envelope.py
+++ b/tests/core/test_envelope.py
@@ -148,14 +148,23 @@ def test_non_string_payload_is_json_serialized(tmp_path: Path) -> None:
     assert env["byte_count"] == len(body.encode("utf-8"))
 
 
-def test_gate_b_rejects_absolute_artifact_name(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "artifact_name",
+    [
+        "/etc/passwd",       # POSIX absolute
+        "\\Windows\\System32\\evil.txt",  # Windows-style backslash absolute
+    ],
+)
+def test_gate_b_rejects_absolute_artifact_name(
+    tmp_path: Path, artifact_name: str
+) -> None:
     payload = "x" * 3000
     with pytest.raises(ValueError, match="must be a relative filename"):
         build_envelope(
             payload,
             threshold=2048,
             persist_dir=tmp_path,
-            artifact_name="/etc/passwd",
+            artifact_name=artifact_name,
         )
     assert list(tmp_path.iterdir()) == []
 

--- a/tests/core/test_envelope.py
+++ b/tests/core/test_envelope.py
@@ -146,3 +146,45 @@ def test_non_string_payload_is_json_serialized(tmp_path: Path) -> None:
     body = Path(env["path"]).read_text(encoding="utf-8")
     assert '"rows"' in body
     assert env["byte_count"] == len(body.encode("utf-8"))
+
+
+def test_gate_b_rejects_absolute_artifact_name(tmp_path: Path) -> None:
+    payload = "x" * 3000
+    with pytest.raises(ValueError, match="must be a relative filename"):
+        build_envelope(
+            payload,
+            threshold=2048,
+            persist_dir=tmp_path,
+            artifact_name="/etc/passwd",
+        )
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_gate_b_rejects_parent_segment_traversal(tmp_path: Path) -> None:
+    persist_dir = tmp_path / "scratch"
+    persist_dir.mkdir()
+    sibling_target = tmp_path / "escaped.txt"
+
+    payload = "x" * 3000
+    with pytest.raises(ValueError, match="escapes persist_dir"):
+        build_envelope(
+            payload,
+            threshold=2048,
+            persist_dir=persist_dir,
+            artifact_name="../escaped.txt",
+        )
+    assert not sibling_target.exists()
+
+
+def test_gate_b_rejects_deep_traversal(tmp_path: Path) -> None:
+    persist_dir = tmp_path / "a" / "b"
+    persist_dir.mkdir(parents=True)
+
+    payload = "x" * 3000
+    with pytest.raises(ValueError, match="escapes persist_dir"):
+        build_envelope(
+            payload,
+            threshold=2048,
+            persist_dir=persist_dir,
+            artifact_name="../../../tmp/pwned.txt",
+        )

--- a/tests/core/test_envelope.py
+++ b/tests/core/test_envelope.py
@@ -1,0 +1,148 @@
+"""Tests for the envelope-reduction response contract reference impl."""
+
+from pathlib import Path
+
+import pytest
+
+from athf.core.envelope import build_envelope
+
+
+def test_under_threshold_returns_inline(tmp_path: Path) -> None:
+    env = build_envelope("hello", persist_dir=tmp_path)
+
+    assert env["persisted"] is False
+    assert env["path"] == ""
+    assert env["byte_count"] == 5
+    assert env["preview"] == "hello"
+    assert env["metadata"] == {}
+
+
+def test_at_threshold_boundary_inline(tmp_path: Path) -> None:
+    payload = "a" * 2048
+    env = build_envelope(payload, threshold=2048, persist_dir=tmp_path)
+
+    assert env["persisted"] is False
+    assert env["byte_count"] == 2048
+    assert env["path"] == ""
+    # No file written below threshold.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_over_threshold_persists_to_disk(tmp_path: Path) -> None:
+    payload = "x" * 3000
+    env = build_envelope(
+        payload,
+        threshold=2048,
+        persist_dir=tmp_path,
+        artifact_name="big.txt",
+    )
+
+    assert env["persisted"] is True
+    assert env["byte_count"] == 3000
+    artifact = Path(env["path"])
+    assert artifact.is_absolute()
+    assert artifact.exists()
+    assert artifact.read_text(encoding="utf-8") == payload
+
+
+def test_persist_dir_is_created_when_missing(tmp_path: Path) -> None:
+    target = tmp_path / "does-not-exist-yet"
+    payload = "x" * 4096
+    env = build_envelope(
+        payload,
+        threshold=2048,
+        persist_dir=target,
+        artifact_name="result.json",
+    )
+
+    assert env["persisted"] is True
+    assert target.is_dir()
+    assert Path(env["path"]).parent.resolve() == target.resolve()
+
+
+def test_gate_b_requires_persist_dir_and_artifact_name(tmp_path: Path) -> None:
+    payload = "x" * 3000
+    with pytest.raises(ValueError):
+        build_envelope(payload, threshold=2048)
+    with pytest.raises(ValueError):
+        build_envelope(payload, threshold=2048, persist_dir=tmp_path)
+    with pytest.raises(ValueError):
+        build_envelope(payload, threshold=2048, artifact_name="x.txt")
+
+
+def test_parent_artifact_forces_persistence_regardless_of_size(tmp_path: Path) -> None:
+    artifact = tmp_path / "R-0042.md"
+    artifact.write_text("# R-0042\n", encoding="utf-8")
+
+    env = build_envelope(
+        "Adversaries run native discovery commands post-access.",
+        parent_artifact="R-0042",
+        path=str(artifact),
+    )
+
+    assert env["persisted"] is True
+    assert env["path"] == str(artifact.resolve())
+    assert env["byte_count"] > 0
+    # Helper does not rewrite the artifact when parent_artifact is set.
+    assert artifact.read_text(encoding="utf-8") == "# R-0042\n"
+
+
+def test_parent_artifact_requires_path() -> None:
+    with pytest.raises(ValueError):
+        build_envelope("payload", parent_artifact="R-0042")
+
+
+def test_path_is_made_absolute_for_gate_a(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    artifact = Path("nested/R-0001.md")
+    artifact.parent.mkdir()
+    artifact.write_text("body", encoding="utf-8")
+
+    env = build_envelope(
+        "preview-source",
+        parent_artifact="R-0001",
+        path=str(artifact),
+    )
+
+    assert Path(env["path"]).is_absolute()
+    assert env["path"] == str(artifact.resolve())
+
+
+def test_metadata_is_preserved(tmp_path: Path) -> None:
+    env = build_envelope(
+        "ok",
+        persist_dir=tmp_path,
+        metadata={"row_count": 1000, "columns": ["time", "host"]},
+    )
+
+    assert env["metadata"] == {"row_count": 1000, "columns": ["time", "host"]}
+
+
+def test_explicit_preview_overrides_default(tmp_path: Path) -> None:
+    env = build_envelope(
+        "ignored as preview source",
+        preview="custom preview",
+        persist_dir=tmp_path,
+    )
+
+    assert env["preview"] == "custom preview"
+
+
+def test_default_preview_collapses_whitespace_and_truncates(tmp_path: Path) -> None:
+    payload = "line1\n  line2\t\tline3 " + ("z" * 500)
+    env = build_envelope(payload, persist_dir=tmp_path, artifact_name="x.txt")
+
+    assert "\n" not in env["preview"]
+    assert "\t" not in env["preview"]
+    assert len(env["preview"]) <= 200
+    assert env["preview"].endswith("...")
+
+
+def test_non_string_payload_is_json_serialized(tmp_path: Path) -> None:
+    payload = {"rows": [{"a": 1}, {"a": 2}]}
+    env = build_envelope(payload, threshold=10, persist_dir=tmp_path, artifact_name="r.json")
+
+    assert env["persisted"] is True
+    body = Path(env["path"]).read_text(encoding="utf-8")
+    assert '"rows"' in body
+    assert env["byte_count"] == len(body.encode("utf-8"))


### PR DESCRIPTION
## Why

Hunt-orchestration conversations on Haiku-class models hit autocompact-thrash because each turn re-includes prior tool-result payloads in the cached prefix. Run \`2ea1fad8\` crashed at 988 messages / 571K tokens. The fix is mechanical: when a payload is large *or* has a natural durable home on disk, the producer writes it to a file and the tool result becomes a small reference. PR #30 already did this for hypothesis writes; this PR formalizes that shape as a contract so other producers (CLI tools, MCP servers) can adopt it without negotiation.

This is **PR 1 of 3** in the envelope-reduction goal:
1. **This PR** — contract spec + reference Python implementation in athf
2. \`athf clickhouse query\` adopts the contract for >2KB results (in hunt-vault)
3. Harness wrapper for scope-filter + 80% context watermark (in nova)

## What changed

- **\`docs/envelope-reduction-contract.md\`** — full spec. Core fields (\`preview\`, \`path\`, \`persisted\`, \`byte_count\`), producer-defined \`metadata\`, two persistence gates (parent-artifact vs. byte-threshold, default 2048), per-producer env-var pattern, examples, backwards-compatibility statement.
- **\`athf/core/envelope.py\`** — \`build_envelope()\` reference implementation. Idempotent; emits absolute paths; supports both gates; raises \`ValueError\` on misuse.
- **\`athf/mcp/tools/agent_tools.py\`** — \`athf_agent_run_hypothesis\` response now layers the contract's core fields on top of PR #30's existing shape. **Strict superset** — every existing field preserved, no rename, no behavior change. Existing consumers reading \`file_path\` / \`hypothesis_preview\` keep working; contract-aware consumers read \`path\` / \`preview\`.
- **\`tests/core/test_envelope.py\`** — 12 tests covering both gates, the threshold boundary, persist-dir auto-create, metadata pass-through, error cases on missing args, explicit-preview override, whitespace-collapse and truncation in default preview, JSON serialization for non-string payloads, and idempotent absolute-path output.

## Verification

- \`pytest tests/core/test_envelope.py\` — 12/12 green
- \`pytest tests/core/test_research_manager_hypothesis.py\` — 5/5 green, **unchanged** (PR #30 regression)
- Full suite: 232 passed, 4 pre-existing failures unrelated to this change (scikit-learn missing + a test_env env-isolation issue, all reproduce on \`main\`)
- Manual smoke: \`build_envelope('x' * 3000, ...)\` writes the file at an absolute path, \`byte_count == 3000\`, file round-trips intact

## Out of scope / follow-ups

- Cleanup / GC of the persistence directory — producers may rotate or operators may sweep; the contract makes no statement.
- TypeScript reference implementation for nova — defer until PRs 2+3 prove the shape on the wire.
- Upstream PR to \`MHaggis/Security-Detections-MCP\` proposing the contract for its 81 tools — tracked as a separate follow-up; would shrink envelopes further once secdet *is* in scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added envelope-reduction response contract and reference implementation; tools now include envelope fields (preview, path, persisted, byte_count) in responses.

* **Documentation**
  * Added envelope-reduction contract spec and updated CHANGELOG for v0.15.0.

* **Tests**
  * Added comprehensive tests covering inline vs persisted outputs, persistence gates, validation, serialization, preview behavior, and byte counts.

* **Chores**
  * Bumped package version to 0.15.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nebulock-Inc/agentic-threat-hunting-framework/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->