### PR TITLE
fix(ci): resolve mypy errors breaking Tests workflow on main

### DIFF
--- a/athf/core/metrics.py
+++ b/athf/core/metrics.py
@@ -168,15 +168,20 @@ class EventStore:
                     fh.write(line)
 
     def _append_flock(self, line: str) -> None:
-        import fcntl
+        import fcntl  # POSIX-only; guarded by _has_fcntl() at the call site
 
+        # Access attributes via getattr so mypy on Windows (where the fcntl
+        # stub is empty) does not flag them; the call site guards on _has_fcntl.
+        flock = getattr(fcntl, "flock")
+        lock_ex = getattr(fcntl, "LOCK_EX")
+        lock_un = getattr(fcntl, "LOCK_UN")
         with open(self.path, "a", encoding="utf-8") as fh:
             try:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                flock(fh.fileno(), lock_ex)
                 fh.write(line)
                 fh.flush()
             finally:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                flock(fh.fileno(), lock_un)
 
     # -- reads -------------------------------------------------------------
 

--- a/athf/core/template_engine.py
+++ b/athf/core/template_engine.py
@@ -235,7 +235,7 @@ def render_hunt_template(
 
     template = Template(_load_hunt_template())
 
-    return template.render(
+    return str(template.render(
         hunt_id=hunt_id,
         title=title,
         status="planning",
@@ -254,4 +254,4 @@ def render_hunt_template(
         evidence=evidence,
         spawned_from=spawned_from,
         hypothesis_duration_minutes=hypothesis_duration_minutes,
-    )
+    ))

--- a/athf/metrics/__init__.py
+++ b/athf/metrics/__init__.py
@@ -91,7 +91,9 @@ def _resolve_active_context() -> tuple[Optional[str], Optional[str], Optional[st
     if provider is None:
         return None, None, None
     try:
-        result = provider()
+        # Providers are external plugins; treat the return as untrusted so the
+        # defensive shape checks below are not narrowed away by the type system.
+        result: Any = provider()
     except Exception:
         return None, None, None
     if not isinstance(result, tuple):

--- a/athf/metrics/__init__.py
+++ b/athf/metrics/__init__.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from athf.core.cost_tracker import estimate_cost
 from athf.core.metrics import (
@@ -59,8 +59,8 @@ logger = logging.getLogger(__name__)
 # Both shapes are accepted so existing plugins keep working; tenant-scoped
 # storage requires the 3-tuple form.
 ContextTuple = Union[
-    tuple[Optional[str], Optional[str]],
-    tuple[Optional[str], Optional[str], Optional[str]],
+    Tuple[Optional[str], Optional[str]],
+    Tuple[Optional[str], Optional[str], Optional[str]],
 ]
 
 _context_provider: Optional[Callable[[], ContextTuple]] = None


### PR DESCRIPTION
## Problem

The `Tests` workflow is red on `main` at the **mypy** step (since the metrics module merged in #35). Because mypy fails, pytest never runs, and every branch off `main` inherits it — including external fork PR #34.

Two distinct mypy errors, one of which only reproduces on mypy 2.x (CI's version on Python 3.10+), which is why the 3.9 job passed while 3.10/3.11/3.12 failed:

\`\`\`
athf/metrics/__init__.py:98:  error: Statement is unreachable  [unreachable]
athf/metrics/__init__.py:103: error: Statement is unreachable  [unreachable]
athf/core/template_engine.py:238: error: Returning Any from function declared to return "str"  [no-any-return]
\`\`\`

## Root causes & fixes

1. **`metrics/__init__.py`** — `_resolve_active_context()` calls an external-plugin provider typed as `ContextTuple` (2- or 3-tuple). mypy used that annotation to prove the `isinstance` guard and final fallback were unreachable. Providers are untrusted plugins, so the defensive checks must stay — annotate the return as `Any` to stop the narrowing.

2. **`core/template_engine.py`** — `jinja2.Template.render()` returns `Any`; the function is declared `-> str`. Wrapped the call in `str()` so the boundary is explicit.

Neither change alters runtime behavior.

## Verification

- `mypy athf --ignore-missing-imports --warn-return-any` → **Success: no issues found in 49 source files**
- `flake8` clean · template + metrics test suites pass
- (Local `TestSimilar` failures need `scikit-learn`, which CI does not install — `importorskip`-skipped in CI.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of plugin-provided context data using defensive typing, while keeping the same validation and exception behavior.
* **Bug Fixes**
  * Ensured hunt template rendering always returns consistent text output by coercing rendered results to a string.
  * Improved POSIX file-locking robustness by safely accessing locking primitives at runtime, preserving the existing lock/unlock flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->