### PR TITLE
chore(athf): remove unused create_search_client factory

### DIFF
--- a/athf/core/web_search.py
+++ b/athf/core/web_search.py
@@ -337,18 +337,3 @@ class TavilySearchClient:
             include_domains=detection_domains,
             include_answer=True,
         )
-
-
-def create_search_client(api_key: Optional[str] = None) -> Optional[TavilySearchClient]:
-    """Create a Tavily search client if API key is available.
-
-    Args:
-        api_key: Optional API key (defaults to TAVILY_API_KEY env var)
-
-    Returns:
-        TavilySearchClient if API key is available, None otherwise
-    """
-    key = api_key or os.getenv("TAVILY_API_KEY")
-    if not key:
-        return None
-    return TavilySearchClient(api_key=key)


### PR DESCRIPTION
## What

Removes the dead `create_search_client` factory from `athf/core/web_search.py` (−15 lines).

## Why

Flagged by dead-code analysis and verified: no importers, not in `__all__`, no dynamic (`getattr`/`importlib`) access, no test references. The sole web_search consumer (`hunt_researcher.py`) instantiates `TavilySearchClient` directly.

## Verification

- Module imports clean; zero residual references.
- `tests/core/` — 126 passed.

## Note

The analyzer also flagged `integrations/quickstart/splunk_example.py` — **skipped as a false positive**. It's a runnable quickstart (`python splunk_example.py`), not an importable module; `in_degree=0` is by design, its import target is live, and it's linked from `integrations/README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the legacy search client factory.
  * Existing search functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->