### PR TITLE
feat(athf): add --workshop spend-guard mode to agent run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ secrets/
 # User-specific ATHF config
 .athfconfig.yaml
 
+# Workshop-mode session audit log (per-workspace, may contain prompt metadata)
+.athf/
+
 # Evidence artifacts (optional - uncomment if you want to exclude large files)
 # evidence/
 

--- a/athf/commands/agent.py
+++ b/athf/commands/agent.py
@@ -24,8 +24,12 @@ def _apply_workshop_mode(agent: Any, token_cap: int) -> None:
     """
     from pathlib import Path
 
-    log_path = Path.cwd() / ".athf" / "session.log"
-    log_path.parent.mkdir(parents=True, exist_ok=True)
+    session_log = Path.cwd() / ".athf" / "session.log"
+    try:
+        session_log.parent.mkdir(parents=True, exist_ok=True)
+        log_path: Optional[Path] = session_log
+    except OSError:
+        log_path = None  # logging unavailable — never block the LLM call
 
     original_call_llm = agent._call_llm
 
@@ -50,11 +54,12 @@ def _apply_workshop_mode(agent: Any, token_cap: int) -> None:
                 "duration_ms": round((time.time() - start) * 1000, 1),
                 "error": error,
             }
-            try:
-                with log_path.open("a", encoding="utf-8") as fh:
-                    fh.write(json.dumps(record) + "\n")
-            except Exception:
-                pass  # never let logging break a hunt
+            if log_path is not None:
+                try:
+                    with log_path.open("a", encoding="utf-8") as fh:
+                        fh.write(json.dumps(record) + "\n")
+                except OSError:
+                    pass  # never let logging break a hunt
 
     agent._call_llm = capped_call_llm
 
@@ -284,6 +289,9 @@ def run(  # noqa: C901
       # Fallback mode (no LLM)
       athf agent run hypothesis-generator --threat-intel "..." --no-llm
     """
+    if workshop and token_cap is not None and token_cap < 1:
+        raise click.BadParameter("--token-cap must be >= 1", param_hint="--token-cap")
+
     if agent_name == "hypothesis-generator":
         if not threat_intel:
             console.print("[red]Error: --threat-intel required for hypothesis-generator[/red]")

--- a/athf/commands/agent.py
+++ b/athf/commands/agent.py
@@ -34,7 +34,8 @@ def _apply_workshop_mode(agent: Any, token_cap: int) -> None:
         start = time.time()
         error = None
         try:
-            return original_call_llm(prompt, max_tokens=effective)
+            result: str = original_call_llm(prompt, max_tokens=effective)
+            return result
         except Exception as exc:  # log the failure, then re-raise unchanged
             error = str(exc)
             raise

--- a/athf/commands/agent.py
+++ b/athf/commands/agent.py
@@ -1,12 +1,61 @@
 """Agent management commands."""
 
 import json
+import time
 from typing import Any, List, Optional
 
 import click
 from rich.console import Console
 
 console = Console()
+
+# Workshop mode default cap on generated tokens per LLM call. Keeps a shared
+# classroom Splunk/LLM budget bounded when 40 attendees run agents at once.
+WORKSHOP_DEFAULT_TOKEN_CAP = 1024
+
+
+def _apply_workshop_mode(agent: Any, token_cap: int) -> None:
+    """Constrain an agent for shared-classroom use (the --workshop flag).
+
+    Wraps the agent's ``_call_llm`` to (1) clamp ``max_tokens`` to ``token_cap``
+    so no attendee can blow the shared budget, and (2) append one JSONL record
+    per LLM call to ``.athf/session.log`` for staff to audit spend live. Purely
+    additive — no change to agent internals.
+    """
+    from pathlib import Path
+
+    log_path = Path.cwd() / ".athf" / "session.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    original_call_llm = agent._call_llm
+
+    def capped_call_llm(prompt: str, max_tokens: int = 4096) -> str:
+        effective = min(max_tokens, token_cap)
+        start = time.time()
+        error = None
+        try:
+            return original_call_llm(prompt, max_tokens=effective)
+        except Exception as exc:  # log the failure, then re-raise unchanged
+            error = str(exc)
+            raise
+        finally:
+            record = {
+                "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "agent": agent.__class__.__name__,
+                "requested_max_tokens": max_tokens,
+                "effective_max_tokens": effective,
+                "token_cap": token_cap,
+                "prompt_chars": len(prompt),
+                "duration_ms": round((time.time() - start) * 1000, 1),
+                "error": error,
+            }
+            try:
+                with log_path.open("a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(record) + "\n")
+            except Exception:
+                pass  # never let logging break a hunt
+
+    agent._call_llm = capped_call_llm
 
 AGENT_EPILOG = """
 \b
@@ -184,6 +233,17 @@ def info(agent_name: str) -> None:
 @click.option("--tactic", help="MITRE tactic filter")
 @click.option("--llm/--no-llm", default=True, help="Enable/disable LLM (default: enabled)")
 @click.option(
+    "--workshop",
+    is_flag=True,
+    help="Workshop mode: cap token spend per LLM call and log calls to .athf/session.log (for shared classroom use)",
+)
+@click.option(
+    "--token-cap",
+    type=int,
+    default=None,
+    help=f"Max tokens per LLM call in --workshop mode (default: {WORKSHOP_DEFAULT_TOKEN_CAP})",
+)
+@click.option(
     "--output-format",
     "output_format",
     type=click.Choice(["table", "json"]),
@@ -200,6 +260,8 @@ def run(  # noqa: C901
     no_web_search: bool,
     tactic: Optional[str],
     llm: bool,
+    workshop: bool,
+    token_cap: Optional[int],
     output_format: str,
 ) -> None:
     """Run an agent.
@@ -231,6 +293,11 @@ def run(  # noqa: C901
             from athf.agents.llm import HypothesisGenerationInput, HypothesisGeneratorAgent
 
             hypothesis_agent = HypothesisGeneratorAgent(llm_enabled=llm)
+
+            if workshop and llm:
+                cap = token_cap or WORKSHOP_DEFAULT_TOKEN_CAP
+                _apply_workshop_mode(hypothesis_agent, cap)
+                console.print(f"[dim]Workshop mode: token cap {cap}/call, logging to .athf/session.log[/dim]\n")
 
             # Load context for hypothesis generation
             # Try to load past hunts and environment data if available
@@ -331,6 +398,11 @@ def run(  # noqa: C901
             console.print()
 
             research_agent = HuntResearcherAgent(llm_enabled=llm)
+
+            if workshop and llm:
+                cap = token_cap or WORKSHOP_DEFAULT_TOKEN_CAP
+                _apply_workshop_mode(research_agent, cap)
+                console.print(f"[dim]Workshop mode: token cap {cap}/call, logging to .athf/session.log[/dim]\n")
 
             # Show progress
             with Progress(

--- a/tests/commands/test_workshop_mode.py
+++ b/tests/commands/test_workshop_mode.py
@@ -91,7 +91,7 @@ def test_setup_failure_does_not_block_call(temp_dir, monkeypatch):
     assert agent.calls == [256]
 
 
-def test_run_rejects_zero_token_cap(monkeypatch):
+def test_run_rejects_zero_token_cap():
     runner = CliRunner()
     result = runner.invoke(
         run,
@@ -101,7 +101,7 @@ def test_run_rejects_zero_token_cap(monkeypatch):
     assert "--token-cap must be >= 1" in result.output
 
 
-def test_run_rejects_negative_token_cap(monkeypatch):
+def test_run_rejects_negative_token_cap():
     runner = CliRunner()
     result = runner.invoke(
         run,

--- a/tests/commands/test_workshop_mode.py
+++ b/tests/commands/test_workshop_mode.py
@@ -1,9 +1,10 @@
 """Tests for `athf agent run --workshop` spend-guard behavior."""
 
 import json
-import os
 
-from athf.commands.agent import WORKSHOP_DEFAULT_TOKEN_CAP, _apply_workshop_mode
+from click.testing import CliRunner
+
+from athf.commands.agent import WORKSHOP_DEFAULT_TOKEN_CAP, _apply_workshop_mode, run
 
 
 class FakeAgent:
@@ -75,3 +76,36 @@ def test_logs_and_reraises_on_error(temp_dir, monkeypatch):
     record = json.loads((temp_dir / ".athf" / "session.log").read_text().strip())
     assert record["error"] == "boom"
     assert record["effective_max_tokens"] == 256
+
+
+def test_setup_failure_does_not_block_call(temp_dir, monkeypatch):
+    """An unwritable log dir must not abort the wrapped LLM call."""
+    monkeypatch.chdir(temp_dir)
+    # Make .athf a file so mkdir raises OSError — logging becomes unavailable.
+    (temp_dir / ".athf").write_text("not a directory")
+
+    agent = FakeAgent()
+    _apply_workshop_mode(agent, token_cap=256)
+
+    assert agent._call_llm("hello", max_tokens=4096) == "ok"
+    assert agent.calls == [256]
+
+
+def test_run_rejects_zero_token_cap(monkeypatch):
+    runner = CliRunner()
+    result = runner.invoke(
+        run,
+        ["hypothesis-generator", "--threat-intel", "x", "--workshop", "--token-cap", "0"],
+    )
+    assert result.exit_code != 0
+    assert "--token-cap must be >= 1" in result.output
+
+
+def test_run_rejects_negative_token_cap(monkeypatch):
+    runner = CliRunner()
+    result = runner.invoke(
+        run,
+        ["hunt-researcher", "--topic", "x", "--workshop", "--token-cap", "-5"],
+    )
+    assert result.exit_code != 0
+    assert "--token-cap must be >= 1" in result.output

--- a/tests/commands/test_workshop_mode.py
+++ b/tests/commands/test_workshop_mode.py
@@ -1,0 +1,77 @@
+"""Tests for `athf agent run --workshop` spend-guard behavior."""
+
+import json
+import os
+
+from athf.commands.agent import WORKSHOP_DEFAULT_TOKEN_CAP, _apply_workshop_mode
+
+
+class FakeAgent:
+    """Minimal stand-in exposing the `_call_llm(prompt, max_tokens)` contract."""
+
+    def __init__(self):
+        self.calls = []
+
+    def _call_llm(self, prompt: str, max_tokens: int = 4096) -> str:
+        self.calls.append(max_tokens)
+        return "ok"
+
+
+def test_clamps_max_tokens_to_cap(temp_dir, monkeypatch):
+    monkeypatch.chdir(temp_dir)
+    agent = FakeAgent()
+
+    _apply_workshop_mode(agent, token_cap=256)
+    agent._call_llm("hello", max_tokens=4096)
+
+    assert agent.calls == [256]
+
+
+def test_does_not_raise_cap_when_request_is_smaller(temp_dir, monkeypatch):
+    monkeypatch.chdir(temp_dir)
+    agent = FakeAgent()
+
+    _apply_workshop_mode(agent, token_cap=WORKSHOP_DEFAULT_TOKEN_CAP)
+    agent._call_llm("hello", max_tokens=128)
+
+    assert agent.calls == [128]
+
+
+def test_writes_audit_record_per_call(temp_dir, monkeypatch):
+    monkeypatch.chdir(temp_dir)
+    agent = FakeAgent()
+
+    _apply_workshop_mode(agent, token_cap=256)
+    agent._call_llm("a prompt", max_tokens=4096)
+
+    log_path = temp_dir / ".athf" / "session.log"
+    assert log_path.exists()
+
+    record = json.loads(log_path.read_text().strip())
+    assert record["requested_max_tokens"] == 4096
+    assert record["effective_max_tokens"] == 256
+    assert record["token_cap"] == 256
+    assert record["prompt_chars"] == len("a prompt")
+    assert record["error"] is None
+
+
+def test_logs_and_reraises_on_error(temp_dir, monkeypatch):
+    monkeypatch.chdir(temp_dir)
+
+    class FailingAgent:
+        def _call_llm(self, prompt: str, max_tokens: int = 4096) -> str:
+            raise RuntimeError("boom")
+
+    agent = FailingAgent()
+    _apply_workshop_mode(agent, token_cap=256)
+
+    raised = False
+    try:
+        agent._call_llm("x", max_tokens=512)
+    except RuntimeError:
+        raised = True
+    assert raised
+
+    record = json.loads((temp_dir / ".athf" / "session.log").read_text().strip())
+    assert record["error"] == "boom"
+    assert record["effective_max_tokens"] == 256


### PR DESCRIPTION
## What

Adds `--workshop` and `--token-cap` flags to `athf agent run`. In workshop mode, per-call `max_tokens` is clamped to the cap (default 1024) and each LLM call appends a JSONL audit record to `.athf/session.log`. Built for shared-classroom budget control (e.g. 40 attendees on one Splunk/LLM budget).

Implementation wraps the agent's `_call_llm`, so both the retry path (hypothesis-generator, via `_call_llm_with_retry`) and the direct path (hunt-researcher) are capped. Purely additive — flags default off.

## Review fixes included

- **gitignore `.athf/`** — session logs may contain prompt metadata; keeps them out of commits (verified via `git check-ignore`). Data-leak footgun in a security repo.
- **Tests added** — cap clamping, no-op when request < cap, audit record shape, and the error path (logs + re-raises).

## Verification

- `tests/commands/test_workshop_mode.py` — 4 passed.
- `tests/commands/` — 50 passed, 13 skipped, 1 pre-existing failure (`test_env_info_shows_info`, a `FileNotFoundError` unrelated to this change — confirmed failing on clean `origin/main`).

## Notes / possible follow-ups

- `--token-cap` passed without `--workshop` is currently silently ignored (cap only applies inside `if workshop and llm`). Left as-is; could add a warning.
- The 4-line clamp+print block is duplicated across the two agent paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “workshop mode” to agent runs via new CLI options (`--workshop`, `--token-cap`).
  * Workshop mode now enforces a per-LLM-call token cap, using a default when not specified.
  * Added session audit logging to `.athf/session.log` for each LLM call (timestamp, agent name, requested vs effective token cap, prompt length, duration, and any error).
* **Bug Fixes**
  * If an LLM call fails, the original error is still raised while the failure is recorded in the audit log.
* **Tests**
  * Added coverage for token-capping, audit logging, and CLI validation for invalid `--token-cap` values.
* **Chores**
  * Updated ignore rules to exclude `.athf/` outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->