### PR TITLE
fix: resolve four workshop-tester framework defects

### DIFF
--- a/athf/agents/base.py
+++ b/athf/agents/base.py
@@ -134,11 +134,29 @@ class LLMAgent(Agent[InputT, OutputT]):
             The generated text content.
         """
         provider = self._get_provider()
-        response = provider.complete(
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=max_tokens,
-            response_format=response_format,
-        )
+        messages = [{"role": "user", "content": prompt}]
+
+        # response_format is a newer, optional kwarg. Only forward it when a
+        # caller actually requests a format, and fall back gracefully for any
+        # third-party provider still on the pre-response_format signature so it
+        # never raises TypeError on a plain text call.
+        if response_format is None:
+            response = provider.complete(messages=messages, max_tokens=max_tokens)
+        else:
+            try:
+                response = provider.complete(
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    response_format=response_format,
+                )
+            except TypeError as exc:
+                if "response_format" not in str(exc):
+                    raise
+                logger.debug(
+                    "provider %s does not accept response_format; retrying "
+                    "without it", type(provider).__name__,
+                )
+                response = provider.complete(messages=messages, max_tokens=max_tokens)
 
         self._log_llm_metrics(
             agent_name=self.__class__.__name__,

--- a/athf/agents/base.py
+++ b/athf/agents/base.py
@@ -114,7 +114,12 @@ class LLMAgent(Agent[InputT, OutputT]):
         self._provider = create_provider(llm_config if llm_config else None)
         return self._provider
 
-    def _call_llm(self, prompt: str, max_tokens: int = 4096) -> str:
+    def _call_llm(
+        self,
+        prompt: str,
+        max_tokens: int = 4096,
+        response_format: Optional[str] = None,
+    ) -> str:
         """Call the LLM and return response text.
 
         Provider-agnostic: works with any configured LLM backend.
@@ -122,6 +127,8 @@ class LLMAgent(Agent[InputT, OutputT]):
         Args:
             prompt: The prompt to send to the LLM.
             max_tokens: Maximum tokens to generate.
+            response_format: Pass ``"json"`` when the caller parses the
+                response as JSON so structured-output providers enforce it.
 
         Returns:
             The generated text content.
@@ -130,6 +137,7 @@ class LLMAgent(Agent[InputT, OutputT]):
         response = provider.complete(
             messages=[{"role": "user", "content": prompt}],
             max_tokens=max_tokens,
+            response_format=response_format,
         )
 
         self._log_llm_metrics(
@@ -150,6 +158,7 @@ class LLMAgent(Agent[InputT, OutputT]):
         validate_fn: Callable[[str], Optional[str]],
         max_retries: int = 2,
         max_tokens: int = 4096,
+        response_format: Optional[str] = None,
     ) -> str:
         """Call LLM with a validation-retry loop.
 
@@ -162,6 +171,7 @@ class LLMAgent(Agent[InputT, OutputT]):
                 None if valid, or an error string if invalid.
             max_retries: Maximum number of retry attempts.
             max_tokens: Maximum tokens to generate.
+            response_format: Pass ``"json"`` to request JSON output.
 
         Returns:
             The generated text (last attempt, even if imperfect).
@@ -170,7 +180,7 @@ class LLMAgent(Agent[InputT, OutputT]):
         result = ""
 
         for attempt in range(1 + max_retries):
-            result = self._call_llm(current_prompt, max_tokens=max_tokens)
+            result = self._call_llm(current_prompt, max_tokens=max_tokens, response_format=response_format)
             error = validate_fn(result)
             if error is None:
                 return result

--- a/athf/agents/llm/hunt_researcher.py
+++ b/athf/agents/llm/hunt_researcher.py
@@ -9,6 +9,7 @@ Implements a structured 5-skill research methodology:
 """
 
 import os
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -101,6 +102,14 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
         self._llm_calls = 0
         self._web_searches = 0
         self._llm_failures = 0
+        # Skills 1-4 run concurrently in a ThreadPoolExecutor and each mutate
+        # these counters; guard every increment so no update is lost to a race.
+        self._metrics_lock = threading.Lock()
+
+    def _record_llm_failure(self) -> None:
+        """Thread-safe increment of the failed-LLM-skill counter."""
+        with self._metrics_lock:
+            self._llm_failures += 1
 
     def _log_llm_metrics(
         self,
@@ -112,8 +121,9 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
         duration_ms: int,
     ) -> None:
         """Track LLM call metrics for cost reporting."""
-        self._llm_calls += 1
-        self._total_cost += cost_usd
+        with self._metrics_lock:
+            self._llm_calls += 1
+            self._total_cost += cost_usd
 
     def _get_search_client(self) -> Optional[Any]:
         """Get or create Tavily search client."""
@@ -302,7 +312,8 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
                 search_results = search_client.search_system_internals(
                     topic, search_depth,
                 )
-                self._web_searches += 1
+                with self._metrics_lock:
+                    self._web_searches += 1
 
                 for result in search_results.results[:5]:
                     snippet = result.content
@@ -370,7 +381,8 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
                         topic, technique, search_depth,
                     )
                 )
-                self._web_searches += 1
+                with self._metrics_lock:
+                    self._web_searches += 1
 
                 for result in search_results.results[:7]:
                     snippet = result.content
@@ -621,7 +633,7 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
             return data["summary"], data["key_findings"]
 
         except Exception as e:
-            self._llm_failures += 1
+            self._record_llm_failure()
             return (
                 "System research for {} (LLM error: {})".format(
                     topic, str(e)[:50],
@@ -683,7 +695,7 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
             return data["summary"], data["key_findings"]
 
         except Exception as e:
-            self._llm_failures += 1
+            self._record_llm_failure()
             return (
                 "Adversary tradecraft for {} (LLM error: {})".format(
                     topic, str(e)[:50],
@@ -732,7 +744,7 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
             return data["summary"], data["key_findings"]
 
         except Exception as e:
-            self._llm_failures += 1
+            self._record_llm_failure()
             return (
                 "Telemetry mapping for {} (LLM error: {})".format(
                     topic, str(e)[:50],
@@ -794,7 +806,7 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
             return data["summary"], data["key_findings"]
 
         except Exception as e:
-            self._llm_failures += 1
+            self._record_llm_failure()
             return (
                 "Research synthesis for {} (LLM error: {})".format(
                     topic, str(e)[:50],

--- a/athf/agents/llm/hunt_researcher.py
+++ b/athf/agents/llm/hunt_researcher.py
@@ -261,24 +261,22 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
             if self.llm_enabled and self._llm_failures > 0:
                 if self._llm_failures >= expected_llm_skills:
                     warnings.append(
-                        "All {} LLM research skills failed — no usable LLM "
-                        "research was produced. Every LLM-backed section "
-                        "contains an 'Error during LLM analysis' placeholder "
-                        "(the related-work section is a local similarity search "
-                        "and may still be populated). Verify the LLM provider "
-                        "is reachable and configured (ATHF_LLM_PROVIDER / API "
-                        "keys / local Ollama), then re-run.".format(
-                            expected_llm_skills,
-                        )
+                        f"All {expected_llm_skills} LLM research skills failed "
+                        "— no usable LLM research was produced. Every LLM-backed "
+                        "section contains an 'Error during LLM analysis' "
+                        "placeholder (the related-work section is a local "
+                        "similarity search and may still be populated). Verify "
+                        "the LLM provider is reachable and configured "
+                        "(ATHF_LLM_PROVIDER / API keys / local Ollama), then "
+                        "re-run."
                     )
                 else:
                     warnings.append(
-                        "{} of {} LLM research skills failed (e.g. the provider "
-                        "was unreachable or returned unparseable output). "
-                        "Affected LLM-backed sections contain 'Error during LLM "
-                        "analysis' placeholders.".format(
-                            self._llm_failures, expected_llm_skills,
-                        )
+                        f"{self._llm_failures} of {expected_llm_skills} LLM "
+                        "research skills failed (e.g. the provider was "
+                        "unreachable or returned unparseable output). Affected "
+                        "LLM-backed sections contain 'Error during LLM analysis' "
+                        "placeholders."
                     )
 
             return AgentResult(

--- a/athf/agents/llm/hunt_researcher.py
+++ b/athf/agents/llm/hunt_researcher.py
@@ -105,6 +105,11 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
         # Skills 1-4 run concurrently in a ThreadPoolExecutor and each mutate
         # these counters; guard every increment so no update is lost to a race.
         self._metrics_lock = threading.Lock()
+        # These per-run counters live on the instance, so two overlapping
+        # execute() calls on the same agent would clobber each other's metrics.
+        # Serialize whole runs to keep each run's cost/call/failure tally its
+        # own. (Production makes a fresh agent per run; this guards reuse.)
+        self._run_lock = threading.Lock()
 
     def _record_llm_failure(self) -> None:
         """Thread-safe increment of the failed-LLM-skill counter."""
@@ -143,12 +148,23 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
     ) -> AgentResult[ResearchOutput]:
         """Execute complete research workflow.
 
+        Serialized on ``_run_lock``: the per-run counters below are instance
+        state, so two overlapping calls on the same agent would clobber each
+        other's cost/call/failure tallies. Holding the lock for the whole run
+        keeps each run's metrics its own.
+
         Args:
             input_data: Research input with topic, technique, and depth
 
         Returns:
             AgentResult with complete research output or error
         """
+        with self._run_lock:
+            return self._execute_run(input_data)
+
+    def _execute_run(
+        self, input_data: ResearchInput,
+    ) -> AgentResult[ResearchOutput]:
         start_time = time.time()
         self._total_cost = 0.0
         self._llm_calls = 0
@@ -245,11 +261,13 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
             if self.llm_enabled and self._llm_failures > 0:
                 if self._llm_failures >= expected_llm_skills:
                     warnings.append(
-                        "All {} LLM research skills failed — no usable research "
-                        "was produced. Every section contains an 'Error during "
-                        "LLM analysis' placeholder. Verify the LLM provider is "
-                        "reachable and configured (ATHF_LLM_PROVIDER / API keys "
-                        "/ local Ollama), then re-run.".format(
+                        "All {} LLM research skills failed — no usable LLM "
+                        "research was produced. Every LLM-backed section "
+                        "contains an 'Error during LLM analysis' placeholder "
+                        "(the related-work section is a local similarity search "
+                        "and may still be populated). Verify the LLM provider "
+                        "is reachable and configured (ATHF_LLM_PROVIDER / API "
+                        "keys / local Ollama), then re-run.".format(
                             expected_llm_skills,
                         )
                     )
@@ -257,8 +275,8 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
                     warnings.append(
                         "{} of {} LLM research skills failed (e.g. the provider "
                         "was unreachable or returned unparseable output). "
-                        "Affected sections contain 'Error during LLM analysis' "
-                        "placeholders.".format(
+                        "Affected LLM-backed sections contain 'Error during LLM "
+                        "analysis' placeholders.".format(
                             self._llm_failures, expected_llm_skills,
                         )
                     )

--- a/athf/agents/llm/hunt_researcher.py
+++ b/athf/agents/llm/hunt_researcher.py
@@ -820,14 +820,17 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
             Path.cwd() / "knowledge" / "OCSF_SCHEMA_REFERENCE.md"
         )
         if schema_path.exists():
-            return schema_path.read_text()[:5000]  # Limit size
+            # Explicit UTF-8: these knowledge files are UTF-8 on disk, and
+            # Windows would otherwise default to cp1252 and raise on any byte
+            # outside that codec, sinking the whole research run.
+            return schema_path.read_text(encoding="utf-8")[:5000]  # Limit size
         return "OCSF schema reference not found"
 
     def _load_environment(self) -> str:
         """Load environment.md content."""
         env_path = Path.cwd() / "environment.md"
         if env_path.exists():
-            return env_path.read_text()[:2000]  # Limit size
+            return env_path.read_text(encoding="utf-8")[:2000]  # Limit size
         return "Environment file not found"
 
     def _extract_hypothesis(

--- a/athf/agents/llm/hunt_researcher.py
+++ b/athf/agents/llm/hunt_researcher.py
@@ -100,6 +100,7 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
         self._total_cost = 0.0
         self._llm_calls = 0
         self._web_searches = 0
+        self._llm_failures = 0
 
     def _log_llm_metrics(
         self,
@@ -142,6 +143,7 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
         self._total_cost = 0.0
         self._llm_calls = 0
         self._web_searches = 0
+        self._llm_failures = 0
 
         try:
             # Get next research ID
@@ -197,6 +199,10 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
             # Build output
             total_duration_ms = int((time.time() - start_time) * 1000)
 
+            # Skills 1, 2, 3, and 5 each make one LLM call when llm_enabled.
+            # Skill 4 (related work) is a local similarity search with no LLM.
+            expected_llm_skills = 4
+
             output = ResearchOutput(
                 research_id=research_id,
                 topic=input_data.topic,
@@ -220,16 +226,44 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
                 total_cost_usd=round(self._total_cost, 4),
             )
 
+            # A research run that produced no usable LLM output must not look
+            # like a clean success — the record has to be trustworthy (a stub
+            # full of "Error during LLM analysis" is worse than nothing if it
+            # reads as done). We still write the doc so the attendee keeps
+            # partial findings; the failure is surfaced loudly via warnings.
+            warnings: List[str] = []
+            if self.llm_enabled and self._llm_failures > 0:
+                if self._llm_failures >= expected_llm_skills:
+                    warnings.append(
+                        "All {} LLM research skills failed — no usable research "
+                        "was produced. Every section contains an 'Error during "
+                        "LLM analysis' placeholder. Verify the LLM provider is "
+                        "reachable and configured (ATHF_LLM_PROVIDER / API keys "
+                        "/ local Ollama), then re-run.".format(
+                            expected_llm_skills,
+                        )
+                    )
+                else:
+                    warnings.append(
+                        "{} of {} LLM research skills failed (e.g. the provider "
+                        "was unreachable or returned unparseable output). "
+                        "Affected sections contain 'Error during LLM analysis' "
+                        "placeholders.".format(
+                            self._llm_failures, expected_llm_skills,
+                        )
+                    )
+
             return AgentResult(
                 success=True,
                 data=output,
                 error=None,
-                warnings=[],
+                warnings=warnings,
                 metadata={
                     "research_id": research_id,
                     "duration_ms": total_duration_ms,
                     "web_searches": self._web_searches,
                     "llm_calls": self._llm_calls,
+                    "llm_failures": self._llm_failures,
                     "cost_usd": round(self._total_cost, 4),
                 },
             )
@@ -582,11 +616,12 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
                 ' "finding3"]\n}}'
             ).format(topic=topic, context=context)
 
-            response = self._call_llm(prompt, max_tokens=2048)
+            response = self._call_llm(prompt, max_tokens=2048, response_format="json")
             data = self._parse_json_response(response)
             return data["summary"], data["key_findings"]
 
         except Exception as e:
+            self._llm_failures += 1
             return (
                 "System research for {} (LLM error: {})".format(
                     topic, str(e)[:50],
@@ -643,11 +678,12 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
                 context=context,
             )
 
-            response = self._call_llm(prompt, max_tokens=2048)
+            response = self._call_llm(prompt, max_tokens=2048, response_format="json")
             data = self._parse_json_response(response)
             return data["summary"], data["key_findings"]
 
         except Exception as e:
+            self._llm_failures += 1
             return (
                 "Adversary tradecraft for {} (LLM error: {})".format(
                     topic, str(e)[:50],
@@ -691,11 +727,12 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
                 environment_data=environment_data[:1000],
             )
 
-            response = self._call_llm(prompt, max_tokens=2048)
+            response = self._call_llm(prompt, max_tokens=2048, response_format="json")
             data = self._parse_json_response(response)
             return data["summary"], data["key_findings"]
 
         except Exception as e:
+            self._llm_failures += 1
             return (
                 "Telemetry mapping for {} (LLM error: {})".format(
                     topic, str(e)[:50],
@@ -752,11 +789,12 @@ class HuntResearcherAgent(LLMAgent[ResearchInput, ResearchOutput]):
                 context=context,
             )
 
-            response = self._call_llm(prompt, max_tokens=2048)
+            response = self._call_llm(prompt, max_tokens=2048, response_format="json")
             data = self._parse_json_response(response)
             return data["summary"], data["key_findings"]
 
         except Exception as e:
+            self._llm_failures += 1
             return (
                 "Research synthesis for {} (LLM error: {})".format(
                     topic, str(e)[:50],

--- a/athf/commands/agent.py
+++ b/athf/commands/agent.py
@@ -33,12 +33,12 @@ def _apply_workshop_mode(agent: Any, token_cap: int) -> None:
 
     original_call_llm = agent._call_llm
 
-    def capped_call_llm(prompt: str, max_tokens: int = 4096) -> str:
+    def capped_call_llm(prompt: str, max_tokens: int = 4096, **kwargs: Any) -> str:
         effective = min(max_tokens, token_cap)
         start = time.time()
         error = None
         try:
-            result: str = original_call_llm(prompt, max_tokens=effective)
+            result: str = original_call_llm(prompt, max_tokens=effective, **kwargs)
             return result
         except Exception as exc:  # log the failure, then re-raise unchanged
             error = str(exc)

--- a/athf/commands/mcp.py
+++ b/athf/commands/mcp.py
@@ -35,19 +35,22 @@ def serve(workspace: str, transport: str, port: int) -> None:
         }
       }
     """
-    # The mcp import happens lazily inside create_server(), so an
-    # incompatible-version ImportError surfaces when mcp_main runs, not at the
-    # import above. Wrap both to give one clear, version-aware message.
+    # The mcp import happens lazily inside create_server(), so a missing or
+    # incompatible mcp surfaces as MCPDependencyError when mcp_main runs, not at
+    # the import above. Catch only that dedicated type so unrelated ImportErrors
+    # (a genuine bug in a tool module) still propagate with a real traceback.
+    from athf.mcp.server import MCPDependencyError
+
     try:
         from athf.mcp.server import main as mcp_main
 
         mcp_main(workspace_path=workspace, transport=transport, port=port)
-    except ImportError as exc:
+    except MCPDependencyError as exc:
         click.echo(
-            "Error starting the ATHF MCP server: {}\n"
+            f"Error starting the ATHF MCP server: {exc}\n"
             "This usually means the mcp package is missing or an incompatible "
             "version is installed (mcp 2.0.0 removed FastMCP). Install a supported "
-            "version with: pip install 'athf[mcp]' (pins mcp[cli]>=1.0.0,<2.0.0).".format(exc),
+            "version with: pip install 'athf[mcp]' (pins mcp[cli]>=1.9.4,<2.0.0).",
             err=True,
         )
         raise SystemExit(1) from exc

--- a/athf/commands/mcp.py
+++ b/athf/commands/mcp.py
@@ -35,10 +35,19 @@ def serve(workspace: str, transport: str, port: int) -> None:
         }
       }
     """
+    # The mcp import happens lazily inside create_server(), so an
+    # incompatible-version ImportError surfaces when mcp_main runs, not at the
+    # import above. Wrap both to give one clear, version-aware message.
     try:
         from athf.mcp.server import main as mcp_main
-    except ImportError:
-        click.echo("Error: MCP dependencies not installed. Install with: pip install 'athf[mcp]'", err=True)
-        raise SystemExit(1) from None
 
-    mcp_main(workspace_path=workspace, transport=transport, port=port)
+        mcp_main(workspace_path=workspace, transport=transport, port=port)
+    except ImportError as exc:
+        click.echo(
+            "Error starting the ATHF MCP server: {}\n"
+            "This usually means the mcp package is missing or an incompatible "
+            "version is installed (mcp 2.0.0 removed FastMCP). Install a supported "
+            "version with: pip install 'athf[mcp]' (pins mcp[cli]>=1.0.0,<2.0.0).".format(exc),
+            err=True,
+        )
+        raise SystemExit(1) from exc

--- a/athf/commands/research.py
+++ b/athf/commands/research.py
@@ -143,6 +143,12 @@ def new(
         console.print("[red]Research failed: No output data[/red]")
         raise click.Abort()
 
+    # Surface partial-failure warnings so a run with stub "Error during LLM
+    # analysis" sections is not silently presented as a clean success.
+    if result.warnings:
+        for warning in result.warnings:
+            console.print(f"[yellow]Warning: {warning}[/yellow]")
+
     # Generate markdown content
     markdown_content = _generate_research_markdown(output)
 
@@ -151,12 +157,13 @@ def new(
         "research_id": output.research_id,
         "topic": output.topic,
         "mitre_techniques": output.mitre_techniques,
-        "status": "completed",
+        "status": "completed_with_errors" if result.warnings else "completed",
         "depth": depth,
         "duration_minutes": round(output.total_duration_ms / 60000, 1),
         "linked_hunts": [],
         "web_searches": output.web_searches_performed,
         "llm_calls": output.llm_calls,
+        "llm_failures": result.metadata.get("llm_failures", 0),
         "total_cost_usd": output.total_cost_usd,
         "data_source_availability": output.data_source_availability,
         "estimated_hunt_complexity": output.estimated_hunt_complexity,

--- a/athf/core/llm_provider.py
+++ b/athf/core/llm_provider.py
@@ -715,11 +715,18 @@ def create_provider(config: Optional[Dict[str, Any]] = None) -> LLMProvider:
     # credentials (e.g. for unrelated tooling) without boto3 installed, so
     # preferring detected-and-reachable Ollama avoids silently picking a
     # provider that then fails to import.
-    ollama_url = effective.get("base_url", "http://localhost:11434")
-    if _ollama_is_running(ollama_url):
+    #
+    # Probe ONLY the fixed loopback address, never a config-supplied base_url:
+    # auto-detect fires unprompted, and probing a config/env-controlled URL here
+    # would be an SSRF sink (an attacker who can influence config could make the
+    # process issue requests to an arbitrary host). A non-default Ollama endpoint
+    # must be selected explicitly via provider="ollama" + base_url, which routes
+    # through _build_provider above and skips this auto-probe.
+    default_ollama_url = "http://localhost:11434"
+    if _ollama_is_running(default_ollama_url):
         detected_model = model or "llama3"
         logger.info("Auto-detected local Ollama -> using Ollama provider with model %s", detected_model)
-        return OllamaProvider(model=detected_model, base_url=ollama_url)
+        return OllamaProvider(model=detected_model, base_url=default_ollama_url)
 
     # AWS credentials -> Bedrock
     if os.getenv("AWS_PROFILE") or os.getenv("AWS_ACCESS_KEY_ID"):

--- a/athf/core/llm_provider.py
+++ b/athf/core/llm_provider.py
@@ -617,21 +617,39 @@ def _load_config_file() -> Dict[str, Any]:
     return {}
 
 
-def _ollama_is_running(base_url: str = "http://localhost:11434") -> bool:
-    """Check whether an Ollama instance is reachable.
+def _ollama_is_running(base_url: str = "http://127.0.0.1:11434") -> bool:
+    """Check whether a local Ollama instance is reachable.
+
+    This is an unprompted auto-detection probe, so it is deliberately locked to
+    the loopback interface and cannot be rerouted off-host:
+      - defaults to the literal ``127.0.0.1`` address (no DNS for "localhost",
+        which a hosts-file entry could otherwise repoint);
+      - uses an opener with no proxy handler, so ``HTTP(S)_PROXY`` env vars
+        cannot funnel the probe through an external host;
+      - disables redirect following, so a response cannot bounce it off-loopback.
 
     Args:
-        base_url: Ollama HTTP API base URL.
+        base_url: Ollama HTTP API base URL. Auto-detect always passes the fixed
+            loopback default; an explicit non-default endpoint must be selected
+            via explicit provider config, not this probe.
 
     Returns:
         True if Ollama responds to a version request.
     """
     import urllib.request
-    import urllib.error
+
+    class _NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+    opener = urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),  # empty map = ignore proxy env vars
+        _NoRedirect(),
+    )
 
     try:
         req = urllib.request.Request("{}/api/version".format(base_url))
-        resp = urllib.request.urlopen(req, timeout=2)
+        resp = opener.open(req, timeout=2)
         return bool(resp.status == 200)
     except Exception:
         return False
@@ -722,7 +740,7 @@ def create_provider(config: Optional[Dict[str, Any]] = None) -> LLMProvider:
     # process issue requests to an arbitrary host). A non-default Ollama endpoint
     # must be selected explicitly via provider="ollama" + base_url, which routes
     # through _build_provider above and skips this auto-probe.
-    default_ollama_url = "http://localhost:11434"
+    default_ollama_url = "http://127.0.0.1:11434"
     if _ollama_is_running(default_ollama_url):
         detected_model = model or "llama3"
         logger.info("Auto-detected local Ollama -> using Ollama provider with model %s", detected_model)

--- a/athf/core/llm_provider.py
+++ b/athf/core/llm_provider.py
@@ -127,6 +127,7 @@ class LLMProvider(ABC):
         messages: List[Dict[str, str]],
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        response_format: Optional[str] = None,
     ) -> LLMResponse:
         """Send a chat-completion request to the LLM.
 
@@ -134,6 +135,11 @@ class LLMProvider(ABC):
             messages: List of message dicts with ``role`` and ``content`` keys.
             max_tokens: Maximum tokens to generate.
             temperature: Sampling temperature (0.0 - 1.0).
+            response_format: Optional output-format hint. Pass ``"json"`` when
+                the caller parses the response as JSON so providers that support
+                a structured-output mode (Ollama, OpenAI) can enforce it. Providers
+                that lack such a mode ignore it. Defaults to ``None`` (free-form
+                text) to preserve behavior for prose callers.
 
         Returns:
             An LLMResponse with the generated text and metadata.
@@ -175,6 +181,7 @@ class LiteLLMProvider(LLMProvider):
         messages: List[Dict[str, str]],
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        response_format: Optional[str] = None,
     ) -> LLMResponse:
         """Complete a chat request via litellm.
 
@@ -182,6 +189,7 @@ class LiteLLMProvider(LLMProvider):
             messages: Chat messages.
             max_tokens: Maximum tokens to generate.
             temperature: Sampling temperature.
+            response_format: Pass ``"json"`` to request JSON output.
 
         Returns:
             LLMResponse with results and metrics.
@@ -196,12 +204,17 @@ class LiteLLMProvider(LLMProvider):
                 "litellm package is not installed. Install it with: pip install litellm"
             )
 
+        kwargs: Dict[str, Any] = {}
+        if response_format == "json":
+            kwargs["response_format"] = {"type": "json_object"}
+
         start = time.monotonic()
         response = litellm.completion(
             model=self.model,
             messages=messages,
             max_tokens=max_tokens,
             temperature=temperature,
+            **kwargs,
         )
         duration_ms = int((time.monotonic() - start) * 1000)
 
@@ -295,6 +308,7 @@ class BedrockProvider(LLMProvider):
         messages: List[Dict[str, str]],
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        response_format: Optional[str] = None,
     ) -> LLMResponse:
         """Send a chat-completion request to AWS Bedrock.
 
@@ -302,6 +316,9 @@ class BedrockProvider(LLMProvider):
             messages: Chat messages.
             max_tokens: Maximum tokens to generate.
             temperature: Sampling temperature.
+            response_format: Accepted for interface parity. The Anthropic
+                Messages API has no format flag, so JSON output is steered via
+                the prompt; this argument is ignored here.
 
         Returns:
             LLMResponse with results and metrics.
@@ -377,6 +394,7 @@ class OllamaProvider(LLMProvider):
         messages: List[Dict[str, str]],
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        response_format: Optional[str] = None,
     ) -> LLMResponse:
         """Send a chat request to the local Ollama API.
 
@@ -384,6 +402,8 @@ class OllamaProvider(LLMProvider):
             messages: Chat messages.
             max_tokens: Maximum tokens to generate.
             temperature: Sampling temperature.
+            response_format: Pass ``"json"`` to set Ollama's ``format`` option
+                so the model returns valid JSON instead of prose.
 
         Returns:
             LLMResponse with results and metrics.
@@ -395,7 +415,7 @@ class OllamaProvider(LLMProvider):
         import urllib.error
 
         url = "{}/api/chat".format(self.base_url)
-        payload = {
+        payload: Dict[str, Any] = {
             "model": self.model,
             "messages": messages,
             "stream": False,
@@ -404,6 +424,8 @@ class OllamaProvider(LLMProvider):
                 "temperature": temperature,
             },
         }
+        if response_format == "json":
+            payload["format"] = "json"
         data = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
 
@@ -501,6 +523,7 @@ class OpenAICompatibleProvider(LLMProvider):
         messages: List[Dict[str, str]],
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        response_format: Optional[str] = None,
     ) -> LLMResponse:
         """Send a chat-completion request to an OpenAI-compatible API.
 
@@ -508,6 +531,7 @@ class OpenAICompatibleProvider(LLMProvider):
             messages: Chat messages.
             max_tokens: Maximum tokens to generate.
             temperature: Sampling temperature.
+            response_format: Pass ``"json"`` to request a JSON object response.
 
         Returns:
             LLMResponse with results and metrics.
@@ -517,12 +541,17 @@ class OpenAICompatibleProvider(LLMProvider):
         """
         client = self._get_client()
 
+        kwargs: Dict[str, Any] = {}
+        if response_format == "json":
+            kwargs["response_format"] = {"type": "json_object"}
+
         start = time.monotonic()
         response = client.chat.completions.create(
             model=self.model,
             messages=messages,
             max_tokens=max_tokens,
             temperature=temperature,
+            **kwargs,
         )
         duration_ms = int((time.monotonic() - start) * 1000)
 
@@ -621,8 +650,8 @@ def create_provider(config: Optional[Dict[str, Any]] = None) -> LLMProvider:
     Auto-detection order:
         ``ANTHROPIC_API_KEY`` -> LiteLLM (Anthropic)
         ``OPENAI_API_KEY`` -> OpenAI-compatible
-        ``AWS_PROFILE`` or ``AWS_ACCESS_KEY_ID`` -> Bedrock
         Ollama running locally -> Ollama
+        ``AWS_PROFILE`` or ``AWS_ACCESS_KEY_ID`` -> Bedrock
         Otherwise -> raises RuntimeError
 
     Args:
@@ -681,6 +710,17 @@ def create_provider(config: Optional[Dict[str, Any]] = None) -> LLMProvider:
             base_url=effective.get("base_url"),
         )
 
+    # Ollama running locally -> prefer it over AWS-cred Bedrock. Bedrock needs
+    # boto3, which is an optional dependency; a machine can carry ambient AWS
+    # credentials (e.g. for unrelated tooling) without boto3 installed, so
+    # preferring detected-and-reachable Ollama avoids silently picking a
+    # provider that then fails to import.
+    ollama_url = effective.get("base_url", "http://localhost:11434")
+    if _ollama_is_running(ollama_url):
+        detected_model = model or "llama3"
+        logger.info("Auto-detected local Ollama -> using Ollama provider with model %s", detected_model)
+        return OllamaProvider(model=detected_model, base_url=ollama_url)
+
     # AWS credentials -> Bedrock
     if os.getenv("AWS_PROFILE") or os.getenv("AWS_ACCESS_KEY_ID"):
         detected_model = model or "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -689,13 +729,6 @@ def create_provider(config: Optional[Dict[str, Any]] = None) -> LLMProvider:
             model_id=detected_model,
             region=effective.get("region"),
         )
-
-    # Ollama running locally
-    ollama_url = effective.get("base_url", "http://localhost:11434")
-    if _ollama_is_running(ollama_url):
-        detected_model = model or "llama3"
-        logger.info("Auto-detected local Ollama -> using Ollama provider with model %s", detected_model)
-        return OllamaProvider(model=detected_model, base_url=ollama_url)
 
     raise RuntimeError(
         "No LLM provider could be determined. Set one of: "

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -51,10 +51,13 @@ def create_server(workspace_path: Optional[str] = None) -> "FastMCP":  # type: i
     """
     try:
         from mcp.server.fastmcp import FastMCP
-    except ImportError:
+    except ImportError as exc:
         raise ImportError(
-            "MCP dependencies not installed. Install with: pip install 'athf[mcp]'"
-        ) from None
+            "Could not import mcp.server.fastmcp.FastMCP ({}). This usually means "
+            "either the mcp package is not installed, or an incompatible version "
+            "is installed: mcp 2.0.0 removed FastMCP. Install a supported version "
+            "with: pip install 'athf[mcp]' (which pins mcp[cli]>=1.0.0,<2.0.0).".format(exc)
+        ) from exc
 
     from athf.mcp.utils import find_workspace, load_workspace_config
 

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -23,7 +23,17 @@ class MCPDependencyError(ImportError):
     incompatible version is installed (e.g. mcp 2.0.0, which removed FastMCP).
 
     Subclasses ImportError so existing `except ImportError` handlers keep
-    working, while giving callers a specific type to catch."""
+    working, while giving callers a specific type to catch. The diagnostic
+    message lives here so raise sites stay a one-liner (Ruff TRY003)."""
+
+    def __init__(self, cause: BaseException) -> None:
+        super().__init__(
+            f"Could not import mcp.server.fastmcp.FastMCP ({cause}). This "
+            "usually means either the mcp package is not installed, or an "
+            "incompatible version is installed: mcp 2.0.0 removed FastMCP. "
+            "Install a supported version with: pip install 'athf[mcp]' "
+            "(which pins mcp[cli]>=1.9.4,<2.0.0)."
+        )
 
 
 def get_workspace() -> Path:
@@ -60,13 +70,7 @@ def create_server(workspace_path: Optional[str] = None) -> "FastMCP":  # type: i
     try:
         from mcp.server.fastmcp import FastMCP
     except ImportError as exc:
-        raise MCPDependencyError(
-            f"Could not import mcp.server.fastmcp.FastMCP ({exc}). This usually "
-            "means either the mcp package is not installed, or an incompatible "
-            "version is installed: mcp 2.0.0 removed FastMCP. Install a supported "
-            "version with: pip install 'athf[mcp]' (which pins "
-            "mcp[cli]>=1.9.4,<2.0.0)."
-        ) from exc
+        raise MCPDependencyError(exc) from exc
 
     from athf.mcp.utils import find_workspace, load_workspace_config
 

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -18,6 +18,14 @@ logger = logging.getLogger(__name__)
 _workspace: Optional[Path] = None
 
 
+class MCPDependencyError(ImportError):
+    """Raised when the optional MCP server dependencies are missing or an
+    incompatible version is installed (e.g. mcp 2.0.0, which removed FastMCP).
+
+    Subclasses ImportError so existing `except ImportError` handlers keep
+    working, while giving callers a specific type to catch."""
+
+
 def get_workspace() -> Path:
     """Return the current workspace path."""
     if _workspace is None:
@@ -52,11 +60,12 @@ def create_server(workspace_path: Optional[str] = None) -> "FastMCP":  # type: i
     try:
         from mcp.server.fastmcp import FastMCP
     except ImportError as exc:
-        raise ImportError(
-            "Could not import mcp.server.fastmcp.FastMCP ({}). This usually means "
-            "either the mcp package is not installed, or an incompatible version "
-            "is installed: mcp 2.0.0 removed FastMCP. Install a supported version "
-            "with: pip install 'athf[mcp]' (which pins mcp[cli]>=1.0.0,<2.0.0).".format(exc)
+        raise MCPDependencyError(
+            f"Could not import mcp.server.fastmcp.FastMCP ({exc}). This usually "
+            "means either the mcp package is not installed, or an incompatible "
+            "version is installed: mcp 2.0.0 removed FastMCP. Install a supported "
+            "version with: pip install 'athf[mcp]' (which pins "
+            "mcp[cli]>=1.9.4,<2.0.0)."
         ) from exc
 
     from athf.mcp.utils import find_workspace, load_workspace_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,18 +99,20 @@ llm = [
     "litellm>=1.30.0",
 ]
 # MCP server
-# Upper-bound the mcp pin: mcp 2.0.0 removed mcp.server.fastmcp.FastMCP,
-# which athf.mcp.server imports. Without the bound, a fresh install resolves
-# 2.0.0 and the server fails to import.
+# Bound the mcp pin on both ends:
+#   - Floor >=1.9.4 avoids GHSA-3qhf-m339-9g5v, a FastMCP DoS fixed in 1.9.4.
+#   - Ceiling <2.0.0 because mcp 2.0.0 removed mcp.server.fastmcp.FastMCP,
+#     which athf.mcp.server imports; without it a fresh install resolves 2.0.0
+#     and the server fails to import.
 mcp = [
-    "mcp[cli]>=1.0.0,<2.0.0",
+    "mcp[cli]>=1.9.4,<2.0.0",
 ]
 all = [
     "litellm>=1.30.0",
     "scikit-learn>=1.0.0",
     "requests>=2.25.0",
     "tavily-python>=0.3.0",
-    "mcp[cli]>=1.0.0,<2.0.0",
+    "mcp[cli]>=1.9.4,<2.0.0",
     "mitreattack-python>=5.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,15 +99,18 @@ llm = [
     "litellm>=1.30.0",
 ]
 # MCP server
+# Upper-bound the mcp pin: mcp 2.0.0 removed mcp.server.fastmcp.FastMCP,
+# which athf.mcp.server imports. Without the bound, a fresh install resolves
+# 2.0.0 and the server fails to import.
 mcp = [
-    "mcp[cli]>=1.0.0",
+    "mcp[cli]>=1.0.0,<2.0.0",
 ]
 all = [
     "litellm>=1.30.0",
     "scikit-learn>=1.0.0",
     "requests>=2.25.0",
     "tavily-python>=0.3.0",
-    "mcp[cli]>=1.0.0",
+    "mcp[cli]>=1.0.0,<2.0.0",
     "mitreattack-python>=5.0.0",
 ]
 

--- a/tests/agents/test_hunt_researcher_honesty.py
+++ b/tests/agents/test_hunt_researcher_honesty.py
@@ -7,12 +7,20 @@ failures), yet the run reported "Research Complete, $0.00". A run that produced
 no usable research must be loud, not look done.
 """
 
+import importlib
 from unittest.mock import patch
 
 import pytest
 
 from athf.agents.llm.hunt_researcher import HuntResearcherAgent, ResearchInput
 from athf.core.llm_provider import LLMProvider, LLMResponse
+
+# Patch the source module's attribute directly. Patching via the string
+# "athf.commands.similar._find_similar_hunts" breaks on Python 3.8-3.10 because
+# athf.commands.__init__ binds the `similar` Click command over the submodule
+# name, so mock's attribute walk resolves `similar` to the command, not the
+# module. Grabbing the module object explicitly sidesteps that shadowing.
+_similar_module = importlib.import_module("athf.commands.similar")
 
 
 class ProseProvider(LLMProvider):
@@ -58,8 +66,8 @@ class TestHuntResearcherHonesty:
         agent = HuntResearcherAgent(llm_enabled=True, provider=provider)
 
         # Isolate the LLM skills: no similarity search, no schema files.
-        with patch(
-            "athf.commands.similar._find_similar_hunts", return_value=[]
+        with patch.object(
+            _similar_module, "_find_similar_hunts", return_value=[]
         ):
             result = agent.execute(_input())
 
@@ -75,8 +83,8 @@ class TestHuntResearcherHonesty:
         provider = ProseProvider()
         agent = HuntResearcherAgent(llm_enabled=True, provider=provider)
 
-        with patch(
-            "athf.commands.similar._find_similar_hunts", return_value=[]
+        with patch.object(
+            _similar_module, "_find_similar_hunts", return_value=[]
         ):
             result = agent.execute(_input())
 
@@ -104,8 +112,8 @@ class TestHuntResearcherHonesty:
                 )
 
         agent = HuntResearcherAgent(llm_enabled=True, provider=CapturingProvider())
-        with patch(
-            "athf.commands.similar._find_similar_hunts", return_value=[]
+        with patch.object(
+            _similar_module, "_find_similar_hunts", return_value=[]
         ):
             result = agent.execute(_input())
 

--- a/tests/agents/test_hunt_researcher_honesty.py
+++ b/tests/agents/test_hunt_researcher_honesty.py
@@ -1,0 +1,114 @@
+"""Tests that HuntResearcherAgent reports failure instead of a silent
+$0.00 'success' when its LLM research skills error out.
+
+Regression guard for the workshop-tester finding: `athf research new` ran with
+Ollama, every section came back "Error during LLM analysis" (JSON parse
+failures), yet the run reported "Research Complete, $0.00". A run that produced
+no usable research must be loud, not look done.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from athf.agents.llm.hunt_researcher import HuntResearcherAgent, ResearchInput
+from athf.core.llm_provider import LLMProvider, LLMResponse
+
+
+class ProseProvider(LLMProvider):
+    """Provider that always returns prose the JSON parser cannot read,
+    reproducing the Ollama-without-format:json failure mode."""
+
+    def __init__(self):
+        self.calls = 0
+
+    @property
+    def provider_name(self):
+        return "prose-mock"
+
+    def complete(self, messages, max_tokens=4096, temperature=0.7, response_format=None):
+        self.calls += 1
+        return LLMResponse(
+            text="Sure! Here is a friendly prose answer with no JSON at all.",
+            input_tokens=10,
+            output_tokens=20,
+            model="prose-model",
+            duration_ms=5,
+            cost_usd=0.0,
+        )
+
+
+def _input():
+    return ResearchInput(
+        topic="LSASS memory dumping",
+        depth="basic",
+        include_past_hunts=False,
+        include_telemetry_mapping=True,
+        web_search_enabled=False,
+    )
+
+
+@pytest.mark.unit
+class TestHuntResearcherHonesty:
+    def test_all_llm_skills_failing_warns_loudly(self):
+        """When every LLM skill fails to parse, the doc is still written but the
+        run carries a loud warning and a non-zero llm_failures count — never a
+        silent clean success."""
+        provider = ProseProvider()
+        agent = HuntResearcherAgent(llm_enabled=True, provider=provider)
+
+        # Isolate the LLM skills: no similarity search, no schema files.
+        with patch(
+            "athf.commands.similar._find_similar_hunts", return_value=[]
+        ):
+            result = agent.execute(_input())
+
+        # Doc is still produced so the attendee keeps partial findings...
+        assert result.data is not None
+        # ...but the failure is surfaced loudly, not hidden.
+        assert result.warnings
+        assert any("LLM research skills failed" in w for w in result.warnings)
+        assert result.metadata["llm_failures"] >= 4
+
+    def test_llm_calls_counted_even_on_parse_failure(self):
+        """The model WAS called; llm_calls must not report 0 on parse failure."""
+        provider = ProseProvider()
+        agent = HuntResearcherAgent(llm_enabled=True, provider=provider)
+
+        with patch(
+            "athf.commands.similar._find_similar_hunts", return_value=[]
+        ):
+            result = agent.execute(_input())
+
+        assert result.metadata["llm_calls"] >= 4
+
+    def test_json_format_requested_from_provider(self):
+        """Research skills must request JSON output from the provider so a
+        format-aware backend (Ollama) returns parseable JSON."""
+        captured = []
+
+        class CapturingProvider(LLMProvider):
+            @property
+            def provider_name(self):
+                return "capture-mock"
+
+            def complete(self, messages, max_tokens=4096, temperature=0.7, response_format=None):
+                captured.append(response_format)
+                return LLMResponse(
+                    text='{"summary": "s", "key_findings": ["f"]}',
+                    input_tokens=1,
+                    output_tokens=1,
+                    model="capture-model",
+                    duration_ms=1,
+                    cost_usd=0.0,
+                )
+
+        agent = HuntResearcherAgent(llm_enabled=True, provider=CapturingProvider())
+        with patch(
+            "athf.commands.similar._find_similar_hunts", return_value=[]
+        ):
+            result = agent.execute(_input())
+
+        assert result.success is True
+        assert captured  # at least one LLM call happened
+        assert all(fmt == "json" for fmt in captured)

--- a/tests/agents/test_hypothesis_generator.py
+++ b/tests/agents/test_hypothesis_generator.py
@@ -41,7 +41,7 @@ class MockProvider(LLMProvider):
     def provider_name(self):
         return "mock"
 
-    def complete(self, messages, max_tokens=4096, temperature=0.7):
+    def complete(self, messages, max_tokens=4096, temperature=0.7, response_format=None):
         self.calls.append({"messages": messages, "max_tokens": max_tokens})
         return LLMResponse(
             text=self.response_text,
@@ -95,7 +95,7 @@ class TestHypothesisGeneratorAgent:
             def provider_name(self):
                 return "retry-mock"
 
-            def complete(self, messages, max_tokens=4096, temperature=0.7):
+            def complete(self, messages, max_tokens=4096, temperature=0.7, response_format=None):
                 nonlocal call_count
                 call_count += 1
                 text = original_text if call_count == 1 else VALID_HYPOTHESIS_JSON
@@ -123,7 +123,7 @@ class TestHypothesisGeneratorAgent:
             def provider_name(self):
                 return "error-mock"
 
-            def complete(self, messages, max_tokens=4096, temperature=0.7):
+            def complete(self, messages, max_tokens=4096, temperature=0.7, response_format=None):
                 raise RuntimeError("LLM is down")
 
         agent = HypothesisGeneratorAgent(provider=ErrorProvider(), llm_enabled=True)
@@ -224,7 +224,7 @@ class TestHypothesisGeneratorDuration:
             def provider_name(self):
                 return "error-mock"
 
-            def complete(self, messages, max_tokens=4096, temperature=0.7):
+            def complete(self, messages, max_tokens=4096, temperature=0.7, response_format=None):
                 raise RuntimeError("LLM is down")
 
         agent = HypothesisGeneratorAgent(provider=ErrorProvider(), llm_enabled=True)

--- a/tests/agents/test_llm_agent_instrumentation.py
+++ b/tests/agents/test_llm_agent_instrumentation.py
@@ -48,3 +48,31 @@ def test_llm_agent_emits_metric_event(tmp_path: Path, monkeypatch: pytest.Monkey
     assert evt["agent"] == "_StubAgent"
     assert evt["duration_ms"] == 50
     assert evt["cost_usd"] == pytest.approx(0.001)
+
+
+class _LegacyProvider:
+    """A third-party provider written before response_format existed: its
+    complete() has no such parameter and rejects the kwarg."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def complete(self, messages: Any, max_tokens: int = 4096) -> _StubResponse:
+        self.calls += 1
+        return _StubResponse()
+
+
+def test_call_llm_tolerates_legacy_provider_signature(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A JSON-requesting call must still work against a provider whose
+    complete() predates the response_format kwarg (retry without it)."""
+    monkeypatch.chdir(tmp_path)
+    provider = _LegacyProvider()
+    agent = _StubAgent(provider=provider)
+
+    # Would raise TypeError on the first attempt; the shim retries without it.
+    result = agent._call_llm("hello", response_format="json")  # type: ignore[attr-defined]
+
+    assert result == "stub"
+    assert provider.calls == 1

--- a/tests/core/test_llm_provider.py
+++ b/tests/core/test_llm_provider.py
@@ -219,6 +219,32 @@ class TestOllamaProvider:
         assert sent_body["options"]["num_predict"] == 512
         assert sent_body["options"]["temperature"] == 0.3
         assert "api/chat" in sent_request.full_url
+        # Default (prose) callers must NOT get a format flag.
+        assert "format" not in sent_body
+
+    def test_ollama_provider_requests_json_format(self):
+        """response_format='json' sets Ollama's format option so the model
+        returns valid JSON instead of prose."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(
+            {
+                "message": {"content": "{}"},
+                "prompt_eval_count": 1,
+                "eval_count": 1,
+            }
+        ).encode("utf-8")
+        mock_resp.status = 200
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            provider = OllamaProvider(model="llama3")
+            provider.complete(
+                messages=[{"role": "user", "content": "test"}],
+                response_format="json",
+            )
+
+        sent_request = mock_urlopen.call_args[0][0]
+        sent_body = json.loads(sent_request.data.decode("utf-8"))
+        assert sent_body["format"] == "json"
 
     def test_ollama_provider_connection_error(self):
         """ConnectionError is raised when Ollama is unreachable."""
@@ -352,15 +378,35 @@ class TestCreateProvider:
             assert isinstance(provider, OpenAICompatibleProvider)
 
     def test_create_provider_auto_detect_aws(self):
-        """AWS_PROFILE triggers BedrockProvider."""
+        """AWS_PROFILE triggers BedrockProvider when no local Ollama is up."""
         env = self._clean_env()
         env["AWS_PROFILE"] = "default"
 
         with patch(
             "athf.core.llm_provider._load_config_file", return_value={}
-        ), patch.dict("os.environ", env, clear=False):
+        ), patch.dict(
+            "os.environ", env, clear=False
+        ), patch(
+            "athf.core.llm_provider._ollama_is_running", return_value=False
+        ):
             provider = create_provider()
             assert isinstance(provider, BedrockProvider)
+
+    def test_create_provider_prefers_ollama_over_aws(self):
+        """A running Ollama wins over ambient AWS creds, so we never silently
+        pick Bedrock (which needs boto3) when a working local model is up."""
+        env = self._clean_env()
+        env["AWS_PROFILE"] = "default"
+
+        with patch(
+            "athf.core.llm_provider._load_config_file", return_value={}
+        ), patch.dict(
+            "os.environ", env, clear=False
+        ), patch(
+            "athf.core.llm_provider._ollama_is_running", return_value=True
+        ):
+            provider = create_provider()
+            assert isinstance(provider, OllamaProvider)
 
     def test_create_provider_auto_detect_ollama(self):
         """Running Ollama triggers OllamaProvider when no API keys set."""


### PR DESCRIPTION
A DEF CON workshop tester ran Modules 3–4 end-to-end and surfaced four framework defects. All confirmed against current code and fixed here.

## Defects fixed

1. **MCP version drift** — `pyproject.toml` pinned `mcp[cli]>=1.0.0` unbounded, so a fresh install resolves mcp 2.0.0, which removed `mcp.server.fastmcp.FastMCP`. `athf mcp serve` then failed with a generic "MCP dependencies not installed." Now bounded `>=1.0.0,<2.0.0` (mcp + all extras); `server.py` and `commands/mcp.py` raise a version-aware error naming the real cause.
2. **Ollama JSON breakage** — `OllamaProvider.complete()` never sent Ollama's `format:"json"`, so the model replied in prose and every research call failed to parse. Added an optional `response_format` param threaded through `complete()` → `_call_llm` → the research skills; Ollama now sends `format:"json"` when requested. Prose/default callers are unaffected. The `--workshop` `_call_llm` wrapper forwards `**kwargs` so it doesn't crash.
3. **Provider auto-detect order** — auto-detect checked AWS creds before a running Ollama, so a machine with ambient AWS creds but no boto3 silently picked Bedrock and failed. Ollama is now probed before AWS-cred Bedrock.
4. **Research error-swallowing** — a run where all LLM skills failed still reported "Research Complete, $0.00", `llm_calls: 0`. Now tracks `_llm_failures`; the doc is still written (attendee keeps partial findings) but a loud warning + `status: completed_with_errors` + `llm_failures` frontmatter surface the failure.

## Tests
Adds coverage for the Ollama `format:json` payload, Ollama-over-AWS ordering, and research warn-on-failure. Full suite: **297 passed**, 13 skipped. (4 failures in this env are pre-existing — scikit-learn not installed + an unrelated FileNotFoundError — reproduce identically with these changes stashed.)

## Notes
No version bump / publish here — release timing is a separate decision. Pairs with the workshop-docs PR (Nebulock-Inc/agentic-hunting-workshop-internal#29).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured JSON response support for LLM calls with automatic fallback for providers that don’t support it.
  * Research runs now surface partial LLM failures as console warnings, record `llm_failures`, and set status to `completed_with_errors` when warnings exist.
  * Provider auto-selection now favors a locally running Ollama instance.

* **Bug Fixes**
  * Workshop-mode LLM calls now forward extra options provided by the user.
  * Improved robustness in counting LLM calls/costs and clearer MCP server startup errors for missing/incompatible MCP dependencies.

* **Tests**
  * Added/updated tests covering JSON enforcement, failure warnings, and legacy provider compatibility.

* **Chores**
  * Updated MCP CLI optional dependency version pins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->