### PR TITLE
fix(investigations): handle investigations in nested directories

### DIFF
--- a/athf/commands/investigate.py
+++ b/athf/commands/investigate.py
@@ -12,7 +12,12 @@ from rich.console import Console
 from rich.prompt import Prompt
 from rich.table import Table
 
-from athf.core.investigation_parser import get_all_investigations, get_next_investigation_id, validate_investigation_file
+from athf.core.investigation_parser import (
+    find_investigation_file,
+    get_all_investigations,
+    get_next_investigation_id,
+    validate_investigation_file,
+)
 from athf.utils.validation import validate_investigation_id
 
 console = Console()
@@ -500,7 +505,7 @@ def search(query: str) -> None:
       athf investigate search "baseline CloudTrail"
     """
     investigations_dir = Path("investigations")
-    investigation_files = sorted(investigations_dir.glob("I-*.md"))
+    investigation_files = sorted(investigations_dir.rglob("I-*.md"))
 
     if not investigation_files:
         console.print("[yellow]No investigation files found.[/yellow]")
@@ -563,17 +568,10 @@ def validate(investigation_id: str) -> None:
         return
 
     investigations_dir = Path("investigations")
-    investigation_file = investigations_dir / f"{investigation_id}.md"
+    investigation_file = find_investigation_file(investigations_dir, investigation_id)
 
-    # Validate path is within investigations directory (Python 3.8 compatible)
-    try:
-        investigation_file.resolve().relative_to(investigations_dir.resolve())
-    except (ValueError, OSError):
-        console.print("[red]Error: Invalid investigation file path[/red]")
-        return
-
-    if not investigation_file.exists():
-        console.print(f"[red]Error: Investigation file not found: {investigation_file}[/red]")
+    if investigation_file is None:
+        console.print(f"[red]Error: Investigation file not found: {investigation_id}[/red]")
         return
 
     is_valid, errors = validate_investigation_file(investigation_file)
@@ -639,19 +637,12 @@ def promote(
         console.print("[yellow]Expected format: I-0001[/yellow]")
         return
 
-    # Check investigation file exists
+    # Check investigation file exists (may live in a subdirectory)
     investigations_dir = Path("investigations")
-    investigation_file = investigations_dir / f"{investigation_id}.md"
+    investigation_file = find_investigation_file(investigations_dir, investigation_id)
 
-    # Validate path is within investigations directory (Python 3.8 compatible)
-    try:
-        investigation_file.resolve().relative_to(investigations_dir.resolve())
-    except (ValueError, OSError):
-        console.print("[red]Error: Invalid investigation file path[/red]")
-        return
-
-    if not investigation_file.exists():
-        console.print(f"[red]Error: Investigation file not found: {investigation_file}[/red]")
+    if investigation_file is None:
+        console.print(f"[red]Error: Investigation file not found: {investigation_id}[/red]")
         return
 
     # Parse investigation file

--- a/athf/core/investigation_parser.py
+++ b/athf/core/investigation_parser.py
@@ -8,9 +8,11 @@ Investigation parser is simpler than hunt parser:
 
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
+
+from athf.utils.validation import validate_investigation_id
 
 
 class InvestigationParser:
@@ -154,6 +156,41 @@ def validate_investigation_file(file_path: Path) -> Tuple[bool, List[str]]:
     return parser.validate()
 
 
+def find_investigation_file(investigations_dir: Path, investigation_id: str) -> Optional[Path]:
+    """Resolve an investigation ID to a file, searching subdirectories.
+
+    Mirrors HuntManager.find_hunt_file: prefer the flat path (where
+    `athf investigate new` writes), then fall back to a recursive search so
+    investigations organized into subdirectories stay reachable.
+
+    Args:
+        investigations_dir: Root investigations directory
+        investigation_id: Investigation ID (e.g. I-0001)
+
+    Returns:
+        Path to the investigation file, or None if it does not exist or
+        resolves outside investigations_dir.
+    """
+    if not validate_investigation_id(investigation_id):
+        return None
+
+    candidates = [investigations_dir / f"{investigation_id}.md"]
+    candidates.extend(sorted(investigations_dir.rglob(f"{investigation_id}.md")))
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        # Keep the containment check: rglob cannot escape the root, but a
+        # symlinked subdirectory can.
+        try:
+            candidate.resolve().relative_to(investigations_dir.resolve())
+        except (ValueError, OSError):
+            continue
+        return candidate
+
+    return None
+
+
 def get_all_investigations(investigations_dir: Path) -> List[Dict[str, Any]]:
     """Get all investigation files from the investigations directory.
 
@@ -168,11 +205,14 @@ def get_all_investigations(investigations_dir: Path) -> List[Dict[str, Any]]:
     if not investigations_dir.exists():
         return []
 
-    # Find all I-*.md files
-    investigation_files = sorted(investigations_dir.glob("I-*.md"))
+    # Find all I-*.md files, including those organized into subdirectories
+    # (e.g. investigations/2026/Q3/I-0001.md). Hunts and research already
+    # recurse; investigations must too, or nested files become invisible to
+    # get_next_investigation_id() and their IDs get handed out a second time.
+    investigation_files = investigations_dir.rglob("I-*.md")
 
     investigations = []
-    for file_path in investigation_files:
+    for file_path in sorted(investigation_files):
         try:
             investigation = parse_investigation_file(file_path)
             investigations.append(investigation)
@@ -180,6 +220,9 @@ def get_all_investigations(investigations_dir: Path) -> List[Dict[str, Any]]:
             # Skip invalid files but log the error
             print(f"Warning: Failed to parse {file_path}: {e}")
             continue
+
+    # Sort by investigation_id, not by path, so nesting does not reorder results
+    investigations.sort(key=lambda i: i.get("investigation_id") or "")
 
     return investigations
 

--- a/tests/commands/test_investigate_nested.py
+++ b/tests/commands/test_investigate_nested.py
@@ -1,0 +1,51 @@
+"""End-to-end: investigate commands must handle nested investigation files."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from athf.commands.investigate import new as investigate_new
+from athf.commands.investigate import promote as investigate_promote
+from athf.commands.investigate import validate as investigate_validate
+
+
+def _nest(investigation_id: str) -> Path:
+    """Move a freshly created investigation into a subdirectory."""
+    src = Path("investigations") / f"{investigation_id}.md"
+    dest_dir = Path("investigations") / "2026" / "Q3"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / src.name
+    src.rename(dest)
+    return dest
+
+
+class TestNestedInvestigationCommands:
+    """Regression: these resolved investigations/I-XXXX.md directly and failed
+    with "Investigation file not found" once a file lived in a subdirectory."""
+
+    def test_validate_finds_nested_investigation(self, tmp_path):
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(investigate_new, ["--title", "Nested", "--non-interactive"])
+            _nest("I-0001")
+
+            result = runner.invoke(investigate_validate, ["I-0001"])
+
+            assert result.exit_code == 0, result.output
+            assert "not found" not in result.output
+            assert "I-0001 is valid" in result.output
+
+    def test_promote_finds_nested_investigation(self, tmp_path):
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(investigate_new, ["--title", "Nested", "--non-interactive"])
+            _nest("I-0001")
+
+            result = runner.invoke(
+                investigate_promote,
+                ["I-0001", "--technique", "T1059.001", "--non-interactive"],
+            )
+
+            assert result.exit_code == 0, result.output
+            assert "not found" not in result.output
+            assert "Promoted I-0001" in result.output

--- a/tests/core/test_investigation_parser.py
+++ b/tests/core/test_investigation_parser.py
@@ -1,0 +1,172 @@
+"""Tests for investigation discovery, including nested directory layouts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athf.core.investigation_parser import (
+    find_investigation_file,
+    get_all_investigations,
+    get_next_investigation_id,
+)
+
+
+def _write_investigation(path: Path, investigation_id: str, title: str = "Test") -> Path:
+    """Write a minimal valid investigation file at an arbitrary path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"""---
+investigation_id: {investigation_id}
+title: {title}
+date: 2026-08-03
+type: finding
+---
+
+# {investigation_id}: {title}
+
+Notes.
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestGetAllInvestigations:
+    """Discovery of investigation files."""
+
+    def test_returns_empty_for_missing_directory(self, tmp_path):
+        assert get_all_investigations(tmp_path / "nope") == []
+
+    def test_finds_flat_investigations(self, tmp_path):
+        _write_investigation(tmp_path / "I-0001.md", "I-0001")
+        _write_investigation(tmp_path / "I-0002.md", "I-0002")
+
+        found = get_all_investigations(tmp_path)
+
+        assert [i["investigation_id"] for i in found] == ["I-0001", "I-0002"]
+
+    def test_finds_nested_investigations(self, tmp_path):
+        """Investigations organized into subdirectories must still be found.
+
+        Hunts (hunts/production/2026/Q3/) and research already recurse; before
+        this fix, investigations used a non-recursive glob and silently ignored
+        anything below the top level.
+        """
+        _write_investigation(tmp_path / "2026" / "Q3" / "I-0001.md", "I-0001")
+
+        found = get_all_investigations(tmp_path)
+
+        assert [i["investigation_id"] for i in found] == ["I-0001"]
+
+    def test_sorts_by_investigation_id_not_path(self, tmp_path):
+        """Nesting must not reorder results.
+
+        Sorting by path would put investigations/2026/Q3/I-0003.md before
+        investigations/I-0001.md, because "2026" < "I-0001.md".
+        """
+        _write_investigation(tmp_path / "I-0001.md", "I-0001")
+        _write_investigation(tmp_path / "2026" / "Q3" / "I-0003.md", "I-0003")
+        _write_investigation(tmp_path / "archive" / "I-0002.md", "I-0002")
+
+        found = get_all_investigations(tmp_path)
+
+        assert [i["investigation_id"] for i in found] == ["I-0001", "I-0002", "I-0003"]
+
+    def test_skips_unparseable_files_without_failing(self, tmp_path):
+        _write_investigation(tmp_path / "I-0001.md", "I-0001")
+        (tmp_path / "I-0002.md").write_text("---\n: : bad yaml :\n---\n", encoding="utf-8")
+
+        found = get_all_investigations(tmp_path)
+
+        assert [i["investigation_id"] for i in found] == ["I-0001"]
+
+    def test_ignores_non_investigation_markdown(self, tmp_path):
+        _write_investigation(tmp_path / "I-0001.md", "I-0001")
+        (tmp_path / "README.md").write_text("# Investigations\n", encoding="utf-8")
+        (tmp_path / "AGENTS.md").write_text("# Context\n", encoding="utf-8")
+
+        found = get_all_investigations(tmp_path)
+
+        assert [i["investigation_id"] for i in found] == ["I-0001"]
+
+
+class TestGetNextInvestigationId:
+    """ID allocation must account for every investigation on disk."""
+
+    def test_first_id_when_empty(self, tmp_path):
+        assert get_next_investigation_id(tmp_path) == "I-0001"
+
+    def test_increments_past_flat_investigations(self, tmp_path):
+        _write_investigation(tmp_path / "I-0001.md", "I-0001")
+        _write_investigation(tmp_path / "I-0002.md", "I-0002")
+
+        assert get_next_investigation_id(tmp_path) == "I-0003"
+
+    def test_increments_past_nested_investigations(self, tmp_path):
+        """Regression: nested investigations were invisible, so IDs collided.
+
+        With a non-recursive glob this returned I-0001, overwriting or
+        duplicating the existing investigation.
+        """
+        _write_investigation(tmp_path / "2026" / "Q3" / "I-0001.md", "I-0001")
+
+        assert get_next_investigation_id(tmp_path) == "I-0002"
+
+    def test_uses_highest_id_across_mixed_layout(self, tmp_path):
+        _write_investigation(tmp_path / "I-0001.md", "I-0001")
+        _write_investigation(tmp_path / "2026" / "Q3" / "I-0007.md", "I-0007")
+        _write_investigation(tmp_path / "archive" / "old" / "I-0004.md", "I-0004")
+
+        assert get_next_investigation_id(tmp_path) == "I-0008"
+
+    @pytest.mark.parametrize("bad_id", ["I-XXXX", "INV-1", "H-0001"])
+    def test_ignores_malformed_ids(self, tmp_path, bad_id):
+        _write_investigation(tmp_path / "I-0001.md", "I-0001")
+        _write_investigation(tmp_path / "other.md", bad_id)
+
+        assert get_next_investigation_id(tmp_path) == "I-0002"
+
+
+class TestFindInvestigationFile:
+    """ID -> path resolution used by `investigate validate` and `promote`."""
+
+    def test_finds_flat_file(self, tmp_path):
+        target = _write_investigation(tmp_path / "I-0001.md", "I-0001")
+
+        assert find_investigation_file(tmp_path, "I-0001") == target
+
+    def test_finds_nested_file(self, tmp_path):
+        """Regression: validate/promote built investigations/I-XXXX.md directly
+        and failed with "Investigation file not found" for nested files."""
+        target = _write_investigation(tmp_path / "2026" / "Q3" / "I-0001.md", "I-0001")
+
+        assert find_investigation_file(tmp_path, "I-0001") == target
+
+    def test_prefers_flat_over_nested(self, tmp_path):
+        flat = _write_investigation(tmp_path / "I-0001.md", "I-0001")
+        _write_investigation(tmp_path / "archive" / "I-0001.md", "I-0001")
+
+        assert find_investigation_file(tmp_path, "I-0001") == flat
+
+    def test_returns_none_when_absent(self, tmp_path):
+        assert find_investigation_file(tmp_path, "I-9999") is None
+
+    def test_returns_none_for_missing_directory(self, tmp_path):
+        assert find_investigation_file(tmp_path / "nope", "I-0001") is None
+
+    @pytest.mark.parametrize("bad_id", ["../../etc/passwd", "I-1", "I-0001/../x", "", "i-0001"])
+    def test_rejects_malformed_ids(self, tmp_path, bad_id):
+        _write_investigation(tmp_path / "I-0001.md", "I-0001")
+
+        assert find_investigation_file(tmp_path, bad_id) is None
+
+    def test_rejects_symlink_escaping_the_root(self, tmp_path):
+        outside = tmp_path / "outside"
+        _write_investigation(outside / "I-0001.md", "I-0001")
+        root = tmp_path / "investigations"
+        root.mkdir()
+        (root / "linked").symlink_to(outside, target_is_directory=True)
+
+        assert find_investigation_file(root, "I-0001") is None


### PR DESCRIPTION
## Problem

Investigations are the only entity type that does not search subdirectories.

- `get_all_investigations()` and `athf investigate search` used a non-recursive `glob("I-*.md")`
- `athf investigate validate` and `athf investigate promote` resolved IDs by building `investigations/I-XXXX.md` directly

Everything else already recurses — hunts (`hunt_manager.rglob`), research (`research_manager.rglob`), metrics, and `athf context`. The MCP investigate tools use `rglob` too, so **MCP and the CLI disagreed about which investigations exist**.

The practical consequence is duplicate IDs, because `get_next_investigation_id()` builds on `get_all_investigations()`:

```console
$ athf investigate new --title First      # -> I-0001
$ mkdir -p investigations/2026/Q3
$ mv investigations/I-0001.md investigations/2026/Q3/
$ athf investigate list                   # -> No investigations found
$ athf investigate new --title Second     # -> I-0001  (collision, silent)
$ athf investigate validate I-0001        # -> Investigation file not found
$ athf investigate promote I-0001         # -> Investigation file not found
```

Nesting is a natural thing to reach for here, since hunts already land in `hunts/production/2026/Q3/`.

## Changes

- `get_all_investigations()` and `investigate search` use `rglob`
- Results sort by `investigation_id` rather than by path, so nesting cannot reorder them — a path sort puts `2026/Q3/I-0003.md` ahead of `I-0001.md`
- New `find_investigation_file()`, mirroring the existing `HuntManager.find_hunt_file`: flat path first, then recursive fallback, keeping the containment check so a symlinked subdirectory cannot escape the root
- `investigate validate` and `investigate promote` use it

Investigation *creation* still writes flat, so default layouts are unchanged.

## Testing

Adds 26 tests across `tests/core/test_investigation_parser.py` and `tests/commands/test_investigate_nested.py`. These modules had no coverage before — `investigation_parser.py` was at 12%.

Verified red/green: with the source changes stashed, 4 parser tests, 2 resolver tests, and both CLI tests fail. The remaining tests pin existing flat-layout behavior so this does not regress default workspaces.

Full suite: **341 passed**, mypy clean, `flake8 --select=E,W,F` clean.

End-to-end against a real workspace, after the fix:

```console
$ athf investigate new --title Second     # -> I-0002
$ athf investigate list                   # -> 2 investigations
$ athf investigate validate I-0001        # -> I-0001 is valid
$ athf investigate promote I-0001 ...     # -> Promoted I-0001 to H-0005
$ athf investigate search First           # -> investigations/2026/Q3/I-0001.md
```

## Note

I found this while reading the repo, and there are a few smaller things alongside it I'm happy to send separately if useful — a CI gap where 49 tests never run, and a default bind address on the MCP HTTP transports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Investigation files can now be stored and discovered in nested subdirectories.
  * Validation and promotion commands locate investigations consistently across directory layouts.
  * Investigation listings are presented in a stable order by investigation ID.

* **Bug Fixes**
  * Improved handling of invalid, missing, malformed, and duplicate investigation files.
  * Prevented paths outside the investigations directory from being resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->