### PR TITLE
fix(mcp): bind HTTP transports to loopback by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ Configure in `~/.claude/mcp-servers.json`:
 
 The standalone `athf-mcp` entry point auto-detects your workspace from cwd or `ATHF_WORKSPACE` env var. Use `athf mcp serve --workspace /path` for explicit paths.
 
+> **Security note:** the `sse` and `streamable-http` transports bind to `127.0.0.1` and are **unauthenticated**. Every tool reads your whole workspace and some invoke LLM agents at your expense. Only pass `--host` to bind a routable interface, and put an authenticating proxy in front when you do. The default `stdio` transport opens no socket at all.
+
 Exposes 17 tools: hunt management, semantic search, ATT&CK coverage, research, investigations, and AI-powered hypothesis generation — all accessible directly from your AI coding assistant.
 
 **Full documentation:** [CLI Reference](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/blob/main/docs/CLI_REFERENCE.md)

--- a/athf/commands/mcp.py
+++ b/athf/commands/mcp.py
@@ -10,9 +10,16 @@ def mcp() -> None:
 
 @mcp.command()
 @click.option("--workspace", default=None, help="Explicit workspace path (auto-detected if not set)")
-@click.option("--transport", default="stdio", type=click.Choice(["stdio", "sse", "streamable-http"]), help="Transport protocol")
+@click.option(
+    "--transport", default="stdio", type=click.Choice(["stdio", "sse", "streamable-http"]), help="Transport protocol"
+)
 @click.option("--port", default=3100, type=int, help="HTTP port for SSE transport")
-def serve(workspace: str, transport: str, port: int) -> None:
+@click.option(
+    "--host",
+    default=None,
+    help="Bind address for SSE/HTTP transport (default: 127.0.0.1). The server is unauthenticated.",
+)
+def serve(workspace: str, transport: str, port: int, host: str) -> None:
     """Start the ATHF MCP server.
 
     This exposes ATHF operations as MCP tools that AI assistants
@@ -27,6 +34,11 @@ def serve(workspace: str, transport: str, port: int) -> None:
       athf mcp serve --transport streamable-http --port 3100
 
     \b
+    The HTTP transports bind to 127.0.0.1 and are UNAUTHENTICATED: every tool
+    reads the whole workspace and can invoke LLM agents. Only pass --host to
+    widen that when an authenticating proxy sits in front of the server.
+
+    \b
     Configuration for Claude Code (~/.claude/mcp-servers.json):
       {
         "athf": {
@@ -39,12 +51,17 @@ def serve(workspace: str, transport: str, port: int) -> None:
     # incompatible mcp surfaces as MCPDependencyError when mcp_main runs, not at
     # the import above. Catch only that dedicated type so unrelated ImportErrors
     # (a genuine bug in a tool module) still propagate with a real traceback.
-    from athf.mcp.server import MCPDependencyError
+    from athf.mcp.server import DEFAULT_HOST, MCPDependencyError
 
     try:
         from athf.mcp.server import main as mcp_main
 
-        mcp_main(workspace_path=workspace, transport=transport, port=port)
+        mcp_main(
+            workspace_path=workspace,
+            transport=transport,
+            port=port,
+            host=host or DEFAULT_HOST,
+        )
     except MCPDependencyError as exc:
         click.echo(
             f"Error starting the ATHF MCP server: {exc}\n"

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -52,9 +52,11 @@ def _discover_plugin_tools() -> list:
     """Discover MCP tool registration functions from installed plugins."""
     if sys.version_info >= (3, 10):
         from importlib.metadata import entry_points
+
         return list(entry_points(group="athf.mcp_tools"))
     else:
         from importlib.metadata import entry_points
+
         return list(entry_points().get("athf.mcp_tools", []))
 
 
@@ -121,11 +123,47 @@ def reset_server() -> None:
     _workspace = None
 
 
-def main(workspace_path: Optional[str] = None, transport: str = "stdio", port: int = 3100) -> None:
-    """Entry point for running the MCP server."""
+DEFAULT_HOST = "127.0.0.1"
+
+# Only these reach nothing beyond this machine. Everything else — a wildcard
+# bind, a LAN address, a public address — is treated as exposed. The MCP server
+# has no authentication and its tools read the full hunt corpus and can invoke
+# LLM agents, so anything outside this set needs an explicit opt-in.
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
+
+
+def is_exposed_host(host: str) -> bool:
+    """Return True if `host` accepts connections from beyond this machine."""
+    return host.strip().lower() not in LOOPBACK_HOSTS
+
+
+def main(
+    workspace_path: Optional[str] = None,
+    transport: str = "stdio",
+    port: int = 3100,
+    host: str = DEFAULT_HOST,
+) -> None:
+    """Entry point for running the MCP server.
+
+    For the HTTP transports the server binds to loopback by default. It serves
+    unauthenticated tools over the whole workspace, so exposing it on a routable
+    interface requires passing `host` explicitly and putting an authenticating
+    proxy in front of it.
+    """
     server = create_server(workspace_path)
     if transport in ("sse", "streamable-http"):
-        server.settings.host = "0.0.0.0"
+        if is_exposed_host(host):
+            logger.warning(
+                "ATHF MCP server binding to %s:%s — reachable from outside this "
+                "machine. The server is UNAUTHENTICATED: anyone who can reach "
+                "this port can read every hunt, investigation, and research "
+                "document in the workspace and invoke LLM-backed tools at your "
+                "expense. Bind to %s and use an authenticating proxy instead.",
+                host,
+                port,
+                DEFAULT_HOST,
+            )
+        server.settings.host = host
         server.settings.port = port
     server.run(transport=transport)
 
@@ -138,5 +176,14 @@ def cli() -> None:
     parser.add_argument("--workspace", default=None, help="Workspace path")
     parser.add_argument("--transport", default="stdio", choices=["stdio", "sse", "streamable-http"])
     parser.add_argument("--port", type=int, default=3100, help="HTTP port for SSE/HTTP transport")
+    parser.add_argument(
+        "--host",
+        default=DEFAULT_HOST,
+        help=(
+            f"Bind address for SSE/HTTP transport (default: {DEFAULT_HOST}). "
+            "The server is unauthenticated; only change this behind an "
+            "authenticating proxy."
+        ),
+    )
     args = parser.parse_args()
-    main(workspace_path=args.workspace, transport=args.transport, port=args.port)
+    main(workspace_path=args.workspace, transport=args.transport, port=args.port, host=args.host)

--- a/tests/mcp/test_server_bind.py
+++ b/tests/mcp/test_server_bind.py
@@ -1,0 +1,85 @@
+"""Tests for MCP server bind-address handling.
+
+The HTTP transports serve unauthenticated tools over the entire workspace, so
+the default bind address must stay on loopback and widening it must be an
+explicit, warned-about choice.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("mcp", reason="MCP optional dependency not installed")
+
+from athf.mcp.server import DEFAULT_HOST, is_exposed_host, main  # noqa: E402
+
+
+class TestIsExposedHost:
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "[::1]", "LOCALHOST", " 127.0.0.1 "])
+    def test_loopback_is_not_exposed(self, host):
+        assert is_exposed_host(host) is False
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::", "[::]", "*", "", "192.168.1.10", "10.0.0.5"])
+    def test_routable_and_wildcard_are_exposed(self, host):
+        assert is_exposed_host(host) is True
+
+
+class TestMainBindAddress:
+    """`main()` must not bind beyond loopback unless explicitly told to."""
+
+    def _run(self, transport, **kwargs):
+        server = MagicMock()
+        server.settings = MagicMock()
+        with patch("athf.mcp.server.create_server", return_value=server):
+            main(transport=transport, **kwargs)
+        return server
+
+    def test_default_host_is_loopback(self):
+        """Regression: this was hardcoded to 0.0.0.0, exposing the workspace."""
+        server = self._run("streamable-http")
+
+        assert server.settings.host == DEFAULT_HOST
+        assert DEFAULT_HOST == "127.0.0.1"
+
+    def test_default_host_is_loopback_for_sse(self):
+        server = self._run("sse")
+
+        assert server.settings.host == DEFAULT_HOST
+
+    def test_explicit_host_is_honored(self):
+        server = self._run("streamable-http", host="0.0.0.0")  # nosec B104
+
+        assert server.settings.host == "0.0.0.0"  # nosec B104
+
+    def test_port_is_applied(self):
+        server = self._run("streamable-http", port=9999)
+
+        assert server.settings.port == 9999
+
+    def test_stdio_does_not_touch_network_settings(self):
+        """stdio has no listening socket, so host/port must never be assigned."""
+
+        class Settings:
+            pass
+
+        server = MagicMock()
+        server.settings = Settings()
+        with patch("athf.mcp.server.create_server", return_value=server):
+            main(transport="stdio")
+
+        server.run.assert_called_once_with(transport="stdio")
+        assert not hasattr(server.settings, "host")
+        assert not hasattr(server.settings, "port")
+
+    def test_exposed_host_logs_warning(self, caplog):
+        with caplog.at_level("WARNING", logger="athf.mcp.server"):
+            self._run("streamable-http", host="0.0.0.0")  # nosec B104
+
+        assert "UNAUTHENTICATED" in caplog.text
+        assert "0.0.0.0" in caplog.text
+
+    def test_loopback_host_logs_no_warning(self, caplog):
+        with caplog.at_level("WARNING", logger="athf.mcp.server"):
+            self._run("streamable-http")
+
+        assert "UNAUTHENTICATED" not in caplog.text


### PR DESCRIPTION
## Problem

`athf/mcp/server.py` hardcoded the bind address for the HTTP transports:

```python
if transport in ("sse", "streamable-http"):
    server.settings.host = "0.0.0.0"
```

Starting the MCP server on either transport published it on every interface. The server has no authentication, and its tools read the entire workspace — hunts, investigations, research — and can invoke LLM-backed agents. Anyone able to reach the port got full read access to the hunt corpus and could spend the operator's model budget.

Bandit flags this as [B104](https://bandit.readthedocs.io/en/latest/plugins/b104_hardcoded_bind_all_interfaces.html) (CWE-605).

**Scope, honestly:** the default transport is `stdio`, which opens no socket, so this only affects users who deliberately chose `sse` or `streamable-http`. It's a sensible default to correct rather than an emergency — no CVE-worthy remote exposure, but a laptop on hotel or conference wifi serving its hunt history to the subnet is a bad surprise, and threat hunting workspaces are exactly the kind of data where that matters.

## Changes

- Default to `127.0.0.1`
- Add `--host` on both `athf mcp serve` and the standalone `athf-mcp` entry point, so widening the bind is explicit
- Binding anywhere other than loopback logs a warning naming the exposure
- Document it in the README MCP section
- `stdio` is untouched

## Verification

Unit tests are mocked, so I checked the real listening sockets:

```console
$ athf mcp serve --transport streamable-http --port 3177
  -> TCP 127.0.0.1:3177 (LISTEN)

$ athf mcp serve --transport streamable-http --port 3178 --host 0.0.0.0
  -> TCP *:3178 (LISTEN)     + warning logged
```

Adds `tests/mcp/test_server_bind.py` — 20 tests covering the loopback default, explicit opt-in, warning emission, and that `stdio` never assigns `host`/`port`. Locally: 335 passed, mypy clean, bandit B104 resolved.

## One caveat on CI

These 20 tests live under `tests/mcp/` behind `pytest.importorskip("mcp")`. The `test` job installs only `".[dev]"`, so **they will skip here and this will merge with its tests not actually having run**. #44 adds a job that installs the extras and fixes that.

No dependency between the changes — merge in either order — but this PR's coverage is only real once #44 lands. If you'd rather not carry that gap, holding this until #44 merges is completely reasonable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host configuration for MCP HTTP transports.
  * HTTP transports now bind to `127.0.0.1` by default.
  * Added warnings when binding to an externally accessible host.

* **Documentation**
  * Documented authentication and security considerations for MCP server transports, including workspace access and potential LLM costs.

* **Bug Fixes**
  * Prevented `stdio` transport from opening a network socket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->