### PR TITLE
fix(investigate): print the real ID in the promote hint; clear lint debt

### DIFF
--- a/athf/commands/agent.py
+++ b/athf/commands/agent.py
@@ -63,6 +63,7 @@ def _apply_workshop_mode(agent: Any, token_cap: int) -> None:
 
     agent._call_llm = capped_call_llm
 
+
 AGENT_EPILOG = """
 \b
 Examples:

--- a/athf/commands/investigate.py
+++ b/athf/commands/investigate.py
@@ -200,7 +200,7 @@ def new(
     console.print(f"  1. Edit [cyan]{investigation_file}[/cyan] to document your investigation")
     console.print("  2. Use LOCK pattern sections (optional/flexible)")
     console.print("  3. View all investigations: [cyan]athf investigate list[/cyan]")
-    console.print("  4. Promote to hunt if valuable: [cyan]athf investigate promote {investigation_id}[/cyan]")
+    console.print(f"  4. Promote to hunt if valuable: [cyan]athf investigate promote {investigation_id}[/cyan]")
 
 
 def _render_investigation_template(

--- a/athf/commands/metrics.py
+++ b/athf/commands/metrics.py
@@ -17,7 +17,6 @@ from rich.console import Console
 from rich.table import Table
 
 from athf.core.metrics import (
-    DEFAULT_AGGREGATES_PATH,
     EVENT_TYPES,
     Aggregator,
     EventStore,

--- a/athf/core/metrics.py
+++ b/athf/core/metrics.py
@@ -27,7 +27,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterable, Iterator, Optional, Union
 
 # ---------------------------------------------------------------------------
 # Schema

--- a/athf/core/research_manager.py
+++ b/athf/core/research_manager.py
@@ -560,9 +560,11 @@ class ResearchManager:
 
         file_path = Path(research_data["file_path"])
 
+        # Probe readability before rewriting: the parsed copy already lives in
+        # research_data, so the content itself is not needed here.
         try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                content = f.read()
+            with open(file_path, "r", encoding="utf-8"):
+                pass
         except OSError:
             return None
 

--- a/athf/mcp/tools/attack_tools.py
+++ b/athf/mcp/tools/attack_tools.py
@@ -1,7 +1,5 @@
 """MITRE ATT&CK MCP tools."""
 
-from typing import Optional
-
 from athf.mcp.server import _json_result
 
 

--- a/tests/commands/test_investigate_output.py
+++ b/tests/commands/test_investigate_output.py
@@ -1,0 +1,23 @@
+"""Tests for `athf investigate` user-facing output."""
+
+from click.testing import CliRunner
+
+from athf.commands.investigate import new as investigate_new
+
+
+class TestInvestigateNewNextSteps:
+    """The next-steps block must print a runnable command, not a template."""
+
+    def test_promote_hint_contains_real_investigation_id(self, tmp_path):
+        """Regression: this line lacked an f-prefix and printed the literal
+        text "{investigation_id}", which is not a runnable command."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(
+                investigate_new,
+                ["--title", "Odd PowerShell parent", "--non-interactive"],
+            )
+
+            assert result.exit_code == 0, result.output
+            assert "athf investigate promote I-0001" in result.output
+            assert "{investigation_id}" not in result.output


### PR DESCRIPTION
## The user-visible bit

`athf investigate new` ends with a next-steps block. The last line printed a template placeholder instead of a runnable command:

```console
$ athf investigate new --title "Odd PowerShell parent" --non-interactive
...
  4. Promote to hunt if valuable: athf investigate promote {investigation_id}
```

The line was missing its `f` prefix. It now prints the actual ID:

```console
  4. Promote to hunt if valuable: athf investigate promote I-0001
```

Small, but it's copy-paste guidance aimed at both humans and AI assistants, and `{investigation_id}` is not a valid ID.

## The lint debt

The CI lint step runs `--exit-zero` for everything except `E9,F63,F7,F82`, so these have been accumulating silently:

| File | Finding |
|---|---|
| `athf/commands/metrics.py` | F401 unused `DEFAULT_AGGREGATES_PATH` |
| `athf/core/metrics.py` | F401 unused `typing.List` |
| `athf/mcp/tools/attack_tools.py` | F401 unused `typing.Optional` |
| `athf/core/research_manager.py` | F841 unused `content` |
| `athf/commands/agent.py` | E305 blank lines before `AGENT_EPILOG` |

`flake8 athf --select=E,W,F` now reports **0**.

The `content` one deserves a note: in `append_hypothesis()` the file was read into a variable that was never used. The read still serves as an `OSError` guard before rewriting, so I kept the guard and dropped the binding rather than deleting the block — the parsed copy already lives in `research_data`.

I left the **C901 complexity warnings alone**. There are 17, and they want refactoring, not a lint pass — not something to smuggle into a cleanup PR.

## Testing

Adds one regression test pinning the promote hint. It fails without the `f` prefix.

316 passed locally, mypy clean.

## Not included

I also have a branch raising the minimum Python to 3.11 — it resolves the `mitreattack-python` resolver failure described in #44 and a mypy config warning. That drops support for live interpreters, so it's a policy call rather than a fix; happy to open it as an issue for discussion if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Investigation creation now displays the actual investigation ID in the suggested promotion command, making the command ready to run.
  - Improved validation when updating research files while preserving existing failure handling.

- **Tests**
  - Added regression coverage to verify investigation guidance includes the generated ID and not a placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->