### PR TITLE
Fix install hints in error messages: PyPI package is agentic-threat-hunting-framework, not athf

### DIFF
--- a/athf/commands/agent.py
+++ b/athf/commands/agent.py
@@ -381,9 +381,9 @@ def run(  # noqa: C901
         except ImportError as e:
             console.print(f"[red]Error loading agent: {e}[/red]")
             console.print("\n[dim]Install an LLM provider:[/dim]")
-            console.print("  pip install 'athf[litellm]'   # All providers via LiteLLM")
-            console.print("  pip install 'athf[openai]'    # OpenAI/GPT")
-            console.print("  pip install 'athf[bedrock]'   # AWS Bedrock")
+            console.print("  pip install 'agentic-threat-hunting-framework[litellm]'   # All providers via LiteLLM")
+            console.print("  pip install 'agentic-threat-hunting-framework[openai]'    # OpenAI/GPT")
+            console.print("  pip install 'agentic-threat-hunting-framework[bedrock]'   # AWS Bedrock")
             raise click.Abort()
         except Exception as e:
             console.print(f"[red]Error: {e}[/red]")
@@ -445,7 +445,7 @@ def run(  # noqa: C901
         except ImportError as e:
             console.print(f"[red]Error loading agent: {e}[/red]")
             console.print("\n[dim]Install an LLM provider:[/dim]")
-            console.print("  pip install 'athf[litellm]'   # All providers via LiteLLM")
+            console.print("  pip install 'agentic-threat-hunting-framework[litellm]'   # All providers via LiteLLM")
             console.print("  pip install tavily-python      # Web search (optional)")
             raise click.Abort()
         except Exception as e:

--- a/athf/commands/attack.py
+++ b/athf/commands/attack.py
@@ -76,7 +76,7 @@ def update(force: bool) -> None:
         from mitreattack.stix20 import MitreAttackData  # noqa: F401
     except ImportError:
         console.print("[red]Error: mitreattack-python is not installed.[/red]")
-        console.print("[dim]Install it with: pip install 'athf[attack]'[/dim]")
+        console.print("[dim]Install it with: pip install 'agentic-threat-hunting-framework[attack]'[/dim]")
         raise click.Abort()
 
     from athf.core.attack_matrix import _get_stix_file_path, reset_provider
@@ -160,7 +160,7 @@ def status() -> None:
         console.print("  [cyan]Library:[/cyan]   mitreattack-python installed")
     except ImportError:
         console.print("  [cyan]Library:[/cyan]   [yellow]mitreattack-python not installed[/yellow]")
-        console.print("[dim]  Install with: pip install 'athf[attack]'[/dim]")
+        console.print("[dim]  Install with: pip install 'agentic-threat-hunting-framework[attack]'[/dim]")
 
     console.print()
 
@@ -205,7 +205,7 @@ def lookup(technique_id: str) -> None:
 
     if not is_using_stix():
         console.print("[yellow]STIX data not available. Technique lookup requires STIX.[/yellow]")
-        console.print("[dim]Install and update: pip install 'athf[attack]' && athf attack update[/dim]")
+        console.print("[dim]Install and update: pip install 'agentic-threat-hunting-framework[attack]' && athf attack update[/dim]")
         return
 
     tech = get_technique(technique_id)
@@ -248,7 +248,7 @@ def techniques(tactic_key: str) -> None:
 
     if not is_using_stix():
         console.print("[yellow]STIX data not available. Technique listing requires STIX.[/yellow]")
-        console.print("[dim]Install and update: pip install 'athf[attack]' && athf attack update[/dim]")
+        console.print("[dim]Install and update: pip install 'agentic-threat-hunting-framework[attack]' && athf attack update[/dim]")
         return
 
     techs = get_techniques_for_tactic(tactic_key)

--- a/athf/commands/mcp.py
+++ b/athf/commands/mcp.py
@@ -50,7 +50,7 @@ def serve(workspace: str, transport: str, port: int) -> None:
             f"Error starting the ATHF MCP server: {exc}\n"
             "This usually means the mcp package is missing or an incompatible "
             "version is installed (mcp 2.0.0 removed FastMCP). Install a supported "
-            "version with: pip install 'athf[mcp]' (pins mcp[cli]>=1.9.4,<2.0.0).",
+            "version with: pip install 'agentic-threat-hunting-framework[mcp]' (pins mcp[cli]>=1.9.4,<2.0.0).",
             err=True,
         )
         raise SystemExit(1) from exc

--- a/athf/commands/similar.py
+++ b/athf/commands/similar.py
@@ -175,7 +175,7 @@ def _find_similar_hunts(
         from sklearn.metrics.pairwise import cosine_similarity
     except ImportError:
         console.print("[red]Error: scikit-learn not installed[/red]")
-        console.print("[dim]Install with: pip install scikit-learn[/dim]")
+        console.print("[dim]Install with: pip install 'agentic-threat-hunting-framework[similarity]'[/dim]")
         raise click.Abort()
 
     # Load all hunts (HuntManager handles recursive search + deduplication)

--- a/athf/core/llm_provider.py
+++ b/athf/core/llm_provider.py
@@ -201,7 +201,7 @@ class LiteLLMProvider(LLMProvider):
             import litellm
         except ImportError:
             raise ImportError(
-                "litellm package is not installed. Install it with: pip install litellm"
+                "litellm package is not installed. Install it with: pip install 'agentic-threat-hunting-framework[litellm]'"
             )
 
         kwargs: Dict[str, Any] = {}
@@ -281,7 +281,7 @@ class BedrockProvider(LLMProvider):
             import boto3
             from botocore.config import Config
         except ImportError:
-            raise ImportError("boto3 package is not installed. Install it with: pip install boto3")
+            raise ImportError("boto3 package is not installed. Install it with: pip install 'agentic-threat-hunting-framework[bedrock]'")
 
         # Long-form generations (e.g. 8k-token reports) can exceed boto3's
         # default 60s read timeout on non-streaming invoke_model. Give the
@@ -506,7 +506,7 @@ class OpenAICompatibleProvider(LLMProvider):
             import openai
         except ImportError:
             raise ImportError(
-                "openai package is not installed. Install it with: pip install openai"
+                "openai package is not installed. Install it with: pip install 'agentic-threat-hunting-framework[openai]'"
             )
 
         kwargs = {}  # type: Dict[str, Any]

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -31,7 +31,7 @@ class MCPDependencyError(ImportError):
             f"Could not import mcp.server.fastmcp.FastMCP ({cause}). This "
             "usually means either the mcp package is not installed, or an "
             "incompatible version is installed: mcp 2.0.0 removed FastMCP. "
-            "Install a supported version with: pip install 'athf[mcp]' "
+            "Install a supported version with: pip install 'agentic-threat-hunting-framework[mcp]' "
             "(which pins mcp[cli]>=1.9.4,<2.0.0)."
         )
 

--- a/athf/mcp/tools/search_tools.py
+++ b/athf/mcp/tools/search_tools.py
@@ -42,7 +42,7 @@ def register_search_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined]
             from sklearn.feature_extraction.text import TfidfVectorizer
             from sklearn.metrics.pairwise import cosine_similarity
         except ImportError:
-            return _json_result({"error": "scikit-learn is required for similarity search. Install with: pip install 'athf[similarity]'"})
+            return _json_result({"error": "scikit-learn is required for similarity search. Install with: pip install 'agentic-threat-hunting-framework[similarity]'"})
 
         # Build corpus
         from athf.core.hunt_parser import parse_hunt_file


### PR DESCRIPTION
Thanks for the great DEF CON workshop! While working through the labs I noticed the install hints in a few error messages suggest pip install 'athf[extra]' — but the package on PyPI is named agentic-threat-hunting-framework, so the suggested command installs the wrong package.

This PR updates those hints to the full package name, and switches the bare hints (scikit-learn, litellm, boto3, openai) to the matching extras you already define in the package metadata — that way the advice works consistently across pip/uv/pipx setups.

Small thing, but it should smooth out the first-run experience for future workshop attendees. Happy to adjust!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated installation guidance shown in dependency error messages to consistently use the full package name.
  - Corrected setup instructions for ATT&CK, MCP, similarity search, and supported AI providers.
  - Ensured users receive accurate optional dependency commands when required features are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->