### PR TITLE
Docs: correct package name in pip install commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,7 +413,7 @@ athf research view R-0001             # View specific research
 athf research search "credential access"  # Search research documents
 athf research stats                   # Show research metrics
 
-# ATT&CK data management (optional: pip install 'athf[attack]')
+# ATT&CK data management (optional: pip install 'agentic-threat-hunting-framework[attack]')
 athf attack update                    # Download/refresh STIX data
 athf attack status                    # Show provider type, version, cache info
 athf attack lookup T1003.001          # Look up technique metadata

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -81,11 +81,11 @@ ATHF agents auto-detect your LLM provider from environment variables. You can us
 
 | Provider | Required Env Var | Install Extra |
 |----------|-----------------|---------------|
-| Anthropic (Claude) | `ANTHROPIC_API_KEY` | `pip install 'athf[anthropic]'` |
-| OpenAI (GPT) | `OPENAI_API_KEY` | `pip install 'athf[openai]'` |
-| AWS Bedrock | `AWS_PROFILE` or `AWS_ACCESS_KEY_ID` | `pip install 'athf[bedrock]'` |
-| Ollama (local) | `OLLAMA_HOST` (default: localhost:11434) | `pip install 'athf[ollama]'` |
-| Any via LiteLLM | varies | `pip install 'athf[litellm]'` |
+| Anthropic (Claude) | `ANTHROPIC_API_KEY` | `pip install 'agentic-threat-hunting-framework[anthropic]'` |
+| OpenAI (GPT) | `OPENAI_API_KEY` | `pip install 'agentic-threat-hunting-framework[openai]'` |
+| AWS Bedrock | `AWS_PROFILE` or `AWS_ACCESS_KEY_ID` | `pip install 'agentic-threat-hunting-framework[bedrock]'` |
+| Ollama (local) | `OLLAMA_HOST` (default: localhost:11434) | `pip install 'agentic-threat-hunting-framework[ollama]'` |
+| Any via LiteLLM | varies | `pip install 'agentic-threat-hunting-framework[litellm]'` |
 
 ### Quick Setup
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ athf research stats                 # Research metrics
 
 ```bash
 # Install STIX support (optional)
-pip install 'athf[attack]'
+pip install 'agentic-threat-hunting-framework[attack]'
 
 # Download live ATT&CK data (835+ techniques with full metadata)
 athf attack update
@@ -210,7 +210,7 @@ Without `mitreattack-python`, ATHF uses a hardcoded v14 fallback (14 tactics, ap
 
 ```bash
 # Install MCP dependencies
-pip install 'athf[mcp]'
+pip install 'agentic-threat-hunting-framework[mcp]'
 
 # Start MCP server (for Claude Code, Copilot, Cursor, etc.)
 athf mcp serve --workspace /path/to/hunts

--- a/athf/data/integrations/MCP_CATALOG.md
+++ b/athf/data/integrations/MCP_CATALOG.md
@@ -6,7 +6,7 @@ ATHF includes its own MCP server that exposes hunting operations as tools for an
 
 **Install:**
 ```bash
-pip install 'athf[mcp]'
+pip install 'agentic-threat-hunting-framework[mcp]'
 ```
 
 **Configure for Claude Code** (`~/.claude/mcp-servers.json`):

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2185,7 +2185,7 @@ athf attack update [OPTIONS]
 
 Downloads the Enterprise ATT&CK STIX bundle from the official MITRE repository and caches it locally. Once downloaded, ATHF automatically switches from the hardcoded fallback data (14 tactics, approximate counts) to live STIX data (835+ techniques with full metadata including platforms, data sources, and sub-techniques).
 
-**Prerequisites:** Requires `mitreattack-python` — install with `pip install 'athf[attack]'`.
+**Prerequisites:** Requires `mitreattack-python` — install with `pip install 'agentic-threat-hunting-framework[attack]'`.
 
 **Cache locations (checked in order):**
 1. `ATHF_STIX_CACHE` environment variable

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -199,11 +199,11 @@ Set **one** of the following environment variables and ATHF auto-detects your pr
 
 | Provider           | Environment Variable                              | Install Extra                   |
 |--------------------|---------------------------------------------------|---------------------------------|
-| Anthropic (Claude) | `ANTHROPIC_API_KEY`                               | `pip install 'athf[anthropic]'` |
-| OpenAI (GPT)       | `OPENAI_API_KEY`<br/>`OPENAI_API_HOST` (optional) | `pip install 'athf[openai]'`    |
-| AWS Bedrock        | `AWS_PROFILE` or `AWS_ACCESS_KEY_ID`              | `pip install 'athf[bedrock]'`   |
-| Ollama (local)     | `OLLAMA_HOST` (default: `localhost:11434`)        | `pip install 'athf[ollama]'`    |
-| Any via LiteLLM    | varies                                            | `pip install 'athf[litellm]'`   |
+| Anthropic (Claude) | `ANTHROPIC_API_KEY`                               | `pip install 'agentic-threat-hunting-framework[anthropic]'` |
+| OpenAI (GPT)       | `OPENAI_API_KEY`<br/>`OPENAI_API_HOST` (optional) | `pip install 'agentic-threat-hunting-framework[openai]'`    |
+| AWS Bedrock        | `AWS_PROFILE` or `AWS_ACCESS_KEY_ID`              | `pip install 'agentic-threat-hunting-framework[bedrock]'`   |
+| Ollama (local)     | `OLLAMA_HOST` (default: `localhost:11434`)        | `pip install 'agentic-threat-hunting-framework[ollama]'`    |
+| Any via LiteLLM    | varies                                            | `pip install 'agentic-threat-hunting-framework[litellm]'`   |
 
 ```bash
 # Example: configure OpenAI

--- a/integrations/MCP_CATALOG.md
+++ b/integrations/MCP_CATALOG.md
@@ -6,7 +6,7 @@ ATHF includes its own MCP server that exposes hunting operations as tools for an
 
 **Install:**
 ```bash
-pip install 'athf[mcp]'
+pip install 'agentic-threat-hunting-framework[mcp]'
 ```
 
 **Configure for Claude Code** (`~/.claude/mcp-servers.json`):


### PR DESCRIPTION
Companion to #48, for the docs side: README, DOCKER.md, AGENTS.md, getting-started, CLI reference, and the MCP catalog all show pip install 'athf[extra]', but the PyPI package is agentic-threat-hunting-framework. This updates them to the full name so copy-paste installs just work.

(Left the CHANGELOGs untouched since those are historical.)

Really enjoying the framework — thanks for building it!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation commands to use the full `agentic-threat-hunting-framework` package name.
  - Corrected optional dependency commands for ATT&CK, MCP, and supported LLM providers.
  - Updated CLI and integration guidance to reference the current published package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->