### PR TITLE
Fix default Anthropic model ID that 404s for new users

### DIFF
--- a/athf/core/llm_provider.py
+++ b/athf/core/llm_provider.py
@@ -165,10 +165,10 @@ class LiteLLMProvider(LLMProvider):
     imported lazily so it is only required when this provider is actually used.
 
     Args:
-        model: A litellm-compatible model string (e.g. ``"anthropic/claude-sonnet-4-5-20250514"``).
+        model: A litellm-compatible model string (e.g. ``"anthropic/claude-sonnet-4-5"``).
     """
 
-    def __init__(self, model: str = "anthropic/claude-sonnet-4-5-20250514"):
+    def __init__(self, model: str = "anthropic/claude-sonnet-4-5"):
         self.model = model
 
     @property
@@ -714,7 +714,7 @@ def create_provider(config: Optional[Dict[str, Any]] = None) -> LLMProvider:
 
     # Anthropic API key -> LiteLLM with anthropic prefix
     if os.getenv("ANTHROPIC_API_KEY"):
-        detected_model = model or "anthropic/claude-sonnet-4-5-20250514"
+        detected_model = model or "anthropic/claude-sonnet-4-5"
         logger.info("Auto-detected ANTHROPIC_API_KEY -> using LiteLLM provider with model %s", detected_model)
         return LiteLLMProvider(model=detected_model)
 
@@ -785,7 +785,7 @@ def _build_provider(name: str, model: Optional[str], config: Dict[str, Any]) -> 
         )
 
     if name == "litellm":
-        return LiteLLMProvider(model=model or "anthropic/claude-sonnet-4-5-20250514")
+        return LiteLLMProvider(model=model or "anthropic/claude-sonnet-4-5")
 
     if name == "bedrock":
         return BedrockProvider(

--- a/tests/core/test_llm_provider.py
+++ b/tests/core/test_llm_provider.py
@@ -48,7 +48,7 @@ class TestLiteLLMProvider:
         mock_litellm.completion.return_value = mock_response
 
         with patch.dict(sys.modules, {"litellm": mock_litellm}):
-            provider = LiteLLMProvider(model="anthropic/claude-sonnet-4-5-20250514")
+            provider = LiteLLMProvider(model="anthropic/claude-sonnet-4-5")
             result = provider.complete(
                 messages=[{"role": "user", "content": "Hi"}]
             )
@@ -56,12 +56,12 @@ class TestLiteLLMProvider:
         assert result.text == "LiteLLM response"
         assert result.input_tokens == 80
         assert result.output_tokens == 40
-        assert result.model == "anthropic/claude-sonnet-4-5-20250514"
+        assert result.model == "anthropic/claude-sonnet-4-5"
         assert provider.provider_name == "litellm"
 
         # Verify the request was built correctly
         mock_litellm.completion.assert_called_once_with(
-            model="anthropic/claude-sonnet-4-5-20250514",
+            model="anthropic/claude-sonnet-4-5",
             messages=[{"role": "user", "content": "Hi"}],
             max_tokens=4096,
             temperature=0.7,


### PR DESCRIPTION
Another one from the workshop trenches! The default LiteLLM model anthropic/claude-sonnet-4-5-20250514 is not a valid Anthropic model ID (Sonnet 4.5's dated ID is ...20250929), so anyone who sets ANTHROPIC_API_KEY without also setting ATHF_LLM_MODEL gets a NotFoundError on their first athf research run.

Swapped to the claude-sonnet-4-5 alias so it also will not go stale on a snapshot date. Provider tests pass (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)