### PR TITLE
Update MCP_CATALOG.md

### DIFF
--- a/integrations/MCP_CATALOG.md
+++ b/integrations/MCP_CATALOG.md
@@ -6,7 +6,7 @@ ATHF includes its own MCP server that exposes hunting operations as tools for an
 
 **Install:**
 ```bash
-pip install 'athf[mcp]'
+pip install 'agentic-threat-hunting-framework[mcp]'
 ```
 
 **Configure for Claude Code** (`~/.claude/mcp-servers.json`):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the built-in MCP server installation command to use the current package name and avoid the deprecated installation option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->