### PR TITLE
chore(llm): migrate default Claude model IDs to Sonnet 4.6

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -247,12 +247,12 @@ claude code "Review this Python function"
 ### Default Models
 
 Claude Code uses these Bedrock models by default:
-- **Primary:** `global.anthropic.claude-sonnet-4-5-20250929-v1:0`
+- **Primary:** `global.anthropic.claude-sonnet-4-6`
 - **Small/Fast:** `us.anthropic.claude-haiku-4-5-20251001-v1:0`
 
 To customize models, add to docker-compose.yml environment section:
 ```yaml
-- ANTHROPIC_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
+- ANTHROPIC_MODEL=global.anthropic.claude-sonnet-4-6
 - ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
 ```
 
@@ -269,7 +269,7 @@ athf research new --topic "Kerberoasting"
 **2. AWS CLI (direct Bedrock API, already installed):**
 ```bash
 aws bedrock-runtime invoke-model \
-    --model-id anthropic.claude-3-5-sonnet-20241022-v2:0 \
+    --model-id us.anthropic.claude-sonnet-4-6 \
     --body '{"anthropic_version":"bedrock-2023-05-31","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}' \
     --region us-east-1 output.json
 ```

--- a/athf/core/cost_tracker.py
+++ b/athf/core/cost_tracker.py
@@ -34,8 +34,8 @@ MODEL_PRICING: Dict[str, Dict[str, float]] = {
 def _normalize_bedrock_model_id(model: str) -> str:
     """Strip Bedrock provider prefixes and version suffixes.
 
-    Converts IDs like 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
-    into 'claude-sonnet-4-5-20250929' for further matching.
+    Converts IDs like 'us.anthropic.claude-sonnet-4-6'
+    into 'claude-sonnet-4-6' for further matching.
 
     Args:
         model: Raw model identifier string.
@@ -122,7 +122,7 @@ def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
 
     Args:
         model: Model identifier (e.g., "claude-sonnet-4", "gpt-4o",
-               or a full Bedrock ID like "us.anthropic.claude-sonnet-4-5-20250929-v1:0").
+               or a full Bedrock ID like "us.anthropic.claude-sonnet-4-6").
         input_tokens: Number of input (prompt) tokens.
         output_tokens: Number of output (completion) tokens.
 

--- a/athf/core/llm_provider.py
+++ b/athf/core/llm_provider.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 # Used as a best-effort fallback when the provider does not report cost.
 _MODEL_PRICING = {
     # Anthropic Claude via Bedrock / direct
+    "claude-sonnet-4-6": (0.003, 0.015),
     "claude-sonnet-4-5": (0.003, 0.015),
     "claude-sonnet-4-5-20250929": (0.003, 0.015),
     "claude-3-5-sonnet": (0.003, 0.015),
@@ -165,10 +166,10 @@ class LiteLLMProvider(LLMProvider):
     imported lazily so it is only required when this provider is actually used.
 
     Args:
-        model: A litellm-compatible model string (e.g. ``"anthropic/claude-sonnet-4-5-20250514"``).
+        model: A litellm-compatible model string (e.g. ``"anthropic/claude-sonnet-4-6"``).
     """
 
-    def __init__(self, model: str = "anthropic/claude-sonnet-4-5-20250514"):
+    def __init__(self, model: str = "anthropic/claude-sonnet-4-6"):
         self.model = model
 
     @property
@@ -252,7 +253,7 @@ class BedrockProvider(LLMProvider):
 
     def __init__(
         self,
-        model_id: str = "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        model_id: str = "us.anthropic.claude-sonnet-4-6",
         region: Optional[str] = None,
     ):
         self.model_id = model_id
@@ -714,7 +715,7 @@ def create_provider(config: Optional[Dict[str, Any]] = None) -> LLMProvider:
 
     # Anthropic API key -> LiteLLM with anthropic prefix
     if os.getenv("ANTHROPIC_API_KEY"):
-        detected_model = model or "anthropic/claude-sonnet-4-5-20250514"
+        detected_model = model or "anthropic/claude-sonnet-4-6"
         logger.info("Auto-detected ANTHROPIC_API_KEY -> using LiteLLM provider with model %s", detected_model)
         return LiteLLMProvider(model=detected_model)
 
@@ -748,7 +749,7 @@ def create_provider(config: Optional[Dict[str, Any]] = None) -> LLMProvider:
 
     # AWS credentials -> Bedrock
     if os.getenv("AWS_PROFILE") or os.getenv("AWS_ACCESS_KEY_ID"):
-        detected_model = model or "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        detected_model = model or "us.anthropic.claude-sonnet-4-6"
         logger.info("Auto-detected AWS credentials -> using Bedrock provider with model %s", detected_model)
         return BedrockProvider(
             model_id=detected_model,
@@ -785,11 +786,11 @@ def _build_provider(name: str, model: Optional[str], config: Dict[str, Any]) -> 
         )
 
     if name == "litellm":
-        return LiteLLMProvider(model=model or "anthropic/claude-sonnet-4-5-20250514")
+        return LiteLLMProvider(model=model or "anthropic/claude-sonnet-4-6")
 
     if name == "bedrock":
         return BedrockProvider(
-            model_id=model or "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            model_id=model or "us.anthropic.claude-sonnet-4-6",
             region=config.get("region"),
         )
 


### PR DESCRIPTION
## Summary

Migrates the framework's default Claude model IDs from Sonnet 4.5 / 4.0 / 3.5 to **Sonnet 4.6** (`us.anthropic.claude-sonnet-4-6`).

Covers all six provider defaults in `llm_provider.py` — `BedrockProvider`, `LiteLLMProvider`, their `detected_model` fallbacks, and both factory functions — plus docstrings and `DOCKER.md`.

## Why the pricing table changed

The 4.6 Bedrock ID carries **no date stamp and no `-v1:0` suffix**, unlike every ID it replaces (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`). Tables keyed on exact IDs or long prefixes can therefore silently fall through to a default rate.

An explicit `claude-sonnet-4-6` entry is **added** to `_MODEL_PRICING`. The existing 4.5 / 3.5 entries are deliberately **retained** — historical `events.jsonl` records must still price correctly. This is additive, not a substitution.

## Verification

- Live Bedrock probe: `invoke-model` with `us.anthropic.claude-sonnet-4-6` returns a valid completion, confirming the ID is reachable and not merely well-spelled.
- Cost resolution checked behaviorally: 4.6 → `$0.0105` per 1k in / 500 out; legacy 4.5 ID still → `$0.0105`.
- `pytest tests/core/test_cost_tracker.py tests/core/test_llm_provider.py` → **34 passed** (re-run after rebase onto `main`).
- Full suite shows 11 pre-existing failures (missing `scikit-learn`, hunt-ID generation, env info). Confirmed unrelated: stashing only these files reproduces the identical 11 failures, and none of those test files reference a model ID.

## Note

`cost_tracker.MODEL_PRICING` has no `claude-3-5-sonnet` key, so legacy 3.5 IDs price at `$0.0000`. Pre-existing and left as-is — adding a key would retroactively change how past 3.5-era records price. Now moot in practice, since no remaining caller uses 3.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support and pricing information for Claude Sonnet 4.6.
  - Updated default Claude models for LiteLLM and Amazon Bedrock integrations to Claude Sonnet 4.6.

- **Documentation**
  - Updated model references and AWS CLI examples to use Claude Sonnet 4.6.
  - Revised Bedrock model ID examples to reflect the current model format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->