### PR TITLE
fix(packaging): ship athf.metrics in built distributions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,10 @@ jobs:
 
     - name: Verify version matches tag
       run: |
-        # Extract version from pyproject.toml
-        PACKAGE_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-        # Extract version from git tag
+        # athf/__version__.py is the single source: pyproject.toml declares the version
+        # dynamic and reads this attribute, so this is also what ends up in the artifact
+        # metadata and what `athf --version` reports.
+        PACKAGE_VERSION=$(python -c "import runpy; print(runpy.run_path('athf/__version__.py')['__version__'])")
         TAG_VERSION=${GITHUB_REF#refs/tags/v}
         echo "Package version: $PACKAGE_VERSION"
         echo "Tag version: $TAG_VERSION"
@@ -48,6 +49,32 @@ jobs:
     - name: Check package with twine
       run: |
         twine check dist/*
+
+    - name: Verify the artifact ships and imports every subpackage
+      run: |
+        python scripts/verify_packaging.py --dist-dir dist --repo-root .
+
+    - name: Verify built artifact version matches tag
+      run: |
+        # The metadata check that twine check does not do: assert the version baked into
+        # the wheel filename is the one being released, not merely the one in the source.
+        TAG_VERSION=${GITHUB_REF#refs/tags/v}
+        python - "$TAG_VERSION" <<'PY'
+        import glob, pathlib, sys, zipfile
+
+        tag = sys.argv[1]
+        wheel = glob.glob("dist/*.whl")[0]
+        archive = zipfile.ZipFile(wheel)
+        metadata = next(n for n in archive.namelist() if n.endswith(".dist-info/METADATA"))
+        version = next(
+            line.split(":", 1)[1].strip()
+            for line in archive.read(metadata).decode().splitlines()
+            if line.startswith("Version:")
+        )
+        print(f"Wheel {pathlib.Path(wheel).name} declares version {version}; tag is {tag}")
+        if version != tag:
+            sys.exit(f"Built artifact version ({version}) does not match tag ({tag})")
+        PY
 
     - name: Publish to Test PyPI
       if: github.event.release.prerelease

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,59 +151,9 @@ jobs:
       run: |
         twine check dist/*
 
-    - name: Verify every source subpackage ships in the wheel
+    - name: Verify the artifact ships and imports every subpackage
       run: |
-        python - <<'PY'
-        import glob, pathlib, sys, zipfile
-
-        on_disk = {
-            str(p.parent).replace("/", ".")
-            for p in pathlib.Path("athf").rglob("__init__.py")
-        }
-        wheel = glob.glob("dist/*.whl")[0]
-        shipped = {
-            "/".join(n.split("/")[:-1]).replace("/", ".")
-            for n in zipfile.ZipFile(wheel).namelist()
-            if n.endswith("__init__.py")
-        }
-
-        missing = sorted(on_disk - shipped)
-        if missing:
-            print(f"Subpackages present in source but absent from {wheel}:")
-            for m in missing:
-                print(f"  - {m}")
-            sys.exit(1)
-        print(f"All {len(on_disk)} subpackages ship in the wheel.")
-        PY
-
-    - name: Import the built wheel in a clean environment
-      run: |
-        python -m venv /tmp/wheelcheck
-        /tmp/wheelcheck/bin/pip install --quiet dist/*.whl
-        # Names are collected here, inside the checkout, because the import must
-        # run from outside it: a stdin script puts the working directory first on
-        # sys.path, so running this from the repo root resolves athf against the
-        # source tree and passes even when the wheel ships nothing. The __file__
-        # assertion is what keeps the step from going hollow again.
-        python - <<'PY' > /tmp/subpackages.txt
-        import pathlib
-
-        for path in sorted(pathlib.Path("athf").rglob("__init__.py")):
-            print(str(path.parent).replace("/", "."))
-        PY
-        cd /tmp
-        /tmp/wheelcheck/bin/python - <<'PY'
-        import importlib, pathlib, sys
-
-        root = pathlib.Path("/tmp/wheelcheck").resolve()
-        names = pathlib.Path("/tmp/subpackages.txt").read_text().split()
-        for name in names:
-            module = importlib.import_module(name)
-            location = pathlib.Path(module.__file__).resolve()
-            if root not in location.parents:
-                sys.exit(f"{name} imported from {location}, not the installed wheel")
-        print(f"All {len(names)} subpackages import from the installed wheel.")
-        PY
+        python scripts/verify_packaging.py --dist-dir dist --repo-root .
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,12 +180,29 @@ jobs:
       run: |
         python -m venv /tmp/wheelcheck
         /tmp/wheelcheck/bin/pip install --quiet dist/*.whl
-        /tmp/wheelcheck/bin/python - <<'PY'
-        import importlib, pathlib
+        # Names are collected here, inside the checkout, because the import must
+        # run from outside it: a stdin script puts the working directory first on
+        # sys.path, so running this from the repo root resolves athf against the
+        # source tree and passes even when the wheel ships nothing. The __file__
+        # assertion is what keeps the step from going hollow again.
+        python - <<'PY' > /tmp/subpackages.txt
+        import pathlib
 
         for path in sorted(pathlib.Path("athf").rglob("__init__.py")):
-            importlib.import_module(str(path.parent).replace("/", "."))
-        print("Every subpackage imports from the installed wheel.")
+            print(str(path.parent).replace("/", "."))
+        PY
+        cd /tmp
+        /tmp/wheelcheck/bin/python - <<'PY'
+        import importlib, pathlib, sys
+
+        root = pathlib.Path("/tmp/wheelcheck").resolve()
+        names = pathlib.Path("/tmp/subpackages.txt").read_text().split()
+        for name in names:
+            module = importlib.import_module(name)
+            location = pathlib.Path(module.__file__).resolve()
+            if root not in location.parents:
+                sys.exit(f"{name} imported from {location}, not the installed wheel")
+        print(f"All {len(names)} subpackages import from the installed wheel.")
         PY
 
     - name: Upload build artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,6 +151,43 @@ jobs:
       run: |
         twine check dist/*
 
+    - name: Verify every source subpackage ships in the wheel
+      run: |
+        python - <<'PY'
+        import glob, pathlib, sys, zipfile
+
+        on_disk = {
+            str(p.parent).replace("/", ".")
+            for p in pathlib.Path("athf").rglob("__init__.py")
+        }
+        wheel = glob.glob("dist/*.whl")[0]
+        shipped = {
+            "/".join(n.split("/")[:-1]).replace("/", ".")
+            for n in zipfile.ZipFile(wheel).namelist()
+            if n.endswith("__init__.py")
+        }
+
+        missing = sorted(on_disk - shipped)
+        if missing:
+            print(f"Subpackages present in source but absent from {wheel}:")
+            for m in missing:
+                print(f"  - {m}")
+            sys.exit(1)
+        print(f"All {len(on_disk)} subpackages ship in the wheel.")
+        PY
+
+    - name: Import the built wheel in a clean environment
+      run: |
+        python -m venv /tmp/wheelcheck
+        /tmp/wheelcheck/bin/pip install --quiet dist/*.whl
+        /tmp/wheelcheck/bin/python - <<'PY'
+        import importlib, pathlib
+
+        for path in sorted(pathlib.Path("athf").rglob("__init__.py")):
+            importlib.import_module(str(path.parent).replace("/", "."))
+        print("Every subpackage imports from the installed wheel.")
+        PY
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/athf/__version__.py
+++ b/athf/__version__.py
@@ -1,3 +1,3 @@
 """Version information for ATHF."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,11 @@ Discussions = "https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/
 athf = "athf.cli:main"
 athf-mcp = "athf.mcp.server:cli"
 
-[tool.setuptools]
-packages = ["athf", "athf.agents", "athf.agents.llm", "athf.commands", "athf.core", "athf.data", "athf.mcp", "athf.mcp.tools", "athf.utils"]
+[tool.setuptools.packages.find]
+# Discovered rather than listed: an explicit list silently drops any new
+# subpackage from the built artifact, which is invisible to `pip install -e .`
+# and to `twine check`. That is how athf.metrics went unshipped in 0.15.0-0.18.0.
+include = ["athf*"]
 
 [tool.setuptools.package-data]
 "athf.data" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-threat-hunting-framework"
-version = "0.18.0"
+# Single-sourced from athf/__version__.py, which is also what `athf --version` reports.
+# Two literals could disagree, and the release pipeline only ever checked this one.
+dynamic = ["version"]
 description = "Agentic Threat Hunting Framework - Memory and AI for threat hunters"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"
@@ -126,6 +128,9 @@ Discussions = "https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/
 [project.scripts]
 athf = "athf.cli:main"
 athf-mcp = "athf.mcp.server:cli"
+
+[tool.setuptools.dynamic]
+version = {attr = "athf.__version__.__version__"}
 
 [tool.setuptools.packages.find]
 # Discovered rather than listed: an explicit list silently drops any new

--- a/scripts/verify_packaging.py
+++ b/scripts/verify_packaging.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Verify that a built distribution actually ships and imports every source subpackage.
+
+Runs three checks against the artifacts in a dist/ directory:
+
+1. Every subpackage present in the source tree is present in the wheel.
+2. Every one of those subpackages imports from the *installed* wheel, asserted via
+   ``__file__``, with the interpreter's working directory outside this checkout.
+3. The sdist carries the same subpackages as the wheel.
+
+Check 2 needs the ``__file__`` assertion and the foreign working directory together.
+A bare ``import athf.metrics`` run from the repo root resolves against the source tree
+because the working directory leads ``sys.path``, so it succeeds even when the wheel
+ships nothing at all. That is how the original version of this check passed for four
+releases while ``athf.metrics`` was missing from every published artifact.
+
+Used by both .github/workflows/tests.yml and .github/workflows/publish.yml so the
+artifact that ships to PyPI is held to the same bar as the artifact reviewed on a PR.
+"""
+
+import argparse
+import glob
+import os
+import pathlib
+import subprocess  # nosec B404
+import sys
+import tarfile
+import tempfile
+import zipfile
+
+PACKAGE_ROOT = "athf"
+
+
+def source_subpackages(repo_root):
+    """Return dotted names of every package in the source tree, e.g. ``athf.metrics``."""
+    root = repo_root / PACKAGE_ROOT
+    if not root.is_dir():
+        sys.exit(f"No {PACKAGE_ROOT}/ directory under {repo_root}; wrong working directory?")
+    return {".".join(path.parent.relative_to(repo_root).parts) for path in root.rglob("__init__.py")}
+
+
+def wheel_subpackages(wheel):
+    return {".".join(name.split("/")[:-1]) for name in zipfile.ZipFile(wheel).namelist() if name.endswith("__init__.py")}
+
+
+def sdist_subpackages(sdist):
+    """Dotted names inside an sdist, whose members are prefixed with ``<name>-<version>/``."""
+    names = set()
+    with tarfile.open(sdist) as archive:
+        for member in archive.getnames():
+            if not member.endswith("__init__.py"):
+                continue
+            parts = member.split("/")[1:-1]
+            if parts and parts[0] == PACKAGE_ROOT:
+                names.add(".".join(parts))
+    return names
+
+
+def only(pattern, dist_dir, label):
+    matches = sorted(glob.glob(str(dist_dir / pattern)))
+    if not matches:
+        sys.exit(f"No {label} found matching {dist_dir / pattern}")
+    if len(matches) > 1:
+        sys.exit(f"Expected exactly one {label} in {dist_dir}, found {len(matches)}: {matches}")
+    return matches[0]
+
+
+def report_missing(expected, actual, artifact, label):
+    missing = sorted(expected - actual)
+    if missing:
+        print(f"FAIL: subpackages in source but absent from {label} {pathlib.Path(artifact).name}:")
+        for name in missing:
+            print(f"  - {name}")
+        return False
+    print(f"OK: all {len(expected)} source subpackages ship in the {label}.")
+    return True
+
+
+def check_imports_from_wheel(wheel, expected):
+    """Install the wheel to a throwaway prefix and prove each module loads from it.
+
+    ``pip install --target`` rather than a venv: venv creation runs ``ensurepip``, which
+    is unavailable or broken on some managed interpreters, and the isolation a venv would
+    add is unnecessary here because the ``__file__`` assertion is what proves provenance.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = pathlib.Path(tmp).resolve()
+        target = tmp / "installed"
+        # A foreign working directory, so a source tree cannot satisfy the imports.
+        run_dir = tmp / "elsewhere"
+        run_dir.mkdir()
+
+        # Fixed argv, no shell; every path is derived locally, none from user input.
+        subprocess.run(  # nosec B603
+            [sys.executable, "-m", "pip", "install", "--quiet", "--target", str(target), str(wheel)],
+            check=True,
+        )
+
+        probe = """
+import importlib, pathlib, sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+names = sys.argv[2:]
+for name in names:
+    module = importlib.import_module(name)
+    location = pathlib.Path(module.__file__).resolve()
+    if root not in location.parents:
+        sys.exit("%s imported from %s, not the installed wheel" % (name, location))
+print("OK: all %d subpackages import from the installed wheel." % len(names))
+"""
+        env = dict(os.environ, PYTHONPATH=str(target))
+        # Keep the source tree out of reach even if the caller exported it.
+        env.pop("PYTHONHOME", None)
+        # Fixed argv, no shell; the module names come from the source tree, not user input.
+        result = subprocess.run(  # nosec B603
+            [sys.executable, "-c", probe, str(target), *sorted(expected)],
+            cwd=str(run_dir),
+            env=env,
+        )
+        return result.returncode == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dist-dir", default="dist", help="directory holding the built artifacts")
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="checkout whose source tree defines the expected set of subpackages",
+    )
+    parser.add_argument(
+        "--skip-import-check",
+        action="store_true",
+        help="run only the archive-content checks (no venv creation)",
+    )
+    args = parser.parse_args()
+
+    repo_root = pathlib.Path(args.repo_root).resolve()
+    dist_dir = pathlib.Path(args.dist_dir).resolve()
+
+    expected = source_subpackages(repo_root)
+    print(f"Source tree declares {len(expected)} subpackages under {PACKAGE_ROOT}/.")
+
+    wheel = only("*.whl", dist_dir, "wheel")
+    sdist = only("*.tar.gz", dist_dir, "sdist")
+
+    ok = report_missing(expected, wheel_subpackages(wheel), wheel, "wheel")
+    ok = report_missing(expected, sdist_subpackages(sdist), sdist, "sdist") and ok
+
+    if args.skip_import_check:
+        print("Skipping clean-environment import check (--skip-import-check).")
+    elif ok:
+        ok = check_imports_from_wheel(wheel, expected)
+    else:
+        print("Skipping import check: the archive already failed, fix that first.")
+
+    if not ok:
+        sys.exit(1)
+    print("Packaging verification passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,45 @@
+"""Tests for packaging declarations that CI alone would not catch until release time."""
+
+import pathlib
+import re
+
+import athf
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _project_table():
+    """Return the text of pyproject.toml's [project] table.
+
+    Parsed with a regex rather than tomllib because the test suite runs on Python 3.8,
+    where tomllib does not exist and no TOML library is a declared dependency.
+    """
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r"^\[project\]\s*$(.*?)^\[", text, re.MULTILINE | re.DOTALL)
+    assert match, "could not locate the [project] table in pyproject.toml"
+    return match.group(1)
+
+
+class TestVersionSingleSource:
+    """athf/__version__.py must be the only place the version is written."""
+
+    def test_pyproject_declares_version_dynamic(self):
+        assert re.search(r'^dynamic\s*=\s*\[[^\]]*"version"', _project_table(), re.MULTILINE), (
+            'pyproject.toml [project] must declare dynamic = ["version"] so the version ' "is read from athf/__version__.py"
+        )
+
+    def test_pyproject_has_no_literal_version(self):
+        assert not re.search(r'^version\s*=\s*"', _project_table(), re.MULTILINE), (
+            "pyproject.toml [project] must not pin a literal version; a second literal can "
+            "disagree with athf/__version__.py and the release pipeline only checks one"
+        )
+
+    def test_dynamic_version_points_at_the_version_module(self):
+        text = PYPROJECT.read_text(encoding="utf-8")
+        assert (
+            'version = {attr = "athf.__version__.__version__"}' in text
+        ), "[tool.setuptools.dynamic] must source the version from athf.__version__"
+
+    def test_version_is_pep440_release(self):
+        assert re.fullmatch(r"\d+\.\d+\.\d+", athf.__version__), f"unexpected version shape: {athf.__version__!r}"


### PR DESCRIPTION
## Problem

`athf.metrics` has never shipped in a published release. The source tree has had `athf/metrics/__init__.py` since 0.15.0, but `[tool.setuptools] packages` was an explicit list that omitted it, so setuptools silently excluded the directory from every built artifact.

Verified against every candidate wheel on PyPI:

| Version | `athf/metrics/` in wheel |
|---|---|
| 0.15.0 | ❌ |
| 0.15.1 | ❌ |
| 0.16.0 | ❌ |
| 0.17.0 | ❌ |
| 0.18.0 | ❌ |

```
$ pip install agentic-threat-hunting-framework==0.18.0
$ python -c "import athf.metrics"
ModuleNotFoundError: No module named 'athf.metrics'
```

## Why CI never caught it

Every test job installs with `pip install -e .`, which resolves imports against the source tree where the package is present. The build job runs `twine check`, which validates metadata rather than package contents. Nothing in CI has ever imported from a built artifact.

The first consumer to install through the published pin was hunt-vault CI, which fails at test collection on all four Python versions:

```
ERROR collecting tests/core/test_metrics_tracker_shim.py
E   ModuleNotFoundError: No module named 'athf.metrics'
!!!!!! Interrupted: 1 error during collection !!!!!!
Process completed with exit code 2
```

## Downstream impact

Wider than the one import. Three core modules import `athf.metrics` inside a `try`/`except`:

- `athf/agents/base.py:267` — `record_llm_call`
- `athf/commands/similar.py:122` — `record_similarity_search`
- `athf/core/web_search.py:167` — `record_web_search`

Because each is guarded, they degrade silently. LLM, web-search, and similarity-search auto-instrumentation has therefore been inert in every published release — no error, no events. `athf metrics` still advertises these as "Auto-instrumented" in its help text.

## Fix

Switch to package discovery so new subpackages are found rather than enumerated:

```toml
[tool.setuptools.packages.find]
include = ["athf*"]
```

Confirmed the discovered set is identical to the corrected explicit list, and diffed the rebuilt wheel against published 0.18.0: **exactly one file added (`athf/metrics/__init__.py`), nothing removed.**

## Regression guards

Two steps added to the `build` job:

1. **Source-vs-wheel parity** — compare every `__init__.py` in `athf/` against the built wheel, fail on any subpackage that does not ship.
2. **Clean-venv import** — install the wheel into a fresh venv and import each subpackage, catching packaged-but-unimportable regressions.

Both were validated in each direction — they fail against the pre-change configuration and pass after it:

```
Testing guard against the UNFIXED wheel:
  GUARD CORRECTLY FAILS -> missing: ['athf.metrics']

After fix:
  GUARD PASSES: all 10 subpackages ship
  Every subpackage imports from the installed wheel.
  hunt-vault's exact import line works: athf.metrics
```

## Release note

This fix only takes effect once published. Downstream consumers pinning `agentic-threat-hunting-framework>=0.15.0` for `athf.metrics` — including Nebulock-Inc/hunt-vault#116, which is currently red on this — stay broken until a release goes out. **A version bump and PyPI release are needed to unblock them.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated ATHF to version 0.19.0.

* **Bug Fixes**
  * Ensured all source subpackages are included in packaged builds.
  * Improved installation reliability by verifying that the complete package can be installed and imported successfully.

* **Build & Quality**
  * Added automated checks to detect missing package components before release.
  * Strengthened validation of built artifacts and version metadata to help ensure users receive complete, correctly versioned installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->