### PR TITLE
fix(ci): make the packaging guard bidirectional and catch single-quoted versions

### DIFF
--- a/scripts/verify_packaging.py
+++ b/scripts/verify_packaging.py
@@ -3,10 +3,11 @@
 
 Runs three checks against the artifacts in a dist/ directory:
 
-1. Every subpackage present in the source tree is present in the wheel.
+1. The wheel's subpackages match the source tree exactly -- nothing missing, and nothing
+   shipped that the source tree no longer contains.
 2. Every one of those subpackages imports from the *installed* wheel, asserted via
    ``__file__``, with the interpreter's working directory outside this checkout.
-3. The sdist carries the same subpackages as the wheel.
+3. The sdist is held to the same parity requirement as the wheel.
 
 Check 2 needs the ``__file__`` assertion and the foreign working directory together.
 A bare ``import athf.metrics`` run from the repo root resolves against the source tree
@@ -65,15 +66,27 @@ def only(pattern, dist_dir, label):
     return matches[0]
 
 
-def report_missing(expected, actual, artifact, label):
-    missing = sorted(expected - actual)
-    if missing:
-        print(f"FAIL: subpackages in source but absent from {label} {pathlib.Path(artifact).name}:")
-        for name in missing:
-            print(f"  - {name}")
-        return False
-    print(f"OK: all {len(expected)} source subpackages ship in the {label}.")
-    return True
+def report_parity(expected, actual, artifact, label):
+    """Require the artifact's subpackages to match the source tree exactly, both directions.
+
+    Checking only for absences would pass an artifact that still carries a package deleted
+    from the source tree -- a stale build directory is enough to produce one, and the
+    resulting archive ships code that no longer exists anywhere in the repo.
+    """
+    name = pathlib.Path(artifact).name
+    ok = True
+    for difference, phrasing in (
+        (expected - actual, "in source but absent from"),
+        (actual - expected, "shipped in but absent from the source tree of"),
+    ):
+        if difference:
+            print(f"FAIL: subpackages {phrasing} {label} {name}:")
+            for dotted in sorted(difference):
+                print(f"  - {dotted}")
+            ok = False
+    if ok:
+        print(f"OK: the {label} carries exactly the {len(expected)} subpackages in the source tree.")
+    return ok
 
 
 def check_imports_from_wheel(wheel, expected):
@@ -144,8 +157,8 @@ def main():
     wheel = only("*.whl", dist_dir, "wheel")
     sdist = only("*.tar.gz", dist_dir, "sdist")
 
-    ok = report_missing(expected, wheel_subpackages(wheel), wheel, "wheel")
-    ok = report_missing(expected, sdist_subpackages(sdist), sdist, "sdist") and ok
+    ok = report_parity(expected, wheel_subpackages(wheel), wheel, "wheel")
+    ok = report_parity(expected, sdist_subpackages(sdist), sdist, "sdist") and ok
 
     if args.skip_import_check:
         print("Skipping clean-environment import check (--skip-import-check).")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -30,7 +30,9 @@ class TestVersionSingleSource:
         )
 
     def test_pyproject_has_no_literal_version(self):
-        assert not re.search(r'^version\s*=\s*"', _project_table(), re.MULTILINE), (
+        # Both quote styles: TOML accepts 'x' as readily as "x", and a single-quoted
+        # literal would reintroduce the second version source this test exists to prevent.
+        assert not re.search(r"^version\s*=\s*['\"]", _project_table(), re.MULTILINE), (
             "pyproject.toml [project] must not pin a literal version; a second literal can "
             "disagree with athf/__version__.py and the release pipeline only checks one"
         )


### PR DESCRIPTION
Closes the two gaps CodeRabbit found in the packaging guard that #54 added. Both were reproduced against real artifacts before being fixed, and both fixes were verified with negative controls.

## 1. The subpackage check was one-directional

`report_missing` compared only `expected - actual`, so an artifact could ship a package that no longer exists in the source tree and still pass. A stale `build/` or `*.egg-info` is enough to produce exactly that archive.

Reproduced by adding `athf/ghostpkg`, building, then deleting it from source. Running **this branch's** guard against those artifacts:

```
Source tree declares 10 subpackages under athf/.
FAIL: subpackages shipped in but absent from the source tree of wheel ...-0.19.0-py3-none-any.whl:
  - athf.ghostpkg
FAIL: subpackages shipped in but absent from the source tree of sdist ...-0.19.0.tar.gz:
  - athf.ghostpkg
EXIT=1
```

Running **`main`'s** guard against the *same* artifacts — this is the gap:

```
OK: all 10 subpackages import from the installed wheel.
OK: all 10 source subpackages ship in the wheel.
OK: all 10 source subpackages ship in the sdist.
Packaging verification passed.
EXIT=0
```

`report_parity` now reports both differences and fails on either.

The original direction still works — reverting `include = ["athf*"]` to the old explicit list:

```
FAIL: subpackages in source but absent from wheel ...:
  - athf.metrics
FAIL: subpackages in source but absent from sdist ...:
  - athf.metrics
EXIT=1
```

## 2. The no-literal-version test matched only double quotes

`version = '0.19.0'` is valid TOML and restored a second version source with all four tests still green.

With a single-quoted literal injected, **this branch**:

```
FAILED tests/test_packaging.py::TestVersionSingleSource::test_pyproject_has_no_literal_version
2 failed, 2 passed
```

**`main`'s** test against the same injected literal:

```
1 passed, 3 deselected
```

The character class is now `['\"]`, so both quote styles are rejected.

## Verification summary

| Control | Expected | Result |
|---|---|---|
| Clean build | exit 0 | 0 — "carries exactly the 10 subpackages" for wheel + sdist, imports from installed wheel |
| Stale package in artifact | exit 1 | 1, names `athf.ghostpkg` in wheel and sdist |
| Package missing from artifact | exit 1 | 1, names `athf.metrics` in wheel and sdist |
| `tests/test_packaging.py` unmodified | 4 pass | 4 passed |
| Single-quoted version literal | test fails | fails |
| Double-quoted version literal | test fails | fails |

black (`--line-length=127`), isort, flake8, and bandit are all clean on both files.

## Why this is a follow-up rather than part of #54

These fixes were ready before #54 merged, but pushing them would have dismissed the live approval (`dismiss_stale_reviews_on_push: true`) and `require_last_push_approval: true` meant the re-push could not be self-approved. Since the remaining blind spot only mis-reports a *stale* package — strictly narrower than the missing-package bug #54 fixed — it was held back to avoid delaying the 0.19.0 packaging fix.

No behavior change to the shipped package: this touches only `scripts/verify_packaging.py` (not shipped in either artifact) and `tests/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package verification to detect missing or unexpectedly included packages in both wheel and source distributions.
  * Enhanced packaging reports to clearly identify mismatches and confirm successful validation.
  * Updated packaging tests to catch version declarations using either single or double quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->