### PR TITLE
chore(athf): raise Python floor to 3.11 so the attack extra installs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
 # Zero out inherited GITHUB_TOKEN defaults; each job grants only what it needs.
 permissions: {}
 
+# Serialize per release tag: a PyPI upload must never be cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   build-and-publish:
     name: Build and Publish to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+# Zero out inherited GITHUB_TOKEN defaults; each job grants only what it needs.
+permissions: {}
+
 jobs:
   build-and-publish:
     name: Build and Publish to PyPI
@@ -103,6 +106,9 @@ jobs:
     name: Publish Docker Image (Optional)
     runs-on: ubuntu-latest
     if: false  # Disabled for now - enable if you want Docker support
+
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,11 @@ on:
 # Zero out inherited GITHUB_TOKEN defaults; each job grants only what it needs.
 permissions: {}
 
+# A newer push obsoletes the older 3-OS x 3-Python matrix, so cancel it rather than pay for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test on ${{ matrix.os }} - Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        exclude:
-          # Optional: Reduce matrix size by excluding some combinations
-          - os: macos-latest
-            python-version: '3.8'
-          - os: windows-latest
-            python-version: '3.8'
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - name: Checkout code
@@ -72,10 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 3.11+ only: the "all" extra pulls mitreattack-python>=5.0.0, which
-        # declares Requires-Python >=3.11, so ".[dev,all]" cannot resolve on
-        # 3.8-3.10 even though pyproject still allows those interpreters.
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+# Zero out inherited GITHUB_TOKEN defaults; each job grants only what it needs.
+permissions: {}
+
 jobs:
   test:
     name: Test on ${{ matrix.os }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -62,6 +67,8 @@ jobs:
   test-extras:
     name: Test with optional extras - Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -98,6 +105,8 @@ jobs:
   validate-hunts:
     name: Validate Hunt Examples
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code
@@ -125,6 +134,8 @@ jobs:
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code
@@ -160,6 +171,8 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/agentic-threat-hunting-framework)](https://pypi.org/project/agentic-threat-hunting-framework/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/agentic-threat-hunting-framework)](https://pypi.org/project/agentic-threat-hunting-framework/)
-[![Python Version](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/Nebulock-Inc/agentic-threat-hunting-framework?style=social)](https://github.com/Nebulock-Inc/agentic-threat-hunting-framework/stargazers)
 
@@ -247,7 +247,7 @@ Watch ATHF in action: initialize a workspace, create hunts, and explore your thr
 See the [Quick Start](#-quick-start) section above for installation options (PyPI, source, or pure markdown).
 
 **Prerequisites:**
-- Python 3.8-3.13 (for CLI option)
+- Python 3.11-3.13 (for CLI option)
 - Your favorite AI code assistant
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Watch ATHF in action: initialize a workspace, create hunts, and explore your thr
 See the [Quick Start](#-quick-start) section above for installation options (PyPI, source, or pure markdown).
 
 **Prerequisites:**
-- Python 3.11-3.13 (for CLI option)
+- Python 3.11 or higher (for CLI option)
 - Your favorite AI code assistant
 
 ## Documentation

--- a/athf/data/__init__.py
+++ b/athf/data/__init__.py
@@ -1,12 +1,7 @@
 """ATHF reference data and templates."""
 
-import sys
+from importlib.resources import files
 from pathlib import Path
-
-if sys.version_info >= (3, 9):
-    from importlib.resources import files
-else:
-    from importlib_resources import files  # type: ignore[import-not-found,no-redef]
 
 
 def get_data_path() -> Path:

--- a/athf/data/docs/CLI_REFERENCE.md
+++ b/athf/data/docs/CLI_REFERENCE.md
@@ -2369,7 +2369,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - run: pip install agentic-threat-hunting-framework
       - run: athf hunt validate
 ```

--- a/athf/data/docs/INSTALL.md
+++ b/athf/data/docs/INSTALL.md
@@ -435,8 +435,11 @@ If all commands work, you're ready to go!
 
 3. Add to PATH:
    ```bash
-   # macOS/Linux (add to ~/.zshrc or ~/.bashrc)
+   # macOS (add to ~/.zshrc or ~/.bashrc)
    export PATH="$HOME/Library/Python/3.11/bin:$PATH"
+
+   # Linux
+   export PATH="$HOME/.local/bin:$PATH"
 
    # Windows (use System Properties > Environment Variables)
    ```

--- a/athf/data/docs/INSTALL.md
+++ b/athf/data/docs/INSTALL.md
@@ -33,7 +33,7 @@ athf init
 ```
 
 **Requirements**:
-- Python 3.8 or higher
+- Python 3.11 or higher
 - pip (comes with Python)
 
 **Virtual Environment (Recommended)**:
@@ -304,7 +304,7 @@ athf hunt list --status completed --output json | \
 
 ATHF includes a GitHub Actions workflow ([.github/workflows/tests.yml](../../../.github/workflows/tests.yml)) that runs:
 
-- Tests across Python 3.8-3.12 on Ubuntu, macOS, Windows
+- Tests across Python 3.11-3.13 on Ubuntu, macOS, Windows
 - Linting with flake8
 - Type checking with mypy
 - Hunt validation
@@ -316,7 +316,7 @@ Customize the workflow for your organization's needs.
 
 All tools are configured in `pyproject.toml`:
 
-- **Black**: Line length 127, targets Python 3.8-3.12
+- **Black**: Line length 127, targets Python 3.11-3.13
 - **isort**: Black-compatible profile
 - **mypy**: Strict type checking enabled
 - **pytest**: Test discovery, coverage reporting
@@ -436,7 +436,7 @@ If all commands work, you're ready to go!
 3. Add to PATH:
    ```bash
    # macOS/Linux (add to ~/.zshrc or ~/.bashrc)
-   export PATH="$HOME/Library/Python/3.9/bin:$PATH"
+   export PATH="$HOME/Library/Python/3.11/bin:$PATH"
 
    # Windows (use System Properties > Environment Variables)
    ```
@@ -465,7 +465,7 @@ python --version
 
 ### "ERROR: Could not find a version that satisfies the requirement"
 
-**Cause**: Python version too old (< 3.8).
+**Cause**: Python version too old (< 3.11).
 
 **Solution**:
 
@@ -473,7 +473,7 @@ python --version
 # Check Python version
 python --version
 
-# Upgrade Python to 3.8 or higher
+# Upgrade Python to 3.11 or higher
 # - macOS: brew install python3
 # - Linux: sudo apt install python3.11
 # - Windows: Download from python.org
@@ -587,7 +587,7 @@ After installation:
 
 ## System Requirements
 
-- **Python**: 3.8 or higher
+- **Python**: 3.11 or higher
 - **OS**: macOS, Linux, or Windows
 - **Disk Space**: ~5 MB for package, more for your hunt data
 - **Memory**: Minimal (< 50 MB)

--- a/athf/data/docs/INSTALL.md
+++ b/athf/data/docs/INSTALL.md
@@ -436,7 +436,7 @@ If all commands work, you're ready to go!
 3. Add to PATH:
    ```bash
    # macOS (add to ~/.zshrc or ~/.bashrc)
-   export PATH="$HOME/Library/Python/3.11/bin:$PATH"
+   export PATH="$(python3 -m site --user-base)/bin:$PATH"
 
    # Linux
    export PATH="$HOME/.local/bin:$PATH"

--- a/athf/mcp/server.py
+++ b/athf/mcp/server.py
@@ -8,7 +8,6 @@ Usage:
 
 import json
 import logging
-import sys
 from pathlib import Path
 from typing import Any, Optional
 
@@ -50,14 +49,9 @@ def _json_result(data: Any) -> str:
 
 def _discover_plugin_tools() -> list:
     """Discover MCP tool registration functions from installed plugins."""
-    if sys.version_info >= (3, 10):
-        from importlib.metadata import entry_points
+    from importlib.metadata import entry_points
 
-        return list(entry_points(group="athf.mcp_tools"))
-    else:
-        from importlib.metadata import entry_points
-
-        return list(entry_points().get("athf.mcp_tools", []))
+    return list(entry_points(group="athf.mcp_tools"))
 
 
 def create_server(workspace_path: Optional[str] = None) -> "FastMCP":  # type: ignore[name-defined]  # noqa: F821

--- a/athf/plugin_system.py
+++ b/athf/plugin_system.py
@@ -1,19 +1,9 @@
 """Plugin system for ATHF extensions."""
 
-import sys
+from importlib.metadata import entry_points
 from typing import Any, Dict, Optional, Type
 
 from click import Command
-
-# Handle importlib.metadata API changes across Python versions
-if sys.version_info >= (3, 10):
-    from importlib.metadata import entry_points
-else:
-    # Python 3.8-3.9: use importlib_metadata backport API
-    try:
-        from importlib.metadata import entry_points
-    except ImportError:
-        from importlib_metadata import entry_points  # type: ignore
 
 
 class PluginRegistry:
@@ -46,11 +36,7 @@ class PluginRegistry:
     def load_plugins(cls) -> None:
         """Auto-discover and load all installed plugins."""
         try:
-            # Python 3.10+ uses group= parameter, 3.8-3.9 uses dict-like access
-            if sys.version_info >= (3, 10):
-                eps = entry_points(group="athf.commands")
-            else:
-                eps = entry_points().get("athf.commands", [])
+            eps = entry_points(group="athf.commands")
 
             for ep in eps:
                 command = ep.load()
@@ -59,11 +45,7 @@ class PluginRegistry:
             pass  # No plugins installed yet
 
         try:
-            # Python 3.10+ uses group= parameter, 3.8-3.9 uses dict-like access
-            if sys.version_info >= (3, 10):
-                eps = entry_points(group="athf.agents")
-            else:
-                eps = entry_points().get("athf.agents", [])
+            eps = entry_points(group="athf.agents")
 
             for ep in eps:
                 agent = ep.load()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tests/core/test_envelope.py` — full coverage of both gates, the threshold boundary, metadata pass-through, error cases, and idempotent absolute-path output.
 
 ### Changed
+- **BREAKING: minimum supported Python is now 3.11** (`requires-python` raised from `>=3.8`). `pip install 'agentic-threat-hunting-framework[attack]'` could never resolve on 3.8–3.10: the `attack` extra requires `mitreattack-python>=5.0.0`, which declares `Requires-Python >=3.11`. No pin recovers 3.8/3.9 — the `MitreAttackData` API that `athf/core/attack_matrix.py` imports does not exist in the versions those interpreters can install. CI, mypy, and Black targets move to 3.11–3.13 to match. Users on 3.10 or older must upgrade; 3.8 and 3.9 are already EOL.
 - `athf_agent_run_hypothesis` MCP response (PR #30 shape) now carries the contract's core fields (`preview`, `path`, `byte_count`) **in addition to** its existing fields (`research_id`, `file_path`, `hypothesis_preview`, `mitre_techniques`, `data_sources`, `persisted`, `metadata`). PR #30's regression test (`tests/core/test_research_manager_hypothesis.py`) passes unchanged. The shape is now described as a strict superset of the contract.
 
 ### Notes

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2496,7 +2496,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - run: pip install agentic-threat-hunting-framework
       - run: athf hunt validate
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -435,8 +435,11 @@ If all commands work, you're ready to go!
 
 3. Add to PATH:
    ```bash
-   # macOS/Linux (add to ~/.zshrc or ~/.bashrc)
+   # macOS (add to ~/.zshrc or ~/.bashrc)
    export PATH="$HOME/Library/Python/3.11/bin:$PATH"
+
+   # Linux
+   export PATH="$HOME/.local/bin:$PATH"
 
    # Windows (use System Properties > Environment Variables)
    ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -436,7 +436,7 @@ If all commands work, you're ready to go!
 3. Add to PATH:
    ```bash
    # macOS/Linux (add to ~/.zshrc or ~/.bashrc)
-   export PATH="$HOME/Library/Python/3.9/bin:$PATH"
+   export PATH="$HOME/Library/Python/3.11/bin:$PATH"
 
    # Windows (use System Properties > Environment Variables)
    ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -436,7 +436,7 @@ If all commands work, you're ready to go!
 3. Add to PATH:
    ```bash
    # macOS (add to ~/.zshrc or ~/.bashrc)
-   export PATH="$HOME/Library/Python/3.11/bin:$PATH"
+   export PATH="$(python3 -m site --user-base)/bin:$PATH"
 
    # Linux
    export PATH="$HOME/.local/bin:$PATH"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -33,7 +33,7 @@ athf init
 ```
 
 **Requirements**:
-- Python 3.8 or higher
+- Python 3.11 or higher
 - pip (comes with Python)
 
 **Virtual Environment (Recommended)**:
@@ -304,7 +304,7 @@ athf hunt list --status completed --output json | \
 
 ATHF includes a GitHub Actions workflow ([.github/workflows/tests.yml](../.github/workflows/tests.yml)) that runs:
 
-- Tests across Python 3.8-3.12 on Ubuntu, macOS, Windows
+- Tests across Python 3.11-3.13 on Ubuntu, macOS, Windows
 - Linting with flake8
 - Type checking with mypy
 - Hunt validation
@@ -316,7 +316,7 @@ Customize the workflow for your organization's needs.
 
 All tools are configured in `pyproject.toml`:
 
-- **Black**: Line length 127, targets Python 3.8-3.12
+- **Black**: Line length 127, targets Python 3.11-3.13
 - **isort**: Black-compatible profile
 - **mypy**: Strict type checking enabled
 - **pytest**: Test discovery, coverage reporting
@@ -465,7 +465,7 @@ python --version
 
 ### "ERROR: Could not find a version that satisfies the requirement"
 
-**Cause**: Python version too old (< 3.8).
+**Cause**: Python version too old (< 3.11).
 
 **Solution**:
 
@@ -473,7 +473,7 @@ python --version
 # Check Python version
 python --version
 
-# Upgrade Python to 3.8 or higher
+# Upgrade Python to 3.11 or higher
 # - macOS: brew install python3
 # - Linux: sudo apt install python3.11
 # - Windows: Download from python.org
@@ -587,7 +587,7 @@ After installation:
 
 ## System Requirements
 
-- **Python**: 3.8 or higher
+- **Python**: 3.11 or higher
 - **OS**: macOS, Linux, or Windows
 - **Disk Space**: ~5 MB for package, more for your hunt data
 - **Memory**: Minimal (< 50 MB)

--- a/integrations/quickstart/splunk-api.md
+++ b/integrations/quickstart/splunk-api.md
@@ -19,7 +19,7 @@ This guide shows how to use ATHF's built-in Splunk REST API client for direct qu
 ## Prerequisites
 
 - Splunk Enterprise 8.0+ or Splunk Cloud
-- Python 3.8+
+- Python 3.11+
 - ATHF installed with dependencies
 
 ## Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "agentic-threat-hunting-framework"
 dynamic = ["version"]
 description = "Agentic Threat Hunting Framework - Memory and AI for threat hunters"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [
     {name = "Sydney Marrone", email = "athf@nebulock.io"}
@@ -37,9 +37,6 @@ classifiers = [
     "Topic :: System :: Monitoring",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -52,7 +49,6 @@ dependencies = [
     "rich>=10.0.0",
     "jinja2>=3.0.0",
     "python-dotenv>=0.19.0",
-    "importlib_resources>=5.0.0; python_version < '3.9'",
 ]
 
 [project.optional-dependencies]
@@ -154,7 +150,7 @@ include = ["athf*"]
 
 [tool.black]
 line-length = 127
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py311', 'py312', 'py313']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -181,7 +177,7 @@ use_parentheses = true
 ensure_newline_before_comments = true
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -7,13 +7,21 @@ import athf
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _minor(version):
+    """Return the 3.x minor number from a '3.x' string, or None if it isn't one."""
+    match = re.fullmatch(r"3\.(\d+)", version.strip())
+    return int(match.group(1)) if match else None
 
 
 def _project_table():
     """Return the text of pyproject.toml's [project] table.
 
-    Parsed with a regex rather than tomllib because callers assert against the raw
-    text of the table, including formatting tomllib would discard.
+    A regex slice rather than tomllib: these callers assert against the literal
+    text so a change in quote style or key placement stays visible, and a targeted
+    text check is simpler than parsing the file to inspect a handful of lines.
     """
     text = PYPROJECT.read_text(encoding="utf-8")
     match = re.search(r"^\[project\]\s*$(.*?)^\[", text, re.MULTILINE | re.DOTALL)
@@ -45,3 +53,55 @@ class TestVersionSingleSource:
 
     def test_version_is_pep440_release(self):
         assert re.fullmatch(r"\d+\.\d+\.\d+", athf.__version__), f"unexpected version shape: {athf.__version__!r}"
+
+
+class TestPythonSupportFloorIsConsistent:
+    """The declared Python floor must agree across metadata, classifiers, and CI.
+
+    #47 shipped because requires-python claimed >=3.8 while the classifiers, the
+    attack extra's transitive floor, and the test-extras matrix had already moved
+    on. Each surface was internally valid, so nothing failed until an install on a
+    real old interpreter. These assertions pin every surface to one floor offline.
+    """
+
+    def test_requires_python_declares_a_lower_bound(self):
+        match = re.search(r'^requires-python\s*=\s*"([^"]+)"', _project_table(), re.MULTILINE)
+        assert match, "pyproject.toml [project] must declare requires-python"
+        floor = re.search(r">=\s*3\.(\d+)", match.group(1))
+        assert floor, f"requires-python must set a >=3.x lower bound, got {match.group(1)!r}"
+
+    def _requires_python_floor(self):
+        match = re.search(r">=\s*3\.(\d+)", _project_table())
+        return int(match.group(1))
+
+    def _classifier_minors(self):
+        return sorted(int(m) for m in re.findall(r'"Programming Language :: Python :: 3\.(\d+)"', _project_table()))
+
+    def test_floor_matches_lowest_classifier(self):
+        classifiers = self._classifier_minors()
+        assert classifiers, "pyproject.toml must list Programming Language :: Python :: 3.x classifiers"
+        assert self._requires_python_floor() == classifiers[0], (
+            f"requires-python floor 3.{self._requires_python_floor()} must equal the lowest "
+            f"Python classifier 3.{classifiers[0]}; a mismatch is exactly the #47 bug"
+        )
+
+    def _matrix_minors(self, workflow):
+        text = (WORKFLOWS / workflow).read_text(encoding="utf-8")
+        found = set()
+        for block in re.findall(r"python-version:\s*\[([^\]]+)\]", text):
+            found.update(m for m in (_minor(v.strip(" '\"")) for v in block.split(",")) if m is not None)
+        for single in re.findall(r"python-version:\s*['\"]?(3\.\d+)['\"]?\s*$", text, re.MULTILINE):
+            m = _minor(single)
+            if m is not None:
+                found.add(m)
+        return sorted(found)
+
+    def test_floor_matches_ci_matrix_minimums(self):
+        floor = self._requires_python_floor()
+        for workflow in ("tests.yml", "publish.yml"):
+            minors = self._matrix_minors(workflow)
+            assert minors, f"{workflow} must pin at least one python-version"
+            assert min(minors) == floor, (
+                f"{workflow} tests 3.{min(minors)} as its lowest Python but requires-python "
+                f"floor is 3.{floor}; CI must exercise the declared floor"
+            )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -12,8 +12,8 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 def _project_table():
     """Return the text of pyproject.toml's [project] table.
 
-    Parsed with a regex rather than tomllib because the test suite runs on Python 3.8,
-    where tomllib does not exist and no TOML library is a declared dependency.
+    Parsed with a regex rather than tomllib because callers assert against the raw
+    text of the table, including formatting tomllib would discard.
     """
     text = PYPROJECT.read_text(encoding="utf-8")
     match = re.search(r"^\[project\]\s*$(.*?)^\[", text, re.MULTILINE | re.DOTALL)


### PR DESCRIPTION
Implements **option A** from #47 — floor at Python 3.11.

## The problem

`pip install 'athf[attack]'` — a documented install path in the README — failed on Python 3.8, 3.9, and 3.10, three of the five interpreters `requires-python` claimed and CI built. The `attack` extra pins `mitreattack-python>=5.0.0`, which declares `Requires-Python >=3.11`, so the resolver had nothing to select.

## Why 3.11 and not 3.10

No pin recovers 3.8/3.9 — `mitreattack-python` moved its floor to `>=3.10` at 2.1.0, and the `MitreAttackData` API `athf/core/attack_matrix.py` imports doesn't exist below that. Only 3.10 was recoverable, by relaxing to `>=4.0.0`. Two reasons I didn't:

1. Only 4.0.0–4.0.2 exist. A resolver on 3.10 would land on a two-year-old release with no security-fix path while 3.11+ users get 6.x.
2. 5.x changed STIX return types from raw dicts to typed `Technique`/`Tactic` wrappers. `StixProvider` reads results as dicts (`stix_tactic.get("x_mitre_shortname", "")`). Supporting 4.x and 6.x means both shapes must keep working — and `StixProvider` currently has **zero** test coverage, so nothing would catch a break.

That trades ~14 months of 3.10 support for an untested dual-API surface. 3.8 and 3.9 are already EOL; 3.10 follows in October 2026.

## Changes

- `requires-python` `>=3.8` → `>=3.11`; drop the 3.8/3.9/3.10 classifiers (these are what PyPI shows users)
- mypy `python_version` `3.9` → `3.11` — current mypy rejected the old value outright
- black `target-version` → `['py311', 'py312', 'py313']`
- CI matrix → `['3.11', '3.12', '3.13']`; drop the now-dead 3.8 `exclude:` block and the `test-extras` comment explaining the 3.11-only workaround, which is no longer a workaround
- drop the `importlib_resources` backport dep and its branch in `athf/data/__init__.py`, plus the `importlib.metadata` version branches in `athf/plugin_system.py` — all dead above 3.10
- README badge and `docs/INSTALL.md` version claims (5 sites)

`docs/CHANGELOG.md` 3.8 entries left alone — accurate history. `all` at `pyproject.toml:118` needs no pin change under A.

## Verification

- **349 tests pass.** 4 failures (`test_env_info_shows_info`, 3 × `TestSimilar`) reproduce on clean `main` at 31b9e8a — pre-existing, unrelated.
- **mypy clean**, 49 source files, and the `Python 3.9 is not supported` warning is gone.
- **flake8** critical selectors: 0.
- **Wheel + sdist** pass `twine check` with `Requires-Python: >=3.11` and no `importlib_resources` in `Requires-Dist`.
- **The actual bug is fixed:** `pip install '<wheel>[attack]'` resolves in a clean venv, `from mitreattack.stix20 import MitreAttackData` imports, and `athf attack status` runs.

## Not in this PR

While verifying, I found `athf/core/attack_matrix.py:281` passes `stix_tactic["id"]` (a STIX UUID) as the `tactic_shortname` argument to `get_techniques_by_tactic()`. The library filters on `kill_chain_phases.phase_name`, which never matches a UUID, so every tactic's `technique_count` is silently `0` under the STIX provider — `athf hunt coverage` under-reports whenever `[attack]` is installed with STIX data present. Unrelated to support policy and wants a `StixProvider` test alongside the fix, so it shouldn't ride along here. Noted in #47 for separate filing.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * The project now requires Python 3.11 or newer; Python 3.8–3.10 are no longer supported.
  * Plugin discovery uses the modern Python entry-point interface.

* **Documentation**
  * Updated installation instructions, requirements, troubleshooting guidance, integration prerequisites, and examples for Python 3.11+.
  * Documented the compatibility change in the changelog.

* **Quality**
  * Automated testing now covers Python 3.11–3.13.
  * Improved CI and publishing permission controls and release handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->