### PR TITLE
feat(athf): five-verdict ladder with evidence & provenance gate (v0.20.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,7 +577,7 @@ athf hunt new \
   --behavior "Shell execution from unusual parents performing reconnaissance..." \
   --location "macOS endpoints (developer workstations)..." \
   --evidence "EDR process telemetry - Fields: process.name, parent.process.name..." \
-  --hunter "Your Name" \
+  --hunter "Sydney Marrone" \
   --non-interactive
 ```
 
@@ -595,7 +595,7 @@ athf hunt new \
 - `--location` - Location/scope (for ABLE framework)
 - `--evidence` - Evidence description (for ABLE framework)
 - `--research` - Research document ID (e.g., R-0001) to link to hunt
-- `--hunter` - Hunter name (default: "AI Assistant")
+- `--hunter` - Hunter name. Falls back to the `hunter` key in `.athfconfig.yaml`, and if neither is set the field is left visibly unfilled rather than filled with a name nobody chose. **Never put your own name here on an AI assistant's behalf, and never carry the unfilled marker into `attested_by`** — attestation names the person answerable for out-of-corpus work, so it is refused.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,7 +579,7 @@ athf hunt new \
   --behavior "Shell execution from unusual parents performing reconnaissance..." \
   --location "macOS endpoints (developer workstations)..." \
   --evidence "EDR process telemetry - Fields: process.name, parent.process.name..." \
-  --hunter "Sydney Marrone" \
+  --hunter "Your Name" \
   --non-interactive
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,7 @@ This repository follows the **LOCK pattern**:
 | Aspect | Hunts (H-XXXX) | Investigations (I-XXXX) |
 |--------|----------------|-------------------------|
 | **Purpose** | Hypothesis-driven hunting | Exploratory analysis |
-| **Metrics** | Tracked (TP/FP/costs) | **NOT tracked** |
+| **Metrics** | Tracked (per-verdict counts, costs) | **NOT tracked** |
 | **Directory** | `hunts/` | `investigations/` |
 | **Validation** | Strict (CI/CD enforced) | Lightweight |
 
@@ -311,6 +311,49 @@ Query syntax, field naming, and performance optimization vary by data source. Re
 - **Capture negative results** - Hunts that found nothing are still valuable
 - **Record lessons learned** - What worked, what didn't, what to try next
 - **Link related hunts** - Reference past work
+
+---
+
+## Verdicts: How to Classify What You Found
+
+Every result gets one of five verdicts. `TP` / `FP` is no longer sufficient — it collapses "the attack happened and our control stopped it" together with "the thing wasn't there," and those are different answers.
+
+| Verdict | Assign when | Goes in |
+|---------|-------------|---------|
+| `confirmed` | Telemetry evidence **plus** independent confirmation outside the log corpus | `findings` |
+| `suspected` | Telemetry evidence only — you could not independently confirm | `findings` |
+| `attempted_not_vulnerable` | Attack behavior observed and the control demonstrably held (**name the control**) | `ruled_out` |
+| `benign` | Explained by specific legitimate activity | `ruled_out` |
+| `inconclusive` | Telemetry too sparse or missing to decide (**name the field/source**) | `ruled_out` |
+
+### 🚨 The Evidence Gate — Non-Negotiable
+
+**Query results are not confirmation.** You MUST NOT write `verdict: confirmed` on the strength of telemetry alone, no matter how convincing the query output looks. Reading logs back and reporting what they say is not verification — it's restating the input.
+
+`confirmed` requires one of these, from **outside** the log corpus:
+
+| Confirmation type | What it means |
+|-------------------|---------------|
+| **Controlled reproduction** | Behavior reproduced in an attack range / lab |
+| **Host forensics** | The artifact recovered — crontab entry, plist, binary on disk, registry key |
+| **Configuration review** | The actual config inspected, proving the activity was possible and occurred |
+
+If you have none of these, the verdict is `suspected`. That is the correct, complete answer — not a downgrade, and not something to apologize for or work around. Escalate to the user that confirmation is needed; do not promote the verdict yourself.
+
+### Routing Rules for AI Assistants
+
+| ❌ Wrong | ✅ Correct |
+|---------|-----------|
+| `verdict: confirmed` backed only by query output | `verdict: suspected` + note what confirmation would take |
+| `attempted_not_vulnerable` listed under `findings` | Put it in `ruled_out` — it closed the question |
+| `benign` listed under `findings` | Put it in `ruled_out` |
+| "No findings" when controls held | `ruled_out` entries naming each control that held |
+| `attempted_not_vulnerable` with no control named | Name the control and how you verified it held |
+| Promoting legacy `true_positives` to `confirmed` | Leave legacy counts alone — they never passed the gate |
+
+**Verify before closeout:** `athf hunt validate H-XXXX` enforces the evidence gate and the routing rule. Run it after writing findings.
+
+**Full field reference:** [athf/data/hunts/FORMAT_GUIDELINES.md](athf/data/hunts/FORMAT_GUIDELINES.md) → The Verdict Ladder
 
 ---
 
@@ -389,7 +432,7 @@ athf --version
 6. **Present hypothesis to user** - ABLE scoping table + threat context
 7. **Execute queries** - Use appropriate data source tools (SIEM interface, query CLI, etc.)
 8. **STOP after each query** - Wait for user feedback before next query
-9. **Document findings** - Update hunt file with results and conclusions
+9. **Document findings** - Update hunt file with results, assign a verdict to each (see [Verdicts](#verdicts-how-to-classify-what-you-found)), then run `athf hunt validate H-XXXX`
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,8 @@ findings:
 
 **No producers declared means no `confirmed`.** A workspace with no `provenance` section refuses every `confirmed` entry. That is intended: the absence of a declaration is not permission.
 
+**Do not write a config inside `hunts/`.** Only the workspace-root config is read; one placed beside a hunt file is ignored. Writing a producer declaration next to your own finding is self-certification, and it will not work.
+
 ### Routing Rules for AI Assistants
 
 | ❌ Wrong | ✅ Correct |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,8 @@ findings:
 
 **Do not write a config inside `hunts/`.** Only the workspace-root config is read; one placed beside a hunt file is ignored. Writing a producer declaration next to your own finding is self-certification, and it will not work.
 
+**`attested_by` must name a person, not the producer.** Repeating `produced_by` there — or naming any other declared producer — is refused: an attestation is a second party vouching for the work, and nothing in config can be asked what it saw. If no person can vouch for the out-of-corpus work, the verdict is `suspected`. Do not put a colleague's name there to satisfy the field; ask the user who should attest.
+
 ### Routing Rules for AI Assistants
 
 | ❌ Wrong | ✅ Correct |
@@ -372,6 +374,7 @@ findings:
 | `verdict: confirmed` backed only by query output | `verdict: suspected` + note what confirmation would take |
 | `confirmation:` as a prose string on `confirmed` | A mapping with `method`, `produced_by`, `attested_by`, `detail` |
 | `attested_by: the team` / `AI assistant` / `pipeline` | A named person answerable for the out-of-corpus work |
+| `attested_by:` repeating `produced_by` (or another producer) | A person distinct from the producer — self-attestation is refused |
 | Declaring `analyst_capabilities:` in the finding | Declare producers in `.athfconfig.yaml`; never self-certify |
 | Editing config to grant yourself a capability | Report that confirmation needs work you cannot do |
 | `attempted_not_vulnerable` listed under `findings` | Put it in `ruled_out` — it closed the question |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,8 @@ findings:
 
 **No producers declared means no `confirmed`.** A workspace with no `provenance` section refuses every `confirmed` entry. That is intended: the absence of a declaration is not permission.
 
+**Name the surface you actually are, not the team you belong to.** A producer is one thing that produces findings, scoped by what it can reach — so a single team legitimately declares several. When you write `produced_by`, pick the entry matching the surface that did the work: if a query-only agent produced the finding, name that agent, never the human team that also does forensics. Borrowing the team's entry to inherit its capabilities is self-certification with an extra step.
+
 **Do not write a config inside `hunts/`.** Only the workspace-root config is read; one placed beside a hunt file is ignored. Writing a producer declaration next to your own finding is self-certification, and it will not work.
 
 **`attested_by` must name a person, not the producer.** Repeating `produced_by` there — or naming any other declared producer — is refused: an attestation is a second party vouching for the work, and nothing in config can be asked what it saw. If no person can vouch for the out-of-corpus work, the verdict is `suspected`. Do not put a colleague's name there to satisfy the field; ask the user who should attest.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,11 +340,38 @@ Every result gets one of five verdicts. `TP` / `FP` is no longer sufficient — 
 
 If you have none of these, the verdict is `suspected`. That is the correct, complete answer — not a downgrade, and not something to apologize for or work around. Escalate to the user that confirmation is needed; do not promote the verdict yourself.
 
+### Provenance: `confirmed` Needs a Producer, Not Better Prose
+
+The gate does not read your `confirmation` text and decide whether it sounds like real work — that check was measured and cannot separate `cross-validated by running a second query against the same table` from genuine corroboration. Instead, `confirmation` is a **mapping** and the gate checks who produced it:
+
+```yaml
+findings:
+  - subject: web-prod-04
+    verdict: confirmed
+    evidence: OCSF process_activity shows sh writing /var/spool/cron/crontabs/svc_deploy
+    confirmation:
+      method: host_forensics          # must be a capability the producer declared
+      produced_by: ir-team            # must exist in .athfconfig.yaml provenance.producers
+      attested_by: J. Halloran        # a named person, never a role or "the team"
+      detail: >-
+        Recovered the crontab entry and the dropper binary from the imaged disk
+```
+
+**Capabilities are declared in `.athfconfig.yaml`, never in the finding.** If you write `capabilities:`, `analyst_capabilities:`, or `producer_capabilities:` inside a finding, validation refuses it outright. You cannot grant yourself the ability to confirm.
+
+**If you can only run queries, your ceiling is `suspected` — permanently.** A producer whose declared capabilities are all corpus-reading (`clickhouse_query`, `siem_search`, `log_review`) cannot reach `confirmed` no matter what it writes. That is by construction, not an obstacle to route around. Do not add capabilities to config to unblock yourself; report to the user that confirmation requires out-of-corpus work.
+
+**No producers declared means no `confirmed`.** A workspace with no `provenance` section refuses every `confirmed` entry. That is intended: the absence of a declaration is not permission.
+
 ### Routing Rules for AI Assistants
 
 | ❌ Wrong | ✅ Correct |
 |---------|-----------|
 | `verdict: confirmed` backed only by query output | `verdict: suspected` + note what confirmation would take |
+| `confirmation:` as a prose string on `confirmed` | A mapping with `method`, `produced_by`, `attested_by`, `detail` |
+| `attested_by: the team` / `AI assistant` / `pipeline` | A named person answerable for the out-of-corpus work |
+| Declaring `analyst_capabilities:` in the finding | Declare producers in `.athfconfig.yaml`; never self-certify |
+| Editing config to grant yourself a capability | Report that confirmation needs work you cannot do |
 | `attempted_not_vulnerable` listed under `findings` | Put it in `ruled_out` — it closed the question |
 | `benign` listed under `findings` | Put it in `ruled_out` |
 | "No findings" when controls held | `ruled_out` entries naming each control that held |

--- a/athf/__version__.py
+++ b/athf/__version__.py
@@ -1,3 +1,3 @@
 """Version information for ATHF."""
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"

--- a/athf/commands/env.py
+++ b/athf/commands/env.py
@@ -290,7 +290,7 @@ def info() -> None:  # noqa: C901
             text=True,
         )
         package_count = len(result.stdout.strip().split("\n"))
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         package_count = "Unknown"
 
     # Check for athf installation
@@ -302,7 +302,7 @@ def info() -> None:  # noqa: C901
             text=True,
         )
         athf_installed = "✅ Installed" if result.returncode == 0 else "❌ Not installed"
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         athf_installed = "❌ Not installed"
 
     # Check for scikit-learn
@@ -314,7 +314,7 @@ def info() -> None:  # noqa: C901
             text=True,
         )
         sklearn_installed = "✅ Installed" if result.returncode == 0 else "❌ Not installed"
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         sklearn_installed = "❌ Not installed"
 
     # Display info

--- a/athf/commands/hunt.py
+++ b/athf/commands/hunt.py
@@ -17,6 +17,7 @@ from athf.core.attack_matrix import get_technique
 from athf.core.hunt_manager import HuntManager
 from athf.core.hunt_parser import validate_hunt_file
 from athf.core.template_engine import render_hunt_template
+from athf.core.verdicts import VERDICTS
 from athf.utils.validation import validate_hunt_id, validate_research_id
 
 console = Console()
@@ -582,6 +583,8 @@ def stats() -> None:
     table.add_row("Total Hunts", str(stats["total_hunts"]))
     table.add_row("Completed Hunts", str(stats["completed_hunts"]))
     table.add_row("Total Findings", str(stats["total_findings"]))
+    for verdict in VERDICTS:
+        table.add_row(verdict.replace("_", " ").capitalize(), str(stats.get(verdict, 0)))
     table.add_row("True Positives", str(stats["true_positives"]))
     table.add_row("False Positives", str(stats["false_positives"]))
     table.add_row("Success Rate", f"{stats['success_rate']}%")
@@ -1150,6 +1153,8 @@ def _build_export_dict(
         "related_hunts": frontmatter.get("related_hunts", []),
         "spawned_from": frontmatter.get("spawned_from"),
         "findings_count": frontmatter.get("findings_count", 0),
+        "findings": hunt_data.get("findings", []),
+        "ruled_out": hunt_data.get("ruled_out", []),
         "true_positives": frontmatter.get("true_positives", 0),
         "false_positives": frontmatter.get("false_positives", 0),
         "events_scanned": frontmatter.get("events_scanned"),

--- a/athf/commands/hunt.py
+++ b/athf/commands/hunt.py
@@ -17,7 +17,7 @@ from athf.core.attack_matrix import get_technique
 from athf.core.hunt_manager import HuntManager
 from athf.core.hunt_parser import validate_hunt_file
 from athf.core.template_engine import render_hunt_template
-from athf.core.verdicts import VERDICTS
+from athf.core.verdicts import UNFILLED_HUNTER, VERDICTS
 from athf.utils.validation import validate_hunt_id, validate_research_id
 
 console = Console()
@@ -141,7 +141,7 @@ def hunt() -> None:
 @click.option("--behavior", help="Behavior description (for ABLE framework)")
 @click.option("--location", help="Location/scope (for ABLE framework)")
 @click.option("--evidence", help="Evidence description (for ABLE framework)")
-@click.option("--hunter", help="Hunter name", default="AI Assistant")
+@click.option("--hunter", help="Hunter name (defaults to the workspace `hunter` config key)")
 @click.option("--research", help="Research document ID (e.g., R-0001) this hunt is based on")
 @click.option(
     "--hypothesis-duration",
@@ -287,6 +287,12 @@ def new(
         ds_input = Prompt.ask("   Data Sources", default=default_sources)
         hunt_data_sources = [ds.strip() for ds in ds_input.split(",")]
 
+        # Hunter — only worth asking when neither the flag nor config answered.
+        if not hunter and not config.get("hunter"):
+            hunter = Prompt.ask("\n6. Hunter (your name)", default="").strip() or None
+
+    hunt_hunter = hunter or config.get("hunter") or UNFILLED_HUNTER
+
     # Render template
     hunt_content = render_hunt_template(
         hunt_id=hunt_id,
@@ -295,7 +301,7 @@ def new(
         tactics=hunt_tactics,
         platform=hunt_platforms,
         data_sources=hunt_data_sources,
-        hunter=hunter or "AI Assistant",
+        hunter=hunt_hunter,
         hypothesis=hypothesis,
         threat_context=threat_context,
         actor=actor,

--- a/athf/commands/hunt.py
+++ b/athf/commands/hunt.py
@@ -485,7 +485,7 @@ def validate(hunt_id: str) -> None:
         if not validate_hunt_id(hunt_id):
             console.print(f"[red]Error: Invalid hunt ID format: {hunt_id}[/red]")
             console.print("[yellow]Expected format: H-0001[/yellow]")
-            return
+            raise click.Abort()
 
         # Validate specific hunt - search recursively for backward compatibility
         hunts_dir = Path("hunts")
@@ -496,7 +496,7 @@ def validate(hunt_id: str) -> None:
             matching_files = list(hunts_dir.rglob(f"{hunt_id}.md"))
             if not matching_files:
                 console.print(f"[red]Hunt not found: {hunt_id}[/red]")
-                return
+                raise click.Abort()
             hunt_file = matching_files[0]  # Use first match
 
         # Validate path is within hunts directory
@@ -504,7 +504,7 @@ def validate(hunt_id: str) -> None:
             hunt_file.resolve().relative_to(hunts_dir.resolve())
         except (ValueError, OSError):
             console.print("[red]Error: Invalid hunt file path[/red]")
-            return
+            raise click.Abort() from None
 
         _validate_single_hunt(hunt_file)
     else:
@@ -539,19 +539,24 @@ def validate(hunt_id: str) -> None:
 
         console.print(f"\n[bold]Results:[/bold] {valid_count} valid, {invalid_count} invalid")
 
+        if invalid_count:
+            raise click.Abort()
+
 
 def _validate_single_hunt(hunt_file: Path) -> None:
-    """Validate a single hunt file."""
+    """Validate a single hunt file, aborting when it fails."""
     console.print(f"\n[bold]🔍 Validating {hunt_file.name}...[/bold]\n")
 
     is_valid, errors = validate_hunt_file(hunt_file)
 
     if is_valid:
         console.print("[green]✅ Hunt is valid![/green]")
-    else:
-        console.print("[red]❌ Hunt has validation errors:[/red]\n")
-        for error in errors:
-            console.print(f"  - {error}")
+        return
+
+    console.print("[red]❌ Hunt has validation errors:[/red]\n")
+    for error in errors:
+        console.print(f"  - {error}")
+    raise click.Abort()
 
 
 @hunt.command()

--- a/athf/commands/init.py
+++ b/athf/commands/init.py
@@ -17,6 +17,11 @@ console = Console()
 # starting point — a starter list of real producers would hand out the strongest
 # verdict in the ladder to whoever ran init.
 PROVENANCE_STUB = """
+# Your name, used as the default for `athf hunt new --hunter`. Safe to keep here
+# because a name is not a grant — it still has to clear attestation on its own
+# merits, and it does not widen what you can claim.
+# hunter: Your Name
+
 # Who may claim 'confirmed', and by what means. Capabilities live here rather
 # than in the hunt file on purpose: an agent writes findings, but it cannot
 # rewrite this file to widen its own reach.

--- a/athf/commands/init.py
+++ b/athf/commands/init.py
@@ -247,8 +247,12 @@ techniques: [T1003.001, T1005, etc.]
 data_sources: [SIEM, EDR, etc.]
 related_hunts: []
 findings_count: 0
-true_positives: 0
-false_positives: 0
+findings: []
+ruled_out: []
+# Legacy counters, kept for hunts predating the ladder. Leave commented out: an
+# explicit value overrides the counts derived from findings/ruled_out above.
+# true_positives: 0
+# false_positives: 0
 customer_deliverables: []
 tags: []
 ---
@@ -372,13 +376,29 @@ tags: []
 
 ### Findings
 
-| **Finding** | **Ticket** | **Description** |
-|-------------|-----------|-----------------|
-| True Positive | [Ticket] | [Description] |
-| False Positive | N/A | [Description] |
+Things you're reporting as malicious. Only `confirmed` and `suspected` belong here.
 
-**True Positives:** [Count]
-**False Positives:** [Count]
+| **Verdict** | **Subject** | **Ticket** | **Evidence** | **Independent Confirmation** |
+|-------------|-------------|-----------|--------------|------------------------------|
+| `confirmed` | [Host, account, or resource] | [INC-####] | [Telemetry that surfaced it] | [What established root cause outside the logs] |
+| `suspected` | [Host, account, or resource] | [INC-####] | [Telemetry that surfaced it] | None — telemetry only |
+
+**The evidence gate:** `confirmed` requires telemetry **plus** something from outside the log
+corpus — controlled reproduction, host forensics, or configuration review. Telemetry alone never
+reaches `confirmed`. If you couldn't confirm, the verdict is `suspected`.
+
+### Ruled Out
+
+Results that closed the question. `attempted_not_vulnerable` is often the most valuable row in a
+customer-facing report.
+
+| **Verdict** | **Subject** | **What Closed It** |
+|-------------|-------------|--------------------|
+| `attempted_not_vulnerable` | [Host, account, or resource] | [Name the control that held and how you verified it] |
+| `benign` | [Host, account, or resource] | [The legitimate activity that explains it] |
+| `inconclusive` | [Host, account, or resource] | [Which telemetry was missing or too sparse] |
+
+**Counts:** `confirmed` [N] · `suspected` [N] · `attempted_not_vulnerable` [N] · `benign` [N] · `inconclusive` [N]
 
 ### Detection Logic
 

--- a/athf/commands/init.py
+++ b/athf/commands/init.py
@@ -12,6 +12,33 @@ from athf.data import get_data_path
 
 console = Console()
 
+# Appended commented-out so a fresh workspace declares nothing. The gate is
+# restrictive: no declared producer means no 'confirmed', and that is the right
+# starting point — a starter list of real producers would hand out the strongest
+# verdict in the ladder to whoever ran init.
+PROVENANCE_STUB = """
+# Who may claim 'confirmed', and by what means. Capabilities live here rather
+# than in the hunt file on purpose: an agent writes findings, but it cannot
+# rewrite this file to widen its own reach.
+#
+# Until a producer is declared here, no finding can reach 'confirmed' — only
+# 'suspected'. That is intended, not a misconfiguration.
+#
+# Capabilities that only read the log corpus (clickhouse_query, siem_search,
+# log_review, splunk_search, sql_query, ...) never satisfy the gate: the corpus
+# cannot corroborate itself. Declare them anyway if they are accurate — they are
+# honest work — but reaching 'confirmed' needs something outside the logs.
+#
+# provenance:
+#   producers:
+#     ir-team:
+#       capabilities: [siem_search, host_forensics, configuration_review]
+#     detection-eng:
+#       capabilities: [siem_search, range_reproduction]
+#     baseline-agent:
+#       capabilities: [clickhouse_query]   # query-only: capped at 'suspected'
+"""
+
 
 @click.command()
 @click.option("--path", default=".", help="Directory to initialize ATHF in")
@@ -96,6 +123,7 @@ def init(path: str, non_interactive: bool) -> None:
     # Save configuration
     with open(config_path, "w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        f.write(PROVENANCE_STUB)
     console.print("  ✓ Created [cyan]config/.athfconfig.yaml[/cyan]")
 
     # Create AGENTS.md if it doesn't exist

--- a/athf/commands/init.py
+++ b/athf/commands/init.py
@@ -34,6 +34,16 @@ PROVENANCE_STUB = """
 # cannot corroborate itself. Declare them anyway if they are accurate — they are
 # honest work — but reaching 'confirmed' needs something outside the logs.
 #
+# A producer is a SURFACE, not an org chart entry. Declare one per thing that
+# produces findings, split by what it can actually reach. One team can and
+# usually should declare several: if the same team runs a query-only agent and
+# also images disks by hand, those are two surfaces with different ceilings.
+#
+# Collapsing them into one all-capable producer disables the check — there is no
+# method the sole producer cannot claim, so nothing is ever refused and the gate
+# becomes a spelling test. Give the agent its own entry and it stays honestly
+# capped at 'suspected' no matter what it writes.
+#
 # provenance:
 #   producers:
 #     ir-team:

--- a/athf/commands/investigate.py
+++ b/athf/commands/investigate.py
@@ -723,8 +723,11 @@ def promote(
         "related_hunts": inv_related_hunts,
         "spawned_from": investigation_id,  # Reference investigation
         "findings_count": 0,
-        "true_positives": 0,
-        "false_positives": 0,
+        # No legacy counters. An explicit true_positives outranks the tally derived
+        # from verdicts, so seeding one here would arm a fuse: the hunter writes an
+        # attested 'confirmed' finding later and the count still reads zero.
+        "findings": [],
+        "ruled_out": [],
         "customer_deliverables": [],
         "tags": inv_tags,
     }

--- a/athf/commands/investigate.py
+++ b/athf/commands/investigate.py
@@ -605,7 +605,7 @@ def promote(
     Creates a hunt file (H-XXXX) from an investigation, adding:
     • Hunt-required metadata (tactics, techniques, platform)
     • Hunt status and tracking fields
-    • Findings count and TP/FP fields (default: 0)
+    • Verdict-ladder fields: findings_count, findings, ruled_out (default: empty)
     • Reference to original investigation (spawned_from)
 
     \b

--- a/athf/commands/metrics.py
+++ b/athf/commands/metrics.py
@@ -22,8 +22,16 @@ from athf.core.metrics import (
     EventStore,
     MetricEvent,
 )
+from athf.core.verdicts import VERDICTS
 
 console = Console()
+
+# Ladder rows shared by `show` and `summary`, e.g. ("Attempted not vulnerable",
+# "attempted_not_vulnerable"). Derived from VERDICTS so a new tier cannot be
+# added to the vocabulary and forgotten in the CLI.
+VERDICT_ROWS: Tuple[Tuple[str, str], ...] = tuple(
+    (verdict.replace("_", " ").capitalize(), verdict) for verdict in VERDICTS
+)
 
 
 METRICS_EPILOG = """
@@ -60,7 +68,7 @@ def metrics() -> None:
 
     \b
     Manual via 'record' or athf.metrics.record_*:
-      • Hunt outcomes (TP / FP / inconclusive)
+      • Hunt outcomes (confirmed / suspected / attempted_not_vulnerable / benign / inconclusive)
       • Custom events
     """
 
@@ -118,6 +126,7 @@ def show(hunt_id: str, output_format: str, workspace: Path) -> None:
         ("Web searches", "web_searches"),
         ("Similarity searches", "similarity_searches"),
         ("Events analyzed", "events_analyzed"),
+        *VERDICT_ROWS,
         ("True positives", "true_positives"),
         ("False positives", "false_positives"),
     ):
@@ -184,6 +193,7 @@ def summary(output_format: str, workspace: Path) -> None:
         ("Web searches", "web_searches", "{:,}"),
         ("Similarity searches", "similarity_searches", "{:,}"),
         ("Events analyzed", "events_analyzed", "{:,}"),
+        *((label, key, "{:,}") for label, key in VERDICT_ROWS),
         ("True positives", "true_positives", "{:,}"),
         ("False positives", "false_positives", "{:,}"),
     ):

--- a/athf/core/hunt_manager.py
+++ b/athf/core/hunt_manager.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from athf.core.attack_matrix import ATTACK_TACTICS, TOTAL_TECHNIQUES, get_sorted_tactics
 from athf.core.hunt_parser import parse_hunt_file
+from athf.core.verdicts import VERDICTS, precision_pair, tally_frontmatter_verdicts
 from athf.utils.validation import validate_file_path, validate_hunt_id
 
 # Documentation files to exclude when discovering hunt files at any directory level
@@ -117,22 +118,28 @@ class HuntManager:
                 else:
                     date_str = str(date_val) if date_val else None
 
-                hunts.append(
-                    {
-                        "hunt_id": frontmatter.get("hunt_id"),
-                        "title": frontmatter.get("title"),
-                        "status": frontmatter.get("status"),
-                        "date": date_str,
-                        "platform": frontmatter.get("platform", []),
-                        "tactics": frontmatter.get("tactics", []),
-                        "techniques": frontmatter.get("techniques", []),
-                        "findings_count": frontmatter.get("findings_count", 0),
-                        "true_positives": frontmatter.get("true_positives", 0),
-                        "false_positives": frontmatter.get("false_positives", 0),
-                        "file_path": str(hunt_file),
-                        "environment": environment,
-                    }
-                )
+                tiers = tally_frontmatter_verdicts(frontmatter) or {v: 0 for v in VERDICTS}
+                positives, negatives = precision_pair(tiers)
+
+                summary = {
+                    "hunt_id": frontmatter.get("hunt_id"),
+                    "title": frontmatter.get("title"),
+                    "status": frontmatter.get("status"),
+                    "date": date_str,
+                    "platform": frontmatter.get("platform", []),
+                    "tactics": frontmatter.get("tactics", []),
+                    "techniques": frontmatter.get("techniques", []),
+                    "findings_count": frontmatter.get("findings_count", 0),
+                    # A hand-typed legacy count always wins: it may record work
+                    # done before the ladder existed, and nothing here should
+                    # overwrite a number a hunter entered deliberately.
+                    "true_positives": frontmatter.get("true_positives", positives),
+                    "false_positives": frontmatter.get("false_positives", negatives),
+                    "file_path": str(hunt_file),
+                    "environment": environment,
+                }
+                summary.update(tiers)
+                hunts.append(summary)
 
             except Exception:
                 # Skip files that can't be parsed
@@ -247,7 +254,7 @@ class HuntManager:
         hunts = self.list_hunts()
 
         if not hunts:
-            return {
+            empty = {
                 "total_hunts": 0,
                 "completed_hunts": 0,
                 "total_findings": 0,
@@ -256,6 +263,8 @@ class HuntManager:
                 "success_rate": 0.0,
                 "tp_fp_ratio": 0.0,
             }
+            empty.update({verdict: 0 for verdict in VERDICTS})
+            return empty
 
         total_hunts = len(hunts)
         completed_hunts = len([h for h in hunts if h.get("status") == "completed"])
@@ -271,7 +280,7 @@ class HuntManager:
         # Calculate TP/FP ratio
         tp_fp_ratio = (total_tp / total_fp) if total_fp > 0 else float("inf")
 
-        return {
+        stats = {
             "total_hunts": total_hunts,
             "completed_hunts": completed_hunts,
             "total_findings": total_findings,
@@ -280,6 +289,10 @@ class HuntManager:
             "success_rate": round(success_rate, 1),
             "tp_fp_ratio": round(tp_fp_ratio, 2) if tp_fp_ratio != float("inf") else "∞",
         }
+        stats.update(
+            {verdict: sum(h.get(verdict, 0) for h in hunts) for verdict in VERDICTS}
+        )
+        return stats
 
     def calculate_attack_coverage(self) -> Dict[str, Any]:
         """Calculate MITRE ATT&CK technique coverage with hunt references.

--- a/athf/core/hunt_manager.py
+++ b/athf/core/hunt_manager.py
@@ -13,6 +13,28 @@ from athf.utils.validation import validate_file_path, validate_hunt_id
 EXCLUDED_DOC_FILES = {"README.md", "FORMAT_GUIDELINES.md", "INDEX.md", "AGENTS.md", "WEEKLY_SUMMARY_TEMPLATE.md"}
 
 
+def _as_count(value: Any) -> int:
+    """Coerce a frontmatter counter to a non-negative int, defaulting to 0.
+
+    Hand-edited hunt files carry quoted numbers, empty keys, and occasionally
+    prose. Rollup runs over whatever is on disk and `athf hunt stats` runs right
+    after validate in CI, so a malformed counter must degrade to 0 rather than
+    raise — only `athf hunt validate` gets to object to a file.
+    """
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(value.strip()), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
 class HuntManager:
     """Manage hunt files and operations."""
 
@@ -269,12 +291,12 @@ class HuntManager:
         total_hunts = len(hunts)
         completed_hunts = len([h for h in hunts if h.get("status") == "completed"])
 
-        total_findings = sum(h.get("findings_count", 0) for h in hunts)
-        total_tp = sum(h.get("true_positives", 0) for h in hunts)
-        total_fp = sum(h.get("false_positives", 0) for h in hunts)
+        total_findings = sum(_as_count(h.get("findings_count")) for h in hunts)
+        total_tp = sum(_as_count(h.get("true_positives")) for h in hunts)
+        total_fp = sum(_as_count(h.get("false_positives")) for h in hunts)
 
         # Calculate success rate (hunts with TP / completed hunts)
-        hunts_with_tp = len([h for h in hunts if h.get("true_positives", 0) > 0])
+        hunts_with_tp = len([h for h in hunts if _as_count(h.get("true_positives")) > 0])
         success_rate = (hunts_with_tp / completed_hunts * 100) if completed_hunts > 0 else 0.0
 
         # Calculate TP/FP ratio

--- a/athf/core/hunt_manager.py
+++ b/athf/core/hunt_manager.py
@@ -45,6 +45,7 @@ class HuntManager:
             hunts_dir: Directory containing hunt files (default: ./hunts)
         """
         self.hunts_dir = Path(hunts_dir) if hunts_dir else Path.cwd() / "hunts"
+        self._registry: Any = None
 
         if not self.hunts_dir.exists():
             self.hunts_dir.mkdir(parents=True, exist_ok=True)
@@ -80,6 +81,19 @@ class HuntManager:
             Sorted list of hunt file Paths
         """
         return sorted(f for f in self.hunts_dir.rglob("*.md") if f.name not in EXCLUDED_DOC_FILES)
+
+    @property
+    def registry(self) -> Any:
+        """Declared producer capabilities, loaded once per manager.
+
+        Aggregation consults the same registry as validation so the tally cannot
+        credit a ``confirmed`` entry that ``athf hunt validate`` rejects.
+        """
+        if self._registry is None:
+            from athf.core.provenance import load_registry
+
+            self._registry = load_registry(self.hunts_dir)
+        return self._registry
 
     def list_hunts(
         self,
@@ -140,7 +154,9 @@ class HuntManager:
                 else:
                     date_str = str(date_val) if date_val else None
 
-                tiers = tally_frontmatter_verdicts(frontmatter) or {v: 0 for v in VERDICTS}
+                tiers = tally_frontmatter_verdicts(frontmatter, self.registry) or {
+                    v: 0 for v in VERDICTS
+                }
                 positives, negatives = precision_pair(tiers)
 
                 summary = {

--- a/athf/core/hunt_manager.py
+++ b/athf/core/hunt_manager.py
@@ -92,7 +92,7 @@ class HuntManager:
         if self._registry is None:
             from athf.core.provenance import load_registry
 
-            self._registry = load_registry(self.hunts_dir)
+            self._registry = load_registry(self.hunts_dir, root=self.hunts_dir.parent)
         return self._registry
 
     def list_hunts(

--- a/athf/core/hunt_parser.py
+++ b/athf/core/hunt_parser.py
@@ -10,11 +10,17 @@ from athf.core.verdicts import (
     ATTEMPTED_NOT_VULNERABLE,
     CIRCULAR_CONFIRMATION,
     CONFIRMED,
+    CORPUS_ONLY_METHOD,
     DEFERRED_CONFIRMATION,
     INVALID_VERDICT,
     LEGACY_VERDICT,
+    METHOD_EXCEEDS_CAPABILITY,
     MISROUTED,
+    MISSING_PROVENANCE,
     MISSING_VERDICT,
+    SELF_DECLARED_CAPABILITY,
+    UNATTESTED,
+    UNKNOWN_PRODUCER,
     UNNAMED_CONTROL,
     UNSUPPORTED_CONFIRMATION,
     VERDICTS,
@@ -27,9 +33,15 @@ LADDER_KEYS = ("findings", "ruled_out")
 class HuntParser:
     """Parser for ATHF hunt files."""
 
-    def __init__(self, file_path: Path):
-        """Initialize parser with hunt file path."""
+    def __init__(self, file_path: Path, registry: Any = None):
+        """Initialize parser with hunt file path.
+
+        ``registry`` supplies declared producer capabilities. Left unset it is
+        loaded from workspace config on first use, so every caller gets the same
+        answer as the aggregation path without having to know it exists.
+        """
         self.file_path = Path(file_path)
+        self._registry = registry
         self.frontmatter: Dict = {}
         self.content = ""
         self.lock_sections: Dict = {}
@@ -210,7 +222,12 @@ class HuntParser:
         where = f"{key}[{index}] ({subject})"
         errors: List[str] = []
 
-        for code, detail in gate_failures(key, entry):
+        if self._registry is None:
+            from athf.core.provenance import load_registry
+
+            self._registry = load_registry(self.file_path.parent)
+
+        for code, detail in gate_failures(key, entry, self._registry):
             if code == MISSING_VERDICT:
                 errors.append(f"{where} is missing required field: verdict")
             elif code == INVALID_VERDICT:
@@ -251,6 +268,45 @@ class HuntParser:
                     f"{where} has verdict '{ATTEMPTED_NOT_VULNERABLE}' but does "
                     "not name the control that held; set 'control' to the specific control and how "
                     "you verified it held"
+                )
+            elif code == MISSING_PROVENANCE:
+                errors.append(
+                    f"{where} claims verdict '{CONFIRMED}' without provenance. "
+                    "Confirmation must be a mapping with 'method', 'produced_by', 'attested_by' "
+                    "and 'detail' — reading a confirmation cannot establish that the work behind "
+                    "it happened, so who produced it is what the gate checks"
+                )
+            elif code == UNKNOWN_PRODUCER:
+                errors.append(
+                    f"{where} names producer '{detail}', which is not declared in "
+                    ".athfconfig.yaml under provenance.producers. Declare it with the capabilities "
+                    "it can actually reach; an undeclared producer cannot reach 'confirmed'"
+                )
+            elif code == METHOD_EXCEEDS_CAPABILITY:
+                producer, method = detail
+                errors.append(
+                    f"{where} claims confirmation method '{method}', which "
+                    f"'{producer}' has not declared in .athfconfig.yaml. A producer cannot confirm "
+                    "by a means it has no access to — either declare the capability or downgrade "
+                    "the verdict to 'suspected'"
+                )
+            elif code == CORPUS_ONLY_METHOD:
+                errors.append(
+                    f"{where} offers '{detail}' as its confirmation method, but "
+                    "that only reads the log corpus, and the corpus cannot corroborate itself. "
+                    "Querying is real work and still caps at 'suspected'"
+                )
+            elif code == SELF_DECLARED_CAPABILITY:
+                errors.append(
+                    f"{where} declares its own capabilities in "
+                    f"{', '.join(detail)}. Capabilities are declared in .athfconfig.yaml, never in "
+                    "the finding — a claim and the licence to make it cannot travel together"
+                )
+            elif code == UNATTESTED:
+                errors.append(
+                    f"{where} claims verdict '{CONFIRMED}' but 'attested_by' does "
+                    f"not name a person ({detail!r}). Out-of-corpus work needs someone answerable "
+                    "for it; a role, a team, or the automation itself cannot vouch for it"
                 )
 
         return errors

--- a/athf/core/hunt_parser.py
+++ b/athf/core/hunt_parser.py
@@ -31,6 +31,151 @@ from athf.core.verdicts import (
 LADDER_KEYS = ("findings", "ruled_out")
 
 
+def _msg_missing_verdict(where: str, detail: Any) -> str:
+    return f"{where} is missing required field: verdict"
+
+
+def _msg_invalid_verdict(where: str, detail: Any) -> str:
+    return f"{where}: {detail}"
+
+
+def _msg_legacy_verdict(where: str, detail: Any) -> str:
+    return (
+        f"{where} uses the legacy verdict '{detail}', which has no "
+        f"place on the ladder; assign one of {', '.join(VERDICTS)} or keep the count "
+        "in the legacy true_positives / false_positives keys"
+    )
+
+
+def _msg_misrouted(where: str, detail: Any) -> str:
+    verdict, expected = detail
+    return f"{where} has verdict '{verdict}', which belongs in {expected}"
+
+
+def _msg_unsupported_confirmation(where: str, detail: Any) -> str:
+    return (
+        f"{where} claims verdict '{CONFIRMED}' but has no usable "
+        f"{' or '.join(detail)}; confirmed requires telemetry evidence plus a "
+        "description of the independent confirmation performed outside the log "
+        "corpus (controlled reproduction, host forensics, or configuration review)"
+    )
+
+
+def _msg_circular_confirmation(where: str, detail: Any) -> str:
+    return (
+        f"{where} confirms verdict '{CONFIRMED}' by pointing back "
+        "at the log corpus; the corpus cannot confirm itself. Describe what you did "
+        "outside it — reproduced the behavior, imaged the host, reviewed the config"
+    )
+
+
+def _msg_deferred_confirmation(where: str, detail: Any) -> str:
+    return (
+        f"{where} claims verdict '{CONFIRMED}' but its confirmation "
+        "says the work has not happened yet; that is a 'suspected' finding until it "
+        "does. Downgrade the verdict and keep the note — flagging what confirmation "
+        "would take is the right answer, not a lesser one"
+    )
+
+
+def _msg_unnamed_control(where: str, detail: Any) -> str:
+    return (
+        f"{where} has verdict '{ATTEMPTED_NOT_VULNERABLE}' but does "
+        "not name the control that held; set 'control' to the specific control and how "
+        "you verified it held"
+    )
+
+
+def _msg_missing_provenance(where: str, detail: Any) -> str:
+    return (
+        f"{where} claims verdict '{CONFIRMED}' without provenance. "
+        "Confirmation must be a mapping with 'method', 'produced_by', 'attested_by' "
+        "and 'detail' — reading a confirmation cannot establish that the work behind "
+        "it happened, so who produced it is what the gate checks"
+    )
+
+
+def _msg_unknown_producer(where: str, detail: Any) -> str:
+    return (
+        f"{where} names producer '{detail}', which is not declared in "
+        ".athfconfig.yaml under provenance.producers. Declare it with the capabilities "
+        "it can actually reach; an undeclared producer cannot reach 'confirmed'"
+    )
+
+
+def _msg_method_exceeds_capability(where: str, detail: Any) -> str:
+    producer, method = detail
+    return (
+        f"{where} claims confirmation method '{method}', which "
+        f"'{producer}' has not declared in .athfconfig.yaml. A producer cannot confirm "
+        "by a means it has no access to — either declare the capability or downgrade "
+        "the verdict to 'suspected'"
+    )
+
+
+def _msg_corpus_only_method(where: str, detail: Any) -> str:
+    return (
+        f"{where} offers '{detail}' as its confirmation method, but "
+        "that only reads the log corpus, and the corpus cannot corroborate itself. "
+        "Querying is real work and still caps at 'suspected'"
+    )
+
+
+def _msg_self_declared_capability(where: str, detail: Any) -> str:
+    return (
+        f"{where} declares its own capabilities in "
+        f"{', '.join(detail)}. Capabilities are declared in .athfconfig.yaml, never in "
+        "the finding — a claim and the licence to make it cannot travel together"
+    )
+
+
+def _msg_unattested(where: str, detail: Any) -> str:
+    return (
+        f"{where} claims verdict '{CONFIRMED}' but 'attested_by' does "
+        f"not name a person ({detail!r}). Out-of-corpus work needs someone answerable "
+        "for it; a role, a team, or the automation itself cannot vouch for it"
+    )
+
+
+def _msg_self_attested(where: str, detail: Any) -> str:
+    producer, attestor = detail
+    return (
+        f"{where} names '{attestor}' in 'attested_by', which is a "
+        f"declared producer, not a person (produced_by is '{producer}'). An "
+        "attestation is a second party vouching for the work; set 'attested_by' to "
+        "the person who can be asked what they saw"
+    )
+
+
+def _unmapped_gate_message(where: str, detail: Any) -> str:
+    # Validity is derived from this list, so a code added to gate_failures
+    # without a message here would make an offending file report clean while
+    # aggregation refuses to count it — the validate/aggregate divergence, again.
+    return (
+        f"{where} fails the verdict gate; see "
+        "FORMAT_GUIDELINES.md → The Verdict Ladder"
+    )
+
+
+_GATE_MESSAGES: Dict[str, Any] = {
+    MISSING_VERDICT: _msg_missing_verdict,
+    INVALID_VERDICT: _msg_invalid_verdict,
+    LEGACY_VERDICT: _msg_legacy_verdict,
+    MISROUTED: _msg_misrouted,
+    UNSUPPORTED_CONFIRMATION: _msg_unsupported_confirmation,
+    CIRCULAR_CONFIRMATION: _msg_circular_confirmation,
+    DEFERRED_CONFIRMATION: _msg_deferred_confirmation,
+    UNNAMED_CONTROL: _msg_unnamed_control,
+    MISSING_PROVENANCE: _msg_missing_provenance,
+    UNKNOWN_PRODUCER: _msg_unknown_producer,
+    METHOD_EXCEEDS_CAPABILITY: _msg_method_exceeds_capability,
+    CORPUS_ONLY_METHOD: _msg_corpus_only_method,
+    SELF_DECLARED_CAPABILITY: _msg_self_declared_capability,
+    UNATTESTED: _msg_unattested,
+    SELF_ATTESTED: _msg_self_attested,
+}
+
+
 class HuntParser:
     """Parser for ATHF hunt files."""
 
@@ -217,117 +362,24 @@ class HuntParser:
         """Render :func:`gate_failures` as hunter-facing messages.
 
         The rules themselves live in ``athf.core.verdicts`` so that validation
-        and aggregation cannot disagree about what earns a verdict.
+        and aggregation cannot disagree about what earns a verdict. The
+        code-to-message rendering lives in ``_GATE_MESSAGES`` so this stays a
+        thin loop; an unmapped code falls back to ``_unmapped_gate_message`` so
+        a code added to ``gate_failures`` without a message here can never make
+        an offending file report clean while aggregation refuses to count it.
         """
         subject = entry.get("subject") or f"{key}[{index}]"
         where = f"{key}[{index}] ({subject})"
-        errors: List[str] = []
 
         if self._registry is None:
             from athf.core.provenance import load_registry
 
             self._registry = load_registry(self.file_path.parent)
 
-        for code, detail in gate_failures(key, entry, self._registry):
-            if code == MISSING_VERDICT:
-                errors.append(f"{where} is missing required field: verdict")
-            elif code == INVALID_VERDICT:
-                errors.append(f"{where}: {detail}")
-            elif code == LEGACY_VERDICT:
-                errors.append(
-                    f"{where} uses the legacy verdict '{detail}', which has no "
-                    f"place on the ladder; assign one of {', '.join(VERDICTS)} or keep the count "
-                    "in the legacy true_positives / false_positives keys"
-                )
-            elif code == MISROUTED:
-                verdict, expected = detail
-                errors.append(
-                    f"{where} has verdict '{verdict}', which belongs in {expected}"
-                )
-            elif code == UNSUPPORTED_CONFIRMATION:
-                errors.append(
-                    f"{where} claims verdict '{CONFIRMED}' but has no usable "
-                    f"{' or '.join(detail)}; confirmed requires telemetry evidence plus a "
-                    "description of the independent confirmation performed outside the log "
-                    "corpus (controlled reproduction, host forensics, or configuration review)"
-                )
-            elif code == CIRCULAR_CONFIRMATION:
-                errors.append(
-                    f"{where} confirms verdict '{CONFIRMED}' by pointing back "
-                    "at the log corpus; the corpus cannot confirm itself. Describe what you did "
-                    "outside it — reproduced the behavior, imaged the host, reviewed the config"
-                )
-            elif code == DEFERRED_CONFIRMATION:
-                errors.append(
-                    f"{where} claims verdict '{CONFIRMED}' but its confirmation "
-                    "says the work has not happened yet; that is a 'suspected' finding until it "
-                    "does. Downgrade the verdict and keep the note — flagging what confirmation "
-                    "would take is the right answer, not a lesser one"
-                )
-            elif code == UNNAMED_CONTROL:
-                errors.append(
-                    f"{where} has verdict '{ATTEMPTED_NOT_VULNERABLE}' but does "
-                    "not name the control that held; set 'control' to the specific control and how "
-                    "you verified it held"
-                )
-            elif code == MISSING_PROVENANCE:
-                errors.append(
-                    f"{where} claims verdict '{CONFIRMED}' without provenance. "
-                    "Confirmation must be a mapping with 'method', 'produced_by', 'attested_by' "
-                    "and 'detail' — reading a confirmation cannot establish that the work behind "
-                    "it happened, so who produced it is what the gate checks"
-                )
-            elif code == UNKNOWN_PRODUCER:
-                errors.append(
-                    f"{where} names producer '{detail}', which is not declared in "
-                    ".athfconfig.yaml under provenance.producers. Declare it with the capabilities "
-                    "it can actually reach; an undeclared producer cannot reach 'confirmed'"
-                )
-            elif code == METHOD_EXCEEDS_CAPABILITY:
-                producer, method = detail
-                errors.append(
-                    f"{where} claims confirmation method '{method}', which "
-                    f"'{producer}' has not declared in .athfconfig.yaml. A producer cannot confirm "
-                    "by a means it has no access to — either declare the capability or downgrade "
-                    "the verdict to 'suspected'"
-                )
-            elif code == CORPUS_ONLY_METHOD:
-                errors.append(
-                    f"{where} offers '{detail}' as its confirmation method, but "
-                    "that only reads the log corpus, and the corpus cannot corroborate itself. "
-                    "Querying is real work and still caps at 'suspected'"
-                )
-            elif code == SELF_DECLARED_CAPABILITY:
-                errors.append(
-                    f"{where} declares its own capabilities in "
-                    f"{', '.join(detail)}. Capabilities are declared in .athfconfig.yaml, never in "
-                    "the finding — a claim and the licence to make it cannot travel together"
-                )
-            elif code == UNATTESTED:
-                errors.append(
-                    f"{where} claims verdict '{CONFIRMED}' but 'attested_by' does "
-                    f"not name a person ({detail!r}). Out-of-corpus work needs someone answerable "
-                    "for it; a role, a team, or the automation itself cannot vouch for it"
-                )
-            elif code == SELF_ATTESTED:
-                producer, attestor = detail
-                errors.append(
-                    f"{where} names '{attestor}' in 'attested_by', which is a "
-                    f"declared producer, not a person (produced_by is '{producer}'). An "
-                    "attestation is a second party vouching for the work; set 'attested_by' to "
-                    "the person who can be asked what they saw"
-                )
-            else:
-                # No branch matched. Validity is derived from this list, so a code
-                # added to gate_failures without a message here would make an
-                # offending file report clean while aggregation refuses to count
-                # it — the validate/aggregate divergence, one more time.
-                errors.append(
-                    f"{where} fails the verdict gate ({code}: {detail!r}); see "
-                    "FORMAT_GUIDELINES.md → The Verdict Ladder"
-                )
-
-        return errors
+        return [
+            _GATE_MESSAGES.get(code, _unmapped_gate_message)(where, detail)
+            for code, detail in gate_failures(key, entry, self._registry)
+        ]
 
 
 def parse_hunt_file(file_path: Path) -> Dict:

--- a/athf/core/hunt_parser.py
+++ b/athf/core/hunt_parser.py
@@ -2,9 +2,24 @@
 
 import re
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import yaml
+
+from athf.core.verdicts import (
+    ATTEMPTED_NOT_VULNERABLE,
+    CONFIRMED,
+    EXPECTED_LIST,
+    LEGACY_VERDICTS,
+    VERDICTS,
+    VerdictError,
+    is_self_referential,
+    is_substantive,
+    normalize_verdict,
+    requires_evidence,
+)
+
+LADDER_KEYS = ("findings", "ruled_out")
 
 
 class HuntParser:
@@ -16,6 +31,8 @@ class HuntParser:
         self.frontmatter: Dict = {}
         self.content = ""
         self.lock_sections: Dict = {}
+        self.findings: List = []
+        self.ruled_out: List = []
 
     def parse(self) -> Dict:
         """Parse hunt file and return structured data.
@@ -38,13 +55,27 @@ class HuntParser:
         # Parse LOCK sections
         self.lock_sections = self._parse_lock_sections(self.content)
 
+        # Verdict ladder. Malformed values surface as validation errors, so
+        # parsing keeps them out of the exposed lists rather than raising here.
+        self.findings = self._ladder_entries("findings")
+        self.ruled_out = self._ladder_entries("ruled_out")
+
         return {
             "file_path": str(self.file_path),
             "hunt_id": self.frontmatter.get("hunt_id"),
             "frontmatter": self.frontmatter,
             "content": self.content,
             "lock_sections": self.lock_sections,
+            "findings": self.findings,
+            "ruled_out": self.ruled_out,
         }
+
+    def _ladder_entries(self, key: str) -> List:
+        """Return the well-formed entries under ``key``, tolerating junk."""
+        raw = self.frontmatter.get(key)
+        if not isinstance(raw, list):
+            return []
+        return [entry for entry in raw if isinstance(entry, dict)]
 
     def _parse_frontmatter(self, content: str) -> Dict:
         """Extract and parse YAML frontmatter.
@@ -139,7 +170,89 @@ class HuntParser:
             if section not in self.lock_sections:
                 errors.append(f"Missing LOCK section: {section.upper()}")
 
+        errors.extend(self._validate_verdicts())
+
         return (len(errors) == 0, errors)
+
+    def _validate_verdicts(self) -> List[str]:
+        """Check the verdict ladder in ``findings`` and ``ruled_out``.
+
+        Absent keys and empty lists are valid: hunts predating the ladder, and
+        hunts that found nothing, must both validate clean.
+        """
+        errors: List[str] = []
+
+        for key in LADDER_KEYS:
+            raw = self.frontmatter.get(key)
+            if raw is None:
+                continue
+            if not isinstance(raw, list):
+                errors.append(f"{key} must be a list of verdict entries; got {type(raw).__name__}")
+                continue
+
+            for index, entry in enumerate(raw):
+                if not isinstance(entry, dict):
+                    errors.append(f"{key}[{index}] must be a mapping; got {type(entry).__name__}")
+                    continue
+                errors.extend(self._validate_entry(key, index, entry))
+
+        return errors
+
+    def _validate_entry(self, key: str, index: int, entry: Dict) -> List[str]:
+        errors: List[str] = []
+        subject = entry.get("subject") or f"{key}[{index}]"
+
+        if "verdict" not in entry:
+            return [f"{key}[{index}] ({subject}) is missing required field: verdict"]
+
+        try:
+            verdict = normalize_verdict(entry["verdict"])
+        except VerdictError as exc:
+            return [f"{key}[{index}] ({subject}): {exc}"]
+
+        if verdict in LEGACY_VERDICTS:
+            return [
+                f"{key}[{index}] ({subject}) uses the legacy verdict '{verdict}', which has no "
+                f"place on the ladder; assign one of {', '.join(VERDICTS)} or keep the count "
+                "in the legacy true_positives / false_positives keys"
+            ]
+
+        expected = EXPECTED_LIST[verdict]
+        if expected != key:
+            errors.append(
+                f"{key}[{index}] ({subject}) has verdict '{verdict}', which belongs in {expected}"
+            )
+
+        # The evidence gate: telemetry alone never reaches confirmed. An
+        # independent confirmation from outside the log corpus is mandatory, and
+        # it has to say what was checked — 'n/a' and 'ok' are how you spell
+        # "I didn't confirm this" while still satisfying a truthiness check.
+        if requires_evidence(verdict):
+            missing = [
+                f for f in ("evidence", "confirmation") if not is_substantive(entry.get(f))
+            ]
+            if missing:
+                errors.append(
+                    f"{key}[{index}] ({subject}) claims verdict '{CONFIRMED}' but has no usable "
+                    f"{' or '.join(missing)}; confirmed requires telemetry evidence plus a "
+                    "description of the independent confirmation performed outside the log "
+                    "corpus (controlled reproduction, host forensics, or configuration review)"
+                )
+            elif is_self_referential(entry.get("confirmation")):
+                errors.append(
+                    f"{key}[{index}] ({subject}) confirms verdict '{CONFIRMED}' by pointing back "
+                    "at the log corpus; the corpus cannot confirm itself. Describe what you did "
+                    "outside it — reproduced the behavior, imaged the host, reviewed the config"
+                )
+
+        if verdict == ATTEMPTED_NOT_VULNERABLE and not is_substantive(entry.get("control")):
+            errors.append(
+                f"{key}[{index}] ({subject}) has verdict '{ATTEMPTED_NOT_VULNERABLE}' but does "
+                "not name the control that held; set 'control' to the specific control and how "
+                "you verified it held"
+            )
+
+        return errors
 
 
 def parse_hunt_file(file_path: Path) -> Dict:

--- a/athf/core/hunt_parser.py
+++ b/athf/core/hunt_parser.py
@@ -10,6 +10,7 @@ from athf.core.verdicts import (
     ATTEMPTED_NOT_VULNERABLE,
     CIRCULAR_CONFIRMATION,
     CONFIRMED,
+    DEFERRED_CONFIRMATION,
     INVALID_VERDICT,
     LEGACY_VERDICT,
     MISROUTED,
@@ -237,6 +238,13 @@ class HuntParser:
                     f"{where} confirms verdict '{CONFIRMED}' by pointing back "
                     "at the log corpus; the corpus cannot confirm itself. Describe what you did "
                     "outside it — reproduced the behavior, imaged the host, reviewed the config"
+                )
+            elif code == DEFERRED_CONFIRMATION:
+                errors.append(
+                    f"{where} claims verdict '{CONFIRMED}' but its confirmation "
+                    "says the work has not happened yet; that is a 'suspected' finding until it "
+                    "does. Downgrade the verdict and keep the note — flagging what confirmation "
+                    "would take is the right answer, not a lesser one"
                 )
             elif code == UNNAMED_CONTROL:
                 errors.append(

--- a/athf/core/hunt_parser.py
+++ b/athf/core/hunt_parser.py
@@ -18,6 +18,7 @@ from athf.core.verdicts import (
     MISROUTED,
     MISSING_PROVENANCE,
     MISSING_VERDICT,
+    SELF_ATTESTED,
     SELF_DECLARED_CAPABILITY,
     UNATTESTED,
     UNKNOWN_PRODUCER,
@@ -307,6 +308,23 @@ class HuntParser:
                     f"{where} claims verdict '{CONFIRMED}' but 'attested_by' does "
                     f"not name a person ({detail!r}). Out-of-corpus work needs someone answerable "
                     "for it; a role, a team, or the automation itself cannot vouch for it"
+                )
+            elif code == SELF_ATTESTED:
+                producer, attestor = detail
+                errors.append(
+                    f"{where} names '{attestor}' in 'attested_by', which is a "
+                    f"declared producer, not a person (produced_by is '{producer}'). An "
+                    "attestation is a second party vouching for the work; set 'attested_by' to "
+                    "the person who can be asked what they saw"
+                )
+            else:
+                # No branch matched. Validity is derived from this list, so a code
+                # added to gate_failures without a message here would make an
+                # offending file report clean while aggregation refuses to count
+                # it — the validate/aggregate divergence, one more time.
+                errors.append(
+                    f"{where} fails the verdict gate ({code}: {detail!r}); see "
+                    "FORMAT_GUIDELINES.md → The Verdict Ladder"
                 )
 
         return errors

--- a/athf/core/hunt_parser.py
+++ b/athf/core/hunt_parser.py
@@ -8,15 +8,16 @@ import yaml
 
 from athf.core.verdicts import (
     ATTEMPTED_NOT_VULNERABLE,
+    CIRCULAR_CONFIRMATION,
     CONFIRMED,
-    EXPECTED_LIST,
-    LEGACY_VERDICTS,
+    INVALID_VERDICT,
+    LEGACY_VERDICT,
+    MISROUTED,
+    MISSING_VERDICT,
+    UNNAMED_CONTROL,
+    UNSUPPORTED_CONFIRMATION,
     VERDICTS,
-    VerdictError,
-    is_self_referential,
-    is_substantive,
-    normalize_verdict,
-    requires_evidence,
+    gate_failures,
 )
 
 LADDER_KEYS = ("findings", "ruled_out")
@@ -199,58 +200,50 @@ class HuntParser:
         return errors
 
     def _validate_entry(self, key: str, index: int, entry: Dict) -> List[str]:
-        errors: List[str] = []
+        """Render :func:`gate_failures` as hunter-facing messages.
+
+        The rules themselves live in ``athf.core.verdicts`` so that validation
+        and aggregation cannot disagree about what earns a verdict.
+        """
         subject = entry.get("subject") or f"{key}[{index}]"
+        where = f"{key}[{index}] ({subject})"
+        errors: List[str] = []
 
-        if "verdict" not in entry:
-            return [f"{key}[{index}] ({subject}) is missing required field: verdict"]
-
-        try:
-            verdict = normalize_verdict(entry["verdict"])
-        except VerdictError as exc:
-            return [f"{key}[{index}] ({subject}): {exc}"]
-
-        if verdict in LEGACY_VERDICTS:
-            return [
-                f"{key}[{index}] ({subject}) uses the legacy verdict '{verdict}', which has no "
-                f"place on the ladder; assign one of {', '.join(VERDICTS)} or keep the count "
-                "in the legacy true_positives / false_positives keys"
-            ]
-
-        expected = EXPECTED_LIST[verdict]
-        if expected != key:
-            errors.append(
-                f"{key}[{index}] ({subject}) has verdict '{verdict}', which belongs in {expected}"
-            )
-
-        # The evidence gate: telemetry alone never reaches confirmed. An
-        # independent confirmation from outside the log corpus is mandatory, and
-        # it has to say what was checked — 'n/a' and 'ok' are how you spell
-        # "I didn't confirm this" while still satisfying a truthiness check.
-        if requires_evidence(verdict):
-            missing = [
-                f for f in ("evidence", "confirmation") if not is_substantive(entry.get(f))
-            ]
-            if missing:
+        for code, detail in gate_failures(key, entry):
+            if code == MISSING_VERDICT:
+                errors.append(f"{where} is missing required field: verdict")
+            elif code == INVALID_VERDICT:
+                errors.append(f"{where}: {detail}")
+            elif code == LEGACY_VERDICT:
                 errors.append(
-                    f"{key}[{index}] ({subject}) claims verdict '{CONFIRMED}' but has no usable "
-                    f"{' or '.join(missing)}; confirmed requires telemetry evidence plus a "
+                    f"{where} uses the legacy verdict '{detail}', which has no "
+                    f"place on the ladder; assign one of {', '.join(VERDICTS)} or keep the count "
+                    "in the legacy true_positives / false_positives keys"
+                )
+            elif code == MISROUTED:
+                verdict, expected = detail
+                errors.append(
+                    f"{where} has verdict '{verdict}', which belongs in {expected}"
+                )
+            elif code == UNSUPPORTED_CONFIRMATION:
+                errors.append(
+                    f"{where} claims verdict '{CONFIRMED}' but has no usable "
+                    f"{' or '.join(detail)}; confirmed requires telemetry evidence plus a "
                     "description of the independent confirmation performed outside the log "
                     "corpus (controlled reproduction, host forensics, or configuration review)"
                 )
-            elif is_self_referential(entry.get("confirmation")):
+            elif code == CIRCULAR_CONFIRMATION:
                 errors.append(
-                    f"{key}[{index}] ({subject}) confirms verdict '{CONFIRMED}' by pointing back "
+                    f"{where} confirms verdict '{CONFIRMED}' by pointing back "
                     "at the log corpus; the corpus cannot confirm itself. Describe what you did "
                     "outside it — reproduced the behavior, imaged the host, reviewed the config"
                 )
-
-        if verdict == ATTEMPTED_NOT_VULNERABLE and not is_substantive(entry.get("control")):
-            errors.append(
-                f"{key}[{index}] ({subject}) has verdict '{ATTEMPTED_NOT_VULNERABLE}' but does "
-                "not name the control that held; set 'control' to the specific control and how "
-                "you verified it held"
-            )
+            elif code == UNNAMED_CONTROL:
+                errors.append(
+                    f"{where} has verdict '{ATTEMPTED_NOT_VULNERABLE}' but does "
+                    "not name the control that held; set 'control' to the specific control and how "
+                    "you verified it held"
+                )
 
         return errors
 

--- a/athf/core/hunt_parser.py
+++ b/athf/core/hunt_parser.py
@@ -374,7 +374,16 @@ class HuntParser:
         if self._registry is None:
             from athf.core.provenance import load_registry
 
-            self._registry = load_registry(self.file_path.parent)
+            # The workspace root is the parent of the hunt file's own ``hunts/``
+            # directory. Anchoring the registry walk there stops an unrelated
+            # ancestor named ``hunts`` (e.g. a workspace under ``/srv/hunts/``)
+            # from being mistaken for the workspace hunt tree and skipping the
+            # real root config.
+            root = next(
+                (a.parent for a in self.file_path.parents if a.name == "hunts"),
+                None,
+            )
+            self._registry = load_registry(self.file_path.parent, root=root)
 
         return [
             _GATE_MESSAGES.get(code, _unmapped_gate_message)(where, detail)

--- a/athf/core/metrics.py
+++ b/athf/core/metrics.py
@@ -560,10 +560,22 @@ def _accumulate_verdict(bucket: Dict[str, Any], raw_verdict: str) -> None:
     Unrecognized verdicts are dropped rather than raised: aggregation runs over
     historical event logs that may predate any given vocabulary change, and a
     stale row must not break `athf metrics extract`.
+
+    ``confirmed`` is deliberately never credited from a ``hunt_outcome`` event,
+    the same refusal ``_verdict_counts_from_body`` makes for the KEEP-section
+    counts. The event is a bare scalar outcome with no producer to check, so
+    honoring it would hand a caller a route around the provenance gate that
+    ``athf hunt validate`` cannot see — an event carries no ``findings`` entry
+    to reject. Legacy ``tp`` still credits: it never claimed a producer, so
+    there is nothing to check, exactly as legacy counters roll up on the file
+    path. The raw event still lands in ``outcomes`` for audit; it just does not
+    reach the gated ``confirmed`` / ``true_positives`` tiers.
     """
     try:
         verdict = normalize_verdict(raw_verdict)
     except VerdictError:
+        return
+    if verdict == CONFIRMED:
         return
     if verdict in bucket:
         bucket[verdict] += 1

--- a/athf/core/metrics.py
+++ b/athf/core/metrics.py
@@ -27,7 +27,16 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, Optional, Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
+
+from athf.core.verdicts import (
+    VERDICTS,
+    VerdictError,
+    counts_as_negative,
+    counts_as_positive,
+    normalize_verdict,
+    tally_frontmatter_verdicts,
+)
 
 # ---------------------------------------------------------------------------
 # Schema
@@ -80,7 +89,8 @@ class MetricEvent:
     rows_returned: Optional[int] = None
     status: Optional[str] = None  # success | error | timeout | inconclusive
 
-    outcome: Optional[str] = None  # TP | FP | inconclusive (for hunt_outcome)
+    # Verdict ladder value for hunt_outcome events; legacy tp | fp also accepted.
+    outcome: Optional[str] = None
 
     custom: Dict[str, Any] = field(default_factory=dict)
 
@@ -223,6 +233,14 @@ _HUNT_BODY_TP_RE = re.compile(r"\*\*True Positives:\*\*\s*(\d+)")
 _HUNT_BODY_FP_RE = re.compile(r"\*\*False Positives:\*\*\s*(\d+)")
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 
+# Per-verdict counts line from the LOCK template's KEEP section, e.g.
+#   **Counts:** `confirmed` 3 · `suspected` 2 · `benign` 1
+# Unfilled `[N]` placeholders don't match, so a blank template counts as zero.
+_HUNT_BODY_VERDICT_RES = {
+    verdict: re.compile(r"`" + verdict + r"`\s*(\d+)")
+    for verdict in VERDICTS
+}
+
 _NUMERIC_FRONTMATTER_FIELDS = (
     "events_analyzed",
     "total_queries",
@@ -238,6 +256,18 @@ _NUMERIC_FRONTMATTER_FIELDS = (
     "false_positives",
     "findings_count",
 )
+
+
+def _verdict_counts_from_body(content: str) -> Optional[Dict[str, int]]:
+    """Read the KEEP section's per-verdict counts line, if a hunter filled it in."""
+    found = False
+    counts = {verdict: 0 for verdict in VERDICTS}
+    for verdict, pattern in _HUNT_BODY_VERDICT_RES.items():
+        m = pattern.search(content)
+        if m:
+            counts[verdict] = int(m.group(1))
+            found = True
+    return counts if found else None
 
 
 class Aggregator:
@@ -442,6 +472,20 @@ class Aggregator:
                     num *= 1_000
                 out["events_analyzed"] = int(num)
 
+        tier_counts = tally_frontmatter_verdicts(frontmatter)
+        if tier_counts is None:
+            tier_counts = _verdict_counts_from_body(content)
+        if tier_counts is not None:
+            out.update(tier_counts)
+            out.setdefault(
+                "true_positives",
+                sum(n for v, n in tier_counts.items() if counts_as_positive(v)),
+            )
+            out.setdefault(
+                "false_positives",
+                sum(n for v, n in tier_counts.items() if counts_as_negative(v)),
+            )
+
         if "true_positives" not in out:
             m = _HUNT_BODY_TP_RE.search(content)
             if m:
@@ -463,7 +507,7 @@ class Aggregator:
 
 
 def _empty_hunt_bucket() -> Dict[str, Any]:
-    return {
+    bucket: Dict[str, Any] = {
         "llm_calls": 0,
         "input_tokens": 0,
         "output_tokens": 0,
@@ -479,6 +523,27 @@ def _empty_hunt_bucket() -> Dict[str, Any]:
         "events": [],
         "outcomes": [],
     }
+    bucket.update({verdict: 0 for verdict in VERDICTS})
+    return bucket
+
+
+def _accumulate_verdict(bucket: Dict[str, Any], raw_verdict: str) -> None:
+    """Increment the per-tier counter plus the legacy precision buckets.
+
+    Unrecognized verdicts are dropped rather than raised: aggregation runs over
+    historical event logs that may predate any given vocabulary change, and a
+    stale row must not break `athf metrics extract`.
+    """
+    try:
+        verdict = normalize_verdict(raw_verdict)
+    except VerdictError:
+        return
+    if verdict in bucket:
+        bucket[verdict] += 1
+    if counts_as_positive(verdict):
+        bucket["true_positives"] += 1
+    elif counts_as_negative(verdict):
+        bucket["false_positives"] += 1
 
 
 def _accumulate(bucket: Dict[str, Any], evt: MetricEvent) -> None:
@@ -499,11 +564,7 @@ def _accumulate(bucket: Dict[str, Any], evt: MetricEvent) -> None:
     elif evt.event_type == "hunt_outcome":
         if evt.outcome:
             bucket["outcomes"].append(evt.outcome)
-            normalized = evt.outcome.strip().upper()
-            if normalized == "TP":
-                bucket["true_positives"] += 1
-            elif normalized == "FP":
-                bucket["false_positives"] += 1
+            _accumulate_verdict(bucket, evt.outcome)
     bucket["events"].append({"id": evt.event_id, "type": evt.event_type, "ts": evt.timestamp})
 
 
@@ -525,6 +586,7 @@ def _aggregate_workspace(per_hunt: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
         "true_positives": 0,
         "false_positives": 0,
     }
+    totals.update({verdict: 0 for verdict in VERDICTS})
     for bucket in per_hunt.values():
         for k in (
             "llm_calls",
@@ -534,7 +596,7 @@ def _aggregate_workspace(per_hunt: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
             "query_duration_ms",
             "web_searches",
             "similarity_searches",
-        ):
+        ) + VERDICTS:
             totals[k] += int(bucket.get(k, 0) or 0)
         totals["cost_usd"] = round(totals["cost_usd"] + float(bucket.get("cost_usd", 0.0) or 0.0), 6)
         totals["events_analyzed"] += int(bucket.get("events_analyzed", 0) or 0)

--- a/athf/core/metrics.py
+++ b/athf/core/metrics.py
@@ -399,6 +399,20 @@ class Aggregator:
             per_hunt["_workspace"] = workspace_bucket
         return per_hunt
 
+    def _provenance_registry(self) -> Any:
+        """Declared producer capabilities for this workspace, loaded once.
+
+        Metrics consults the same registry as ``athf hunt validate`` so a
+        ``confirmed`` entry validation rejects is never credited here.
+        """
+        cached = getattr(self, "_registry_cache", None)
+        if cached is None:
+            from athf.core.provenance import load_registry
+
+            cached = load_registry(self.workspace)
+            self._registry_cache = cached
+        return cached
+
     def _scan_hunt_files(self) -> Dict[str, Dict[str, Any]]:
         """Walk ``hunts/`` and extract per-hunt metrics from frontmatter+body."""
         result: Dict[str, Dict[str, Any]] = {}
@@ -416,14 +430,14 @@ class Aggregator:
             except OSError:
                 continue
 
-            metrics = self.extract_from_hunt_file(content)
+            metrics = self.extract_from_hunt_file(content, self._provenance_registry())
             hunt_id = metrics.get("hunt_id") or hunt_file.stem
             metrics.pop("hunt_id", None)
             result[str(hunt_id)] = metrics
         return result
 
     @staticmethod
-    def extract_from_hunt_file(content: str) -> Dict[str, Any]:
+    def extract_from_hunt_file(content: str, registry: Any = None) -> Dict[str, Any]:
         """Pull metrics from a hunt markdown file.
 
         Frontmatter (YAML) wins over body regexes when both are present.
@@ -474,7 +488,7 @@ class Aggregator:
                     num *= 1_000
                 out["events_analyzed"] = int(num)
 
-        tier_counts = tally_frontmatter_verdicts(frontmatter)
+        tier_counts = tally_frontmatter_verdicts(frontmatter, registry)
         if tier_counts is None:
             tier_counts = _verdict_counts_from_body(content)
         if tier_counts is not None:

--- a/athf/core/metrics.py
+++ b/athf/core/metrics.py
@@ -236,8 +236,10 @@ _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 # Per-verdict counts line from the LOCK template's KEEP section, e.g.
 #   **Counts:** `confirmed` 3 · `suspected` 2 · `benign` 1
 # Unfilled `[N]` placeholders don't match, so a blank template counts as zero.
+# Six digits is well past any real hunt and keeps a pasted-in tracking number
+# from landing in an aggregate as a million findings.
 _HUNT_BODY_VERDICT_RES = {
-    verdict: re.compile(r"`" + verdict + r"`\s*(\d+)")
+    verdict: re.compile(r"`" + verdict + r"`\s*(\d{1,6})(?!\d)")
     for verdict in VERDICTS
 }
 

--- a/athf/core/metrics.py
+++ b/athf/core/metrics.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
 
 from athf.core.verdicts import (
+    CONFIRMED,
     VERDICTS,
     VerdictError,
     counts_as_negative,
@@ -261,10 +262,20 @@ _NUMERIC_FRONTMATTER_FIELDS = (
 
 
 def _verdict_counts_from_body(content: str) -> Optional[Dict[str, int]]:
-    """Read the KEEP section's per-verdict counts line, if a hunter filled it in."""
+    """Read the KEEP section's per-verdict counts line, if a hunter filled it in.
+
+    ``confirmed`` is deliberately not readable from the body. Every other verdict
+    summarizes work the hunt did; ``confirmed`` asserts that work happened
+    outside the log corpus, and a markdown sentence carries no producer to check
+    that against. Honoring it here would hand a query-only agent a route around
+    the provenance gate that ``athf hunt validate`` cannot even see, since a hunt
+    with no ``findings`` list has nothing to reject.
+    """
     found = False
     counts = {verdict: 0 for verdict in VERDICTS}
     for verdict, pattern in _HUNT_BODY_VERDICT_RES.items():
+        if verdict == CONFIRMED:
+            continue
         m = pattern.search(content)
         if m:
             counts[verdict] = int(m.group(1))

--- a/athf/core/metrics.py
+++ b/athf/core/metrics.py
@@ -420,7 +420,7 @@ class Aggregator:
         if cached is None:
             from athf.core.provenance import load_registry
 
-            cached = load_registry(self.workspace)
+            cached = load_registry(self.workspace, root=self.workspace)
             self._registry_cache = cached
         return cached
 

--- a/athf/core/provenance.py
+++ b/athf/core/provenance.py
@@ -1,0 +1,137 @@
+"""Who produced a confirmation, and could they have done the work.
+
+The prose check on ``confirmation`` was measured against a labeled corpus and
+hit a floor it cannot cross: "cross-validated by running a second query against
+the same table" is grammatically indistinguishable from real corroboration. No
+pattern set separates them, because reading a confirmation cannot establish that
+the work behind it happened.
+
+What is not forgeable by an agent that can only run queries is *who produced the
+finding*. So capabilities live here — in workspace config, loaded from disk —
+never in the finding. An LLM emits ``verdict`` / ``evidence`` / ``confirmation``;
+it cannot rewrite the config that says what its producer can reach. That
+separation is the gate. A producer declaring only query access is capped at
+``suspected`` by construction, permanently, without anyone grading its prose.
+
+Declared capability is still forgeable by a human editing config. That is the
+accepted residual: the lie moves out of unfalsifiable prose into a separate file,
+in its own commit, contradicted by source an auditor can read.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, FrozenSet, Mapping, Optional
+
+# Capabilities that only read the log corpus. Declaring one is honest — querying
+# is real work — but it can never be a *confirmation* method, because the corpus
+# is the thing being confirmed. Naming these explicitly is what stops a
+# corpus-only producer from satisfying the gate by declaring what it already does.
+CORPUS_ONLY_CAPABILITIES: FrozenSet[str] = frozenset(
+    {
+        "clickhouse_query",
+        "dataset_query",
+        "log_query",
+        "log_review",
+        "siem_search",
+        "splunk_search",
+        "sql_query",
+        "telemetry_review",
+    }
+)
+
+# Keys that would carry capability inside the finding itself. Present means an
+# author tried to declare their own reach in the same payload as the claim, which
+# is the forgeable field this module exists to replace. Refused rather than
+# ignored: silently dropping it would let the author believe it counted.
+SELF_DECLARATION_KEYS = ("analyst_capabilities", "capabilities", "producer_capabilities")
+
+
+class ProducerRegistry:
+    """The declared capabilities of each producer, loaded from workspace config.
+
+    Constructed from config, never from a hunt file. ``athf hunt validate``
+    already loads workspace config, so the gate can reach this without the
+    finding supplying any part of it.
+    """
+
+    def __init__(self, producers: Optional[Mapping[str, Any]] = None):
+        self._capabilities: Dict[str, FrozenSet[str]] = {}
+        for name, spec in (producers or {}).items():
+            declared = spec.get("capabilities") if isinstance(spec, Mapping) else None
+            if not isinstance(declared, (list, tuple, set, frozenset)):
+                declared = ()
+            self._capabilities[str(name)] = frozenset(
+                str(c).strip().lower() for c in declared if isinstance(c, str) and c.strip()
+            )
+
+    @classmethod
+    def from_config(cls, config: Optional[Mapping[str, Any]]) -> "ProducerRegistry":
+        """Build from a loaded ``.athfconfig.yaml`` mapping.
+
+        A config with no ``provenance`` section yields an empty registry — every
+        workspace already on PyPI. Empty is restrictive, not permissive: nothing
+        is registered, so nothing reaches ``confirmed``.
+        """
+        section = (config or {}).get("provenance")
+        producers = section.get("producers") if isinstance(section, Mapping) else None
+        return cls(producers if isinstance(producers, Mapping) else {})
+
+    def knows(self, producer: Any) -> bool:
+        """Return ``True`` when ``producer`` is declared in config."""
+        return isinstance(producer, str) and producer in self._capabilities
+
+    def capabilities_for(self, producer: Any) -> FrozenSet[str]:
+        """Return the declared capabilities, or empty for an unknown producer."""
+        if not isinstance(producer, str):
+            return frozenset()
+        return self._capabilities.get(producer, frozenset())
+
+    def is_empty(self) -> bool:
+        return not self._capabilities
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostic only
+        return f"ProducerRegistry({sorted(self._capabilities)!r})"
+
+
+def confirming_capabilities(registry: ProducerRegistry, producer: Any) -> FrozenSet[str]:
+    """Return the producer's capabilities that could actually confirm something."""
+    return registry.capabilities_for(producer) - CORPUS_ONLY_CAPABILITIES
+
+
+def load_registry(workspace: Optional[Path] = None) -> ProducerRegistry:
+    """Load the registry from workspace config, or an empty one.
+
+    Both enforcement surfaces call this so they agree: ``athf hunt validate``
+    rejects what the tally declines to count. They decided this separately once
+    before, and a ``confirmed`` entry whose confirmation read ``ok`` was refused
+    by validate and credited by the dashboard in the same breath.
+
+    A missing or unreadable config yields an empty registry, which is restrictive.
+    Failing closed here is deliberate: an unparseable config must not become a
+    reason that ``confirmed`` starts passing.
+    """
+    import yaml
+
+    base = Path(workspace) if workspace else Path.cwd()
+    # Walk up: hunt files live several directories below the workspace root
+    # (hunts/production/2026/Q2/H-0042.md), and the config is at the root.
+    for parent in (base, *base.parents):
+        for candidate in (parent / "config" / ".athfconfig.yaml", parent / ".athfconfig.yaml"):
+            if not candidate.exists():
+                continue
+            try:
+                with open(candidate, "r", encoding="utf-8") as handle:
+                    return ProducerRegistry.from_config(yaml.safe_load(handle) or {})
+            except (OSError, yaml.YAMLError):
+                return ProducerRegistry()
+    return ProducerRegistry()
+
+
+__all__ = [
+    "CORPUS_ONLY_CAPABILITIES",
+    "SELF_DECLARATION_KEYS",
+    "ProducerRegistry",
+    "confirming_capabilities",
+    "load_registry",
+]

--- a/athf/core/provenance.py
+++ b/athf/core/provenance.py
@@ -129,7 +129,10 @@ def load_registry(workspace: Optional[Path] = None) -> ProducerRegistry:
     for parent in (base, *base.parents):
         if _inside_hunt_tree(parent):
             continue
-        for candidate in (parent / "config" / ".athfconfig.yaml", parent / ".athfconfig.yaml"):
+        # Root before config/: `athf init` writes the config/ copy, so most
+        # workspaces have both, and the root file is the one the docs tell hunters
+        # to edit. Reading config/ first made an edited root declaration invisible.
+        for candidate in (parent / ".athfconfig.yaml", parent / "config" / ".athfconfig.yaml"):
             if not candidate.exists():
                 continue
             try:

--- a/athf/core/provenance.py
+++ b/athf/core/provenance.py
@@ -81,6 +81,16 @@ class ProducerRegistry:
         """Return ``True`` when ``producer`` is declared in config."""
         return isinstance(producer, str) and producer in self._capabilities
 
+    def knows_folded(self, name: str) -> bool:
+        """Return ``True`` when ``name`` matches a declared producer, ignoring case.
+
+        Used by the attestation check, which asks whether a name refers to a
+        producer at all rather than looking its capabilities up. Case-insensitive
+        because ``attested_by: Analyst`` names the same tool as ``analyst``, and a
+        rule one shift key wide is not a rule.
+        """
+        return name in {p.strip().lower() for p in self._capabilities}
+
     def capabilities_for(self, producer: Any) -> FrozenSet[str]:
         """Return the declared capabilities, or empty for an unknown producer."""
         if not isinstance(producer, str):

--- a/athf/core/provenance.py
+++ b/athf/core/provenance.py
@@ -117,6 +117,8 @@ def load_registry(workspace: Optional[Path] = None) -> ProducerRegistry:
     # Walk up: hunt files live several directories below the workspace root
     # (hunts/production/2026/Q2/H-0042.md), and the config is at the root.
     for parent in (base, *base.parents):
+        if _inside_hunt_tree(parent):
+            continue
         for candidate in (parent / "config" / ".athfconfig.yaml", parent / ".athfconfig.yaml"):
             if not candidate.exists():
                 continue
@@ -126,6 +128,22 @@ def load_registry(workspace: Optional[Path] = None) -> ProducerRegistry:
             except (OSError, yaml.YAMLError):
                 return ProducerRegistry()
     return ProducerRegistry()
+
+
+def _inside_hunt_tree(directory: Path) -> bool:
+    """Return ``True`` for a directory at or below ``hunts/``.
+
+    Config found there is ignored. The walk starts from a hunt file's own
+    directory, which is a place the finding author writes to — so without this,
+    an agent drops ``.athfconfig.yaml`` beside ``H-0042.md``, declares itself
+    capable of host forensics, and validation accepts the ``confirmed``. That is
+    a self-declaration with a different filename, and the whole reason
+    capabilities live in config is that the claim cannot reach the grant.
+
+    A workspace whose own root is named ``hunts`` therefore declares no
+    producers. That fails closed, which is the right direction to be wrong in.
+    """
+    return "hunts" in directory.parts
 
 
 __all__ = [

--- a/athf/core/provenance.py
+++ b/athf/core/provenance.py
@@ -109,7 +109,9 @@ def confirming_capabilities(registry: ProducerRegistry, producer: Any) -> Frozen
     return registry.capabilities_for(producer) - CORPUS_ONLY_CAPABILITIES
 
 
-def load_registry(workspace: Optional[Path] = None) -> ProducerRegistry:
+def load_registry(
+    workspace: Optional[Path] = None, *, root: Optional[Path] = None
+) -> ProducerRegistry:
     """Load the registry from workspace config, or an empty one.
 
     Both enforcement surfaces call this so they agree: ``athf hunt validate``
@@ -120,14 +122,22 @@ def load_registry(workspace: Optional[Path] = None) -> ProducerRegistry:
     A missing or unreadable config yields an empty registry, which is restrictive.
     Failing closed here is deliberate: an unparseable config must not become a
     reason that ``confirmed`` starts passing.
+
+    ``root`` is the workspace root. When given, the walk stops there and the
+    hunt-tree test is evaluated *relative* to it, so an unrelated ancestor
+    directory that happens to be named ``hunts`` (e.g. a workspace under
+    ``/srv/hunts/``) no longer skips the workspace root's own config. Callers
+    that know the root should always pass it; the ``None`` default keeps the
+    older absolute-path behavior for callers that don't.
     """
     import yaml
 
     base = Path(workspace) if workspace else Path.cwd()
+    root = Path(root) if root is not None else None
     # Walk up: hunt files live several directories below the workspace root
     # (hunts/production/2026/Q2/H-0042.md), and the config is at the root.
     for parent in (base, *base.parents):
-        if _inside_hunt_tree(parent):
+        if _inside_hunt_tree(parent, root):
             continue
         # Root before config/: `athf init` writes the config/ copy, so most
         # workspaces have both, and the root file is the one the docs tell hunters
@@ -140,11 +150,15 @@ def load_registry(workspace: Optional[Path] = None) -> ProducerRegistry:
                     return ProducerRegistry.from_config(yaml.safe_load(handle) or {})
             except (OSError, yaml.YAMLError):
                 return ProducerRegistry()
+        # The root's config is the last one the workspace legitimately owns.
+        # Never keep walking into ancestors above it looking for a stray config.
+        if root is not None and parent == root:
+            break
     return ProducerRegistry()
 
 
-def _inside_hunt_tree(directory: Path) -> bool:
-    """Return ``True`` for a directory at or below ``hunts/``.
+def _inside_hunt_tree(directory: Path, root: Optional[Path] = None) -> bool:
+    """Return ``True`` for a directory inside the workspace's ``hunts/`` tree.
 
     Config found there is ignored. The walk starts from a hunt file's own
     directory, which is a place the finding author writes to — so without this,
@@ -153,10 +167,22 @@ def _inside_hunt_tree(directory: Path) -> bool:
     a self-declaration with a different filename, and the whole reason
     capabilities live in config is that the claim cannot reach the grant.
 
-    A workspace whose own root is named ``hunts`` therefore declares no
-    producers. That fails closed, which is the right direction to be wrong in.
+    With ``root`` the test runs on the path *below* the workspace root, so a
+    ``hunts`` component sitting above the root (an unrelated ancestor) is no
+    longer mistaken for the workspace's own hunt tree — that false match made
+    ``load_registry`` skip the real root config and left ``confirmed``
+    unreachable workspace-wide with no diagnostic. A directory at or above the
+    root is never inside the tree. Without ``root`` the older behavior stands:
+    any ancestor named ``hunts`` skips, which also means a workspace whose own
+    root is named ``hunts`` fails closed.
     """
-    return "hunts" in directory.parts
+    if root is None:
+        return "hunts" in directory.parts
+    try:
+        relative = directory.relative_to(root)
+    except ValueError:
+        return False
+    return "hunts" in relative.parts
 
 
 __all__ = [

--- a/athf/core/template_engine.py
+++ b/athf/core/template_engine.py
@@ -21,8 +21,8 @@ related_hunts: []
 {% if spawned_from %}spawned_from: {{ spawned_from }}
 {% endif %}{% if hypothesis_duration_minutes %}hypothesis_duration_minutes: {{ hypothesis_duration_minutes }}
 {% endif %}findings_count: 0
-true_positives: 0
-false_positives: 0
+findings: []
+ruled_out: []
 customer_deliverables: []
 tags: {{ tags }}
 ---
@@ -134,12 +134,29 @@ tags: {{ tags }}
 
 ### Findings
 
-| **Finding** | **Ticket** | **Description** |
-|-------------|-----------|-----------------|
-| [Type] | [Ticket] | [Description] |
+Things you're reporting as malicious. Only `confirmed` and `suspected` belong here.
 
-**True Positives:** 0
-**False Positives:** 0
+| **Verdict** | **Subject** | **Ticket** | **Evidence** | **Independent Confirmation** |
+|-------------|-------------|-----------|--------------|------------------------------|
+| `confirmed` | [Host, account, or resource] | [INC-####] | [Telemetry that surfaced it] | [What established root cause outside the logs] |
+| `suspected` | [Host, account, or resource] | [INC-####] | [Telemetry that surfaced it] | None — telemetry only |
+
+**The evidence gate:** `confirmed` requires telemetry **plus** something from outside the log
+corpus — controlled reproduction, host forensics, or configuration review. Telemetry alone never
+reaches `confirmed`. If you couldn't confirm, the verdict is `suspected`.
+
+### Ruled Out
+
+Results that closed the question. `attempted_not_vulnerable` is often the most valuable row in a
+customer-facing report.
+
+| **Verdict** | **Subject** | **What Closed It** |
+|-------------|-------------|--------------------|
+| `attempted_not_vulnerable` | [Host, account, or resource] | [Name the control that held and how you verified it] |
+| `benign` | [Host, account, or resource] | [The legitimate activity that explains it] |
+| `inconclusive` | [Host, account, or resource] | [Which telemetry was missing or too sparse] |
+
+**Counts:** `confirmed` [N] · `suspected` [N] · `attempted_not_vulnerable` [N] · `benign` [N] · `inconclusive` [N]
 
 ### Lessons Learned
 

--- a/athf/core/template_engine.py
+++ b/athf/core/template_engine.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 from jinja2 import Template
 
+from athf.core.verdicts import UNFILLED_HUNTER
+
 # Default bundled template - used when no custom template exists
 HUNT_TEMPLATE = """---
 hunt_id: {{ hunt_id }}
@@ -209,7 +211,7 @@ def render_hunt_template(
     tactics: Optional[list] = None,
     platform: Optional[list] = None,
     data_sources: Optional[list] = None,
-    hunter: str = "[Your Name]",
+    hunter: str = UNFILLED_HUNTER,
     hypothesis: Optional[str] = None,
     threat_context: Optional[str] = None,
     actor: Optional[str] = None,

--- a/athf/core/verdicts.py
+++ b/athf/core/verdicts.py
@@ -364,6 +364,7 @@ METHOD_EXCEEDS_CAPABILITY = "method_exceeds_capability"
 CORPUS_ONLY_METHOD = "corpus_only_method"
 SELF_DECLARED_CAPABILITY = "self_declared_capability"
 UNATTESTED = "unattested"
+SELF_ATTESTED = "self_attested"
 
 # Ways of filling ``attested_by`` without naming anyone answerable. The first is
 # not hypothetical: ``athf hunt new`` defaults ``--hunter`` to "AI Assistant", so
@@ -409,6 +410,27 @@ def is_attributable(value: Any) -> bool:
     return folded not in _UNATTRIBUTABLE and folded not in _PLACEHOLDERS
 
 
+def _attests_to_itself(attestor: Any, producer: Any, registry: Any) -> bool:
+    """Return ``True`` when the attestation names a producer rather than a person.
+
+    Two cases, one rule. The attestor is the producer, so the finding says "I did
+    the work and I confirm I did the work". Or the attestor is some *other* entry
+    in the producer registry, which is a tool or a team in config — nothing there
+    can be asked what it saw.
+
+    Registry membership is what separates a producer from a person, so an attestor
+    who appears nowhere in config passes: that is the ordinary case of a human
+    vouching for a tool's output, and rejecting it would leave the field with no
+    valid value at all.
+    """
+    if not isinstance(attestor, str):
+        return False
+    folded = " ".join(attestor.split()).lower()
+    if isinstance(producer, str) and folded == " ".join(producer.split()).lower():
+        return True
+    return registry is not None and registry.knows_folded(folded)
+
+
 def _provenance_failures(confirmation: Any, registry: Any) -> List[Tuple[str, Any]]:
     """Return why ``confirmation`` does not establish out-of-corpus provenance.
 
@@ -440,8 +462,11 @@ def _provenance_failures(confirmation: Any, registry: Any) -> List[Tuple[str, An
         elif defers_confirmation(detail):
             failures.append((DEFERRED_CONFIRMATION, detail))
 
-    if not is_attributable(confirmation.get("attested_by")):
-        failures.append((UNATTESTED, confirmation.get("attested_by")))
+    attestor = confirmation.get("attested_by")
+    if not is_attributable(attestor):
+        failures.append((UNATTESTED, attestor))
+    elif _attests_to_itself(attestor, producer, registry):
+        failures.append((SELF_ATTESTED, (producer, attestor)))
 
     if not isinstance(method, str) or not method.strip():
         failures.append((MISSING_PROVENANCE, "confirmation.method"))
@@ -634,6 +659,7 @@ __all__ = [
     "CORPUS_ONLY_METHOD",
     "SELF_DECLARED_CAPABILITY",
     "UNATTESTED",
+    "SELF_ATTESTED",
     "is_attributable",
     "tally_frontmatter_verdicts",
     "precision_pair",

--- a/athf/core/verdicts.py
+++ b/athf/core/verdicts.py
@@ -20,7 +20,7 @@ Telemetry alone never reaches ``confirmed``. See
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 CONFIRMED = "confirmed"
 SUSPECTED = "suspected"
@@ -226,15 +226,91 @@ def is_self_referential(value: Any) -> bool:
     return any(pattern.search(candidate) for pattern in _SELF_REFERENCE_PATTERNS)
 
 
+# Reason codes returned by :func:`gate_failures`. Callers render these however
+# suits them — ``athf hunt validate`` as hunter-facing messages, aggregation as
+# "do not count this entry".
+NOT_A_MAPPING = "not_a_mapping"
+MISSING_VERDICT = "missing_verdict"
+INVALID_VERDICT = "invalid_verdict"
+LEGACY_VERDICT = "legacy_verdict"
+MISROUTED = "misrouted"
+UNSUPPORTED_CONFIRMATION = "unsupported_confirmation"
+CIRCULAR_CONFIRMATION = "circular_confirmation"
+UNNAMED_CONTROL = "unnamed_control"
+
+
+def gate_failures(key: str, entry: Any) -> List[Tuple[str, Any]]:
+    """Return the reasons ``entry`` in list ``key`` does not earn its verdict.
+
+    The single source of truth behind both enforcement surfaces. Validation
+    renders these as messages; aggregation treats a non-empty result as "do not
+    count". They used to decide this separately — the tally consulted routing
+    alone — so a ``confirmed`` entry whose confirmation read ``ok`` was rejected
+    by validate and credited by the dashboard in the same breath.
+
+    Only the verdicts that carry gates today are checked: ``confirmed`` needs
+    substantive evidence plus non-circular confirmation, and
+    ``attempted_not_vulnerable`` needs a named control. ``benign`` and
+    ``inconclusive`` pass on shape alone — a known asymmetry with its own fix,
+    since widening it here would silently drop existing counts.
+
+    Each item is ``(code, detail)``. ``detail`` carries whatever the renderer
+    needs: the offending value, or the list of unusable fields.
+    """
+    if not isinstance(entry, Mapping):
+        return [(NOT_A_MAPPING, type(entry).__name__)]
+
+    if "verdict" not in entry:
+        return [(MISSING_VERDICT, None)]
+
+    try:
+        verdict = normalize_verdict(entry["verdict"])
+    except VerdictError as exc:
+        return [(INVALID_VERDICT, exc)]
+
+    if verdict in LEGACY_VERDICTS:
+        return [(LEGACY_VERDICT, verdict)]
+
+    failures: List[Tuple[str, Any]] = []
+
+    expected = EXPECTED_LIST[verdict]
+    if expected != key:
+        failures.append((MISROUTED, (verdict, expected)))
+
+    # The evidence gate: telemetry alone never reaches confirmed. An independent
+    # confirmation from outside the log corpus is mandatory, and it has to say
+    # what was checked — 'n/a' and 'ok' are how you spell "I didn't confirm this"
+    # while still satisfying a truthiness check.
+    if requires_evidence(verdict):
+        unusable = [f for f in ("evidence", "confirmation") if not is_substantive(entry.get(f))]
+        if unusable:
+            failures.append((UNSUPPORTED_CONFIRMATION, unusable))
+        elif is_self_referential(entry.get("confirmation")):
+            failures.append((CIRCULAR_CONFIRMATION, entry.get("confirmation")))
+
+    if verdict == ATTEMPTED_NOT_VULNERABLE and not is_substantive(entry.get("control")):
+        failures.append((UNNAMED_CONTROL, entry.get("control")))
+
+    return failures
+
+
+def entry_fails_gate(key: str, entry: Any) -> bool:
+    """Return ``True`` when ``entry`` in list ``key`` does not earn its verdict."""
+    return bool(gate_failures(key, entry))
+
+
 def tally_frontmatter_verdicts(
     frontmatter: Mapping[str, Any]
 ) -> Optional[Dict[str, int]]:
     """Tally verdicts across the ``findings`` / ``ruled_out`` frontmatter lists.
 
     Returns ``None`` when neither key holds a non-empty list, letting callers
-    fall back to legacy counters. Malformed entries are skipped rather than
-    raised: ``athf hunt validate`` is where a hunter is told their file is
-    wrong, so reporting must survive anything already on disk.
+    fall back to legacy counters. Entries that fail the gate are counted as
+    zero rather than raising: ``athf hunt validate`` is where a hunter is told
+    their file is wrong, so reporting must survive anything already on disk.
+    A present-but-rejected list still returns counts, because falling back to
+    legacy counters would let an ungated ``confirmed`` reappear as a legacy
+    true positive.
     """
     found = False
     counts = {verdict: 0 for verdict in VERDICTS}
@@ -245,15 +321,9 @@ def tally_frontmatter_verdicts(
             continue
         found = found or bool(value)
         for entry in value:
-            if not isinstance(entry, Mapping):
+            if entry_fails_gate(key, entry):
                 continue
-            candidate = _soften(entry.get("verdict"))
-            # A verdict is only counted from the list it belongs in. Otherwise a
-            # `confirmed` entry parked in ``ruled_out`` would be credited as a
-            # positive, which is the report separation collapsing quietly —
-            # `athf hunt validate` rejects that shape, so drop it here.
-            if EXPECTED_LIST.get(candidate) == key:
-                counts[candidate] += 1
+            counts[_soften(entry.get("verdict"))] += 1
 
     return counts if found else None
 
@@ -281,6 +351,16 @@ __all__ = [
     "EXPECTED_LIST",
     "is_substantive",
     "is_self_referential",
+    "gate_failures",
+    "entry_fails_gate",
+    "NOT_A_MAPPING",
+    "MISSING_VERDICT",
+    "INVALID_VERDICT",
+    "LEGACY_VERDICT",
+    "MISROUTED",
+    "UNSUPPORTED_CONFIRMATION",
+    "CIRCULAR_CONFIRMATION",
+    "UNNAMED_CONTROL",
     "tally_frontmatter_verdicts",
     "precision_pair",
 ]

--- a/athf/core/verdicts.py
+++ b/athf/core/verdicts.py
@@ -366,10 +366,11 @@ SELF_DECLARED_CAPABILITY = "self_declared_capability"
 UNATTESTED = "unattested"
 SELF_ATTESTED = "self_attested"
 
-# Ways of filling ``attested_by`` without naming anyone answerable. The first is
-# not hypothetical: ``athf hunt new`` defaults ``--hunter`` to "AI Assistant", so
-# the placeholder ships with the tool. A role, a team, or the automation itself
-# cannot vouch for out-of-corpus work — only a person can.
+# Ways of filling ``attested_by`` without naming anyone answerable. A role, a
+# team, or the automation itself cannot vouch for out-of-corpus work — only a
+# person can. "AI Assistant" earns its entry from history: it was ``athf hunt
+# new``'s ``--hunter`` default, so it is still sitting in existing frontmatter
+# where a hunter may copy it from.
 _UNATTRIBUTABLE = frozenset(
     {
         "agent",
@@ -393,6 +394,39 @@ _UNATTRIBUTABLE = frozenset(
 # Shortest string that can name a person. "Jo" is two.
 _MIN_NAME_LEN = 2
 
+# The blank a template leaves for a name, copied through unfilled. `hunter: [Your
+# Name]` ships in HUNT_LOCK.md and the init template, so this is the placeholder a
+# hunter is most likely to have in front of them — and an unrendered `{{ hunter }}`
+# or an unexpanded `$USER` says the same thing: nobody typed a name here.
+#
+# Matched against the whole value with the bracket, brace and sigil punctuation
+# stripped, never as a substring: "Hunter Davis" is a person and "[Sydney
+# Marrone]" is a name someone chose to bracket.
+_NAME_PLACEHOLDERS = frozenset(
+    {
+        "fixme",
+        "hunter",
+        "hunter name",
+        "insert name",
+        "name",
+        "name here",
+        "todo",
+        "user",
+        "your name",
+        "xxx",
+        "yourname",
+    }
+)
+
+# Punctuation a template wraps its blanks in. Stripped before the comparison so
+# one placeholder does not need an entry per syntax.
+_PLACEHOLDER_WRAPPERS = "[]<>{}()$_-\"'` \t"
+
+# What generators write into ``hunter`` when nobody supplied a name. Exported so
+# the tools that fill the field and the gate that judges it cannot drift apart —
+# it has to be a value ``is_attributable`` refuses, or the field is forgeable.
+UNFILLED_HUNTER = "[Your Name]"
+
 
 def is_attributable(value: Any) -> bool:
     """Return ``True`` when ``value`` names someone who could be asked about it.
@@ -407,7 +441,10 @@ def is_attributable(value: Any) -> bool:
     if len(candidate) < _MIN_NAME_LEN:
         return False
     folded = candidate.lower().rstrip(".")
-    return folded not in _UNATTRIBUTABLE and folded not in _PLACEHOLDERS
+    if folded in _UNATTRIBUTABLE or folded in _PLACEHOLDERS:
+        return False
+    unwrapped = " ".join(folded.strip(_PLACEHOLDER_WRAPPERS).split())
+    return unwrapped not in _NAME_PLACEHOLDERS
 
 
 def _attests_to_itself(attestor: Any, producer: Any, registry: Any) -> bool:

--- a/athf/core/verdicts.py
+++ b/athf/core/verdicts.py
@@ -1,0 +1,286 @@
+"""The verdict ladder: shared vocabulary for hunt outcomes.
+
+Five verdicts replace the old ``TP`` / ``FP`` / ``inconclusive`` triple, each
+carrying a gate that says what it takes to claim it:
+
+- ``confirmed`` — telemetry evidence **plus** independent confirmation from
+  outside the log corpus (controlled reproduction, host forensics, or
+  configuration review).
+- ``suspected`` — telemetry evidence only. The ceiling when you cannot
+  independently confirm.
+- ``attempted_not_vulnerable`` — attack behavior observed and the named
+  control demonstrably held.
+- ``benign`` — explained as legitimate activity.
+- ``inconclusive`` — insufficient telemetry to decide.
+
+Telemetry alone never reaches ``confirmed``. See
+``athf/data/hunts/FORMAT_GUIDELINES.md`` for the field reference.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+CONFIRMED = "confirmed"
+SUSPECTED = "suspected"
+ATTEMPTED_NOT_VULNERABLE = "attempted_not_vulnerable"
+BENIGN = "benign"
+INCONCLUSIVE = "inconclusive"
+
+VERDICTS = (
+    CONFIRMED,
+    SUSPECTED,
+    ATTEMPTED_NOT_VULNERABLE,
+    BENIGN,
+    INCONCLUSIVE,
+)
+
+LEGACY_VERDICTS = ("tp", "fp")
+
+_ALIASES = {"attempted-not-vulnerable": ATTEMPTED_NOT_VULNERABLE}
+
+_POSITIVE = frozenset({CONFIRMED, "tp"})
+_NEGATIVE = frozenset({BENIGN, "fp"})
+
+# Which frontmatter list each verdict belongs in. ``findings`` is what you are
+# reporting as malicious; ``ruled_out`` is what closed the question. Keeping them
+# apart is what lets a report say "here is what we found, and here is what your
+# controls stopped" instead of collapsing both into one number.
+EXPECTED_LIST = {
+    CONFIRMED: "findings",
+    SUSPECTED: "findings",
+    ATTEMPTED_NOT_VULNERABLE: "ruled_out",
+    BENIGN: "ruled_out",
+    INCONCLUSIVE: "ruled_out",
+}
+
+# Ways of writing "I did not actually do this" that a truthiness check would
+# accept. An agent optimizing for the cheapest path past validation reaches for
+# these long before it reaches for anything Python considers falsy.
+_PLACEHOLDERS = frozenset(
+    {
+        "",
+        "-",
+        "--",
+        "---",
+        ".",
+        "..",
+        "...",
+        "?",
+        "??",
+        "n/a",
+        "n\\a",
+        "na",
+        "n.a.",
+        "nil",
+        "no",
+        "none",
+        "not applicable",
+        "not available",
+        "not confirmed",
+        "not done",
+        "null",
+        "ok",
+        "pending",
+        "tbc",
+        "tbd",
+        "todo",
+        "unconfirmed",
+        "unknown",
+        "yes",
+    }
+)
+
+# Shortest string that can plausibly describe what was checked. Every legitimate
+# example in the format guidelines is a full clause; this only has to be long
+# enough that a token of assent cannot pass for an account.
+_MIN_SUBSTANTIVE_LEN = 12
+
+# Nouns that name the log corpus itself. Confirmation that cites one of these as
+# its source is circular: the corpus is the thing being confirmed.
+_CORPUS = (
+    r"(?:telemetry|log(?:s|\s+data)?|quer(?:y|ies)|query\s+results?"
+    r"|events?|evidence|data|above)"
+)
+
+# Ways of answering "how did you independently confirm this?" by pointing back at
+# the input. An agent asked to confirm a finding reaches for the cheapest passing
+# answer, and the cheapest is to cite the logs it just finished reading.
+_SELF_REFERENCE_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        # "see telemetry above", "see the evidence field", "see above"
+        r"^(?:please\s+)?see\b",
+        # Opening with a deferral is a pointer regardless of what it points at.
+        r"^as\s+(?:shown|described|noted|stated|documented|detailed)\b",
+        # "per the query results" — but not "per the host forensics report"
+        r"^per\s+(?:the\s+)?" + _CORPUS + r"\b",
+        # "same as evidence", "same as above"
+        r"^same\s+as\b",
+        # "confirmed by the telemetry" — the corpus cannot confirm itself
+        r"\bconfirm(?:ed|s|ation)?\s+(?:by|from|in|via)\s+(?:the\s+)?" + _CORPUS + r"\b",
+        # "the log data confirms it", "telemetry already confirmed this"
+        r"\b" + _CORPUS + r"\s+(?:\w+\s+)?confirm(?:s|ed)?\b",
+    )
+)
+
+
+class VerdictError(ValueError):
+    """Raised when a verdict string is not part of the accepted vocabulary.
+
+    Subclasses ``ValueError`` so callers that documented ``ValueError`` on
+    their public API keep that contract.
+    """
+
+
+def _soften(raw: Any) -> str:
+    """Lowercase / de-hyphenate without raising. Unknowns pass through."""
+    if not isinstance(raw, str):
+        return ""
+    candidate = raw.strip().lower()
+    return _ALIASES.get(candidate, candidate)
+
+
+def normalize_verdict(raw: Any) -> str:
+    """Return the canonical form of ``raw``, or raise :class:`VerdictError`.
+
+    Accepts the five ladder verdicts (case-insensitive, and
+    ``attempted-not-vulnerable`` for the hyphenated spelling) plus the legacy
+    ``tp`` / ``fp`` values.
+
+    Legacy ``tp`` / ``fp`` are returned lowercased but NOT remapped onto the
+    ladder: those outcomes were recorded before the evidence gate existed, so
+    promoting a legacy ``tp`` to ``confirmed`` would fabricate rigor nobody
+    can vouch for.
+    """
+    if not isinstance(raw, str):
+        raise VerdictError(
+            "verdict must be a string; got {!r}".format(raw)
+        )
+
+    candidate = _soften(raw)
+    if candidate in VERDICTS or candidate in LEGACY_VERDICTS:
+        return candidate
+
+    raise VerdictError(
+        "verdict must be one of {}; got {!r}".format(
+            ", ".join(VERDICTS + LEGACY_VERDICTS), raw
+        )
+    )
+
+
+def requires_evidence(verdict: Any) -> bool:
+    """Return ``True`` when the verdict is subject to the evidence gate."""
+    return _soften(verdict) == CONFIRMED
+
+
+def counts_as_positive(verdict: Any) -> bool:
+    """Return ``True`` when the verdict participates in precision as a positive.
+
+    ``suspected`` never passed the evidence gate, so it is deliberately
+    excluded — counting it would import unverified findings into a quality
+    number.
+    """
+    return _soften(verdict) in _POSITIVE
+
+
+def counts_as_negative(verdict: Any) -> bool:
+    """Return ``True`` when the verdict participates in precision as a negative.
+
+    ``attempted_not_vulnerable`` is excluded: the behavior really was there,
+    so the hunt was right. Scoring a working control as a false positive would
+    punish hunters for reporting blocked attacks.
+    """
+    return _soften(verdict) in _NEGATIVE
+
+
+def is_substantive(value: Any) -> bool:
+    """Return ``True`` when ``value`` is prose that accounts for something.
+
+    Guards the evidence gate and the control-naming rule. Non-strings are
+    rejected outright: ``confirmation: true`` asserts that confirmation happened
+    without saying what was done, which is exactly the claim the gate exists to
+    refuse. Placeholders and single tokens of assent are rejected for the same
+    reason — the gate asks what you checked, not whether you'd like to pass.
+    """
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip()
+    if candidate.lower().rstrip(".") in _PLACEHOLDERS:
+        return False
+    return len(candidate) >= _MIN_SUBSTANTIVE_LEN
+
+
+def is_self_referential(value: Any) -> bool:
+    """Return ``True`` when ``value`` cites the log corpus as its own confirmation.
+
+    Applies to ``confirmation`` only. Mentioning telemetry is fine — "forensic
+    image shows the crontab entry matching the process_activity log" is exactly
+    the corroboration the ladder wants — so this anchors on the phrasings that
+    *defer* to the corpus rather than scanning for telemetry words anywhere.
+    """
+    if not isinstance(value, str):
+        return False
+    candidate = " ".join(value.split())
+    return any(pattern.search(candidate) for pattern in _SELF_REFERENCE_PATTERNS)
+
+
+def tally_frontmatter_verdicts(
+    frontmatter: Mapping[str, Any]
+) -> Optional[Dict[str, int]]:
+    """Tally verdicts across the ``findings`` / ``ruled_out`` frontmatter lists.
+
+    Returns ``None`` when neither key holds a non-empty list, letting callers
+    fall back to legacy counters. Malformed entries are skipped rather than
+    raised: ``athf hunt validate`` is where a hunter is told their file is
+    wrong, so reporting must survive anything already on disk.
+    """
+    found = False
+    counts = {verdict: 0 for verdict in VERDICTS}
+
+    for key in ("findings", "ruled_out"):
+        value = frontmatter.get(key)
+        if not isinstance(value, list):
+            continue
+        found = found or bool(value)
+        for entry in value:
+            if not isinstance(entry, Mapping):
+                continue
+            candidate = _soften(entry.get("verdict"))
+            # A verdict is only counted from the list it belongs in. Otherwise a
+            # `confirmed` entry parked in ``ruled_out`` would be credited as a
+            # positive, which is the report separation collapsing quietly —
+            # `athf hunt validate` rejects that shape, so drop it here.
+            if EXPECTED_LIST.get(candidate) == key:
+                counts[candidate] += 1
+
+    return counts if found else None
+
+
+def precision_pair(counts: Mapping[str, int]) -> Tuple[int, int]:
+    """Return ``(positives, negatives)`` for a per-verdict count mapping."""
+    positives = sum(n for v, n in counts.items() if counts_as_positive(v))
+    negatives = sum(n for v, n in counts.items() if counts_as_negative(v))
+    return positives, negatives
+
+
+__all__ = [
+    "VERDICTS",
+    "LEGACY_VERDICTS",
+    "CONFIRMED",
+    "SUSPECTED",
+    "ATTEMPTED_NOT_VULNERABLE",
+    "BENIGN",
+    "INCONCLUSIVE",
+    "VerdictError",
+    "normalize_verdict",
+    "requires_evidence",
+    "counts_as_positive",
+    "counts_as_negative",
+    "EXPECTED_LIST",
+    "is_substantive",
+    "is_self_referential",
+    "tally_frontmatter_verdicts",
+    "precision_pair",
+]

--- a/athf/core/verdicts.py
+++ b/athf/core/verdicts.py
@@ -420,9 +420,6 @@ def _provenance_failures(confirmation: Any, registry: Any) -> List[Tuple[str, An
     """
     from athf.core.provenance import CORPUS_ONLY_CAPABILITIES, SELF_DECLARATION_KEYS
 
-    if not isinstance(confirmation, Mapping):
-        return [(MISSING_PROVENANCE, confirmation)]
-
     failures: List[Tuple[str, Any]] = []
 
     # Capability declared inside the finding is the forgeable field this gate

--- a/athf/core/verdicts.py
+++ b/athf/core/verdicts.py
@@ -97,31 +97,120 @@ _PLACEHOLDERS = frozenset(
 # enough that a token of assent cannot pass for an account.
 _MIN_SUBSTANTIVE_LEN = 12
 
+# Characters that carry no meaning but move a string's first word out of reach of
+# an anchored pattern. A zero-width space in front of "see telemetry above" bought
+# a pass; twelve of the measured misses were nothing but a lead-in like this.
+_ZERO_WIDTH = re.compile(r"[​-‏⁠﻿]")
+_LEAD_IN = re.compile(r"^(?:\d+[.)]\s*|[\W_])+")
+
+# The closing half of a wrapper. `_same as above_` kept its underscore glued to
+# `above`, and an underscore is a word character, so the word boundary the pattern
+# needed was never there.
+_TRAIL_OUT = re.compile(r"[\W_]+$")
+
 # Nouns that name the log corpus itself. Confirmation that cites one of these as
 # its source is circular: the corpus is the thing being confirmed.
+#
+# Deliberately not extended. Measurement says this class is open — 18 of 18
+# corpus synonyms a hunter might reach for instead ("the dataset", "the rows",
+# "the index") pass untouched, and each noun added invites another. Enumeration
+# raises the cost of the cheapest circular phrasing; it cannot close the gap.
+# What closes it is knowing who produced the confirmation, not reading it.
 _CORPUS = (
     r"(?:telemetry|log(?:s|\s+data)?|quer(?:y|ies)|query\s+results?"
     r"|events?|evidence|data|above)"
 )
 
+# Verbs for the confirmation work itself. Used to require that a deferral is
+# deferring *confirmation* rather than merely containing a word like "pending".
+_CONFIRMATION_WORK = (
+    r"(?:confirm\w*|validat\w*|verif\w*|corroborat\w*|forensic\w*|reproduc\w*"
+    r"|acquisition|acquir\w*|detonat\w*|imag(?:e|ed|ing)|triage|review\w*"
+    r"|interview\w*|range\s+test)"
+)
+
 # Ways of answering "how did you independently confirm this?" by pointing back at
 # the input. An agent asked to confirm a finding reaches for the cheapest passing
 # answer, and the cheapest is to cite the logs it just finished reading.
-_SELF_REFERENCE_PATTERNS = tuple(
+#
+# Every pattern requires a corpus noun. An earlier version also matched citation
+# grammar on its own (`^see`, `^as documented`), which turned out to be the single
+# largest source of false blocks: it rejected "As documented in the range runbook,
+# we replayed the technique" — a real detonation, refused for its opening clause.
+_CORPUS_CITATION_PATTERNS = tuple(
     re.compile(pattern, re.IGNORECASE)
     for pattern in (
-        # "see telemetry above", "see the evidence field", "see above"
-        r"^(?:please\s+)?see\b",
-        # Opening with a deferral is a pointer regardless of what it points at.
-        r"^as\s+(?:shown|described|noted|stated|documented|detailed)\b",
-        # "per the query results" — but not "per the host forensics report"
-        r"^per\s+(?:the\s+)?" + _CORPUS + r"\b",
+        # "see telemetry above", "see the evidence above", "see above" — but not
+        # "see the attached forensic report", which points outside the corpus.
+        r"\b(?:please\s+)?see\s+(?:the\s+)?" + _CORPUS + r"\b",
         # "same as evidence", "same as above"
-        r"^same\s+as\b",
-        # "confirmed by the telemetry" — the corpus cannot confirm itself
-        r"\bconfirm(?:ed|s|ation)?\s+(?:by|from|in|via)\s+(?:the\s+)?" + _CORPUS + r"\b",
-        # "the log data confirms it", "telemetry already confirmed this"
-        r"\b" + _CORPUS + r"\s+(?:\w+\s+)?confirm(?:s|ed)?\b",
+        r"\bsame\s+as\s+(?:the\s+)?" + _CORPUS + r"\b",
+        # "per the query results" — but not "per the host forensics report"
+        r"\bper\s+(?:the\s+)?" + _CORPUS + r"\b",
+        # "confirmed by the telemetry", "validated in the events we already have"
+        r"\b(?:confirm|validat|verif|corroborat)\w*\s+(?:by|from|in|via)\s+"
+        r"(?:the\s+)?" + _CORPUS + r"\b",
+        # "the log data confirms it", "our telemetry confirms this". The corpus
+        # noun has to be bare or take a bare determiner — "the forensic image data
+        # confirms the artifact on disk" is outside work and must pass.
+        r"(?:^|\b(?:the|this|that|these|those|our|my|its)\s+)" + _CORPUS
+        + r"\s+(?:\w+\s+)?confirm(?:s|ed)?\b",
+        # "as shown in the telemetry above", "as documented in the events listed
+        # above". Citation grammar is only circular when it cites the corpus, so
+        # the corpus noun has to be inside the citation itself — "as documented in
+        # the range runbook, we replayed the technique" points somewhere real.
+        r"^as\s+(?:shown|described|noted|stated|documented|detailed)\s+"
+        r"(?:\w+\s+){0,3}?" + _CORPUS + r"\b",
+    )
+)
+
+# Ways of saying "I did not do the confirmation" in the field that asserts it was
+# done. Unlike citing the corpus this is honest — the verdict is simply the wrong
+# one — so it earns its own reason code and its own instruction.
+#
+# Each pattern is narrowed to the confirmation claim rather than matching its
+# vocabulary anywhere in the sentence. Unnarrowed, these rejected "recovered the
+# scheduled task XML under C:\Windows\System32\Tasks\Updater" on `scheduled`, "the
+# deployment tool cannot produce this argument pattern" on `cannot`, and "the role
+# could not have assumed the admin role" on both — ordinary hunting prose, and the
+# fastest way to teach a hunter that the gate is noise worth routing around.
+_DEFERRAL_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        # "pending host forensics", "confirmation deferred to IR", "still outstanding"
+        r"\b(?:pend(?:ing|s)?|await(?:ing|s)?|outstanding|deferred?|queued)\b",
+        # "Planned: detonate in the range next sprint" — a plan, stated as a result
+        r"^(?:planned|scheduled|to\s?do|next\s+steps?)\b",
+        # "will confirm later", "not yet independently verified"
+        r"\b(?:not\s+yet|yet\s+to\s+be|will\s+(?:be\s+)?confirm"
+        r"|to\s+be\s+(?:confirmed|validated|verified)|follow-?up\s+required"
+        r"|requires?\s+further|needs?\s+independent)\b",
+        # "no independent confirmation performed", "reproduction not attempted",
+        # "no out-of-band confirmation obtained" — hyphenated qualifiers count as
+        # one intervening word, so the filler class allows them.
+        r"\b(?:no|none|not|never|nothing)\s+(?:[\w-]+\s+){0,3}?"
+        r"(?:confirm\w*|valid\w*|verif\w*|forensic\w*|reproduc\w*|review\w*"
+        r"|perform\w*|happen\w*|obtain\w*|done|attempted|possible|available|recovered)\b",
+        # "so this remains unconfirmed" — the negation is inside the word
+        r"\b(?:remains?|still|is|are|was|were)\s+un(?:confirmed|verified|validated"
+        r"|corroborated|substantiated)\b",
+        # "could not validate", "unable to acquire the host" — the analyst is the
+        # one who could not, not some component of the attack being described.
+        r"\b(?:could\s*n[o']?t|cannot|can'?t|unable\s+to|was\s+not\s+able\s+to"
+        r"|fail(?:ed|s)?\s+to|unsuccessful\s+at)\s+(?:\w+\s+){0,3}?"
+        + _CONFIRMATION_WORK + r"\b",
+        # "confirmation attempt failed"
+        r"\b" + _CONFIRMATION_WORK + r"\s+(?:\w+\s+){0,2}?(?:fail\w*|unsuccessful)\b",
+        # "assumed confirmed", "presumed malicious" — but not "assumed the admin role"
+        r"\b(?:assum|presum)\w+\s+(?:\w+\s+){0,2}?"
+        r"(?:confirm\w*|valid\w*|verif\w*|malicious|benign|true|compromis\w*)\b",
+        # Hedges. A confirmation field is where you say what you did; "probably"
+        # and "self-evident" are how you say you did nothing.
+        r"\b(?:likely|probably|believed|inferred|self-?evident|obvious"
+        r"|trust\s+me|reasonably\s+certain|unverified)\b",
+        # "out of scope", "accepted risk", "closed without confirmation"
+        r"\b(?:out\s+of\s+scope|deprioriti\w+|declined|waived|skipped"
+        r"|without\s+confirmation|accepted\s+risk|not\s+worth)\b",
     )
 )
 
@@ -212,18 +301,49 @@ def is_substantive(value: Any) -> bool:
     return len(candidate) >= _MIN_SUBSTANTIVE_LEN
 
 
-def is_self_referential(value: Any) -> bool:
-    """Return ``True`` when ``value`` cites the log corpus as its own confirmation.
+def _normalize_prose(value: str) -> str:
+    """Collapse whitespace and strip decorative lead-ins.
+
+    Markdown bullets, quote markers, list numbers, wrapping quotes and zero-width
+    characters all changed which pattern could reach a string's first word without
+    changing what it says. Normalizing here means the patterns describe phrasings
+    rather than formatting.
+    """
+    candidate = " ".join(_ZERO_WIDTH.sub("", value).split())
+    return _TRAIL_OUT.sub("", _LEAD_IN.sub("", candidate))
+
+
+def cites_the_corpus(value: Any) -> bool:
+    """Return ``True`` when ``value`` offers the log corpus as its own confirmation.
 
     Applies to ``confirmation`` only. Mentioning telemetry is fine — "forensic
     image shows the crontab entry matching the process_activity log" is exactly
-    the corroboration the ladder wants — so this anchors on the phrasings that
-    *defer* to the corpus rather than scanning for telemetry words anywhere.
+    the corroboration the ladder wants — so this matches the phrasings that
+    *defer to* the corpus, not every occurrence of a telemetry word.
+
+    A passing result means no circular phrasing was recognized. It is not evidence
+    that confirmation happened: measured against 128 deliberately circular strings
+    this misses 11%, and "cross-validated by running a second query against the
+    same table" is invisible to any pattern set. Reading a confirmation cannot
+    establish that the work behind it occurred.
     """
     if not isinstance(value, str):
         return False
-    candidate = " ".join(value.split())
-    return any(pattern.search(candidate) for pattern in _SELF_REFERENCE_PATTERNS)
+    candidate = _normalize_prose(value)
+    return any(pattern.search(candidate) for pattern in _CORPUS_CITATION_PATTERNS)
+
+
+def defers_confirmation(value: Any) -> bool:
+    """Return ``True`` when ``value`` says the confirmation has not happened yet.
+
+    "Pending host forensics" in a ``confirmation`` field is not a circular
+    argument — it is an accurate note attached to the wrong verdict. Separated
+    from :func:`cites_the_corpus` so the hunter is told to downgrade to
+    ``suspected`` rather than accused of reasoning in a circle.
+    """
+    if not isinstance(value, str):
+        return False
+    return any(pattern.search(_normalize_prose(value)) for pattern in _DEFERRAL_PATTERNS)
 
 
 # Reason codes returned by :func:`gate_failures`. Callers render these however
@@ -236,7 +356,28 @@ LEGACY_VERDICT = "legacy_verdict"
 MISROUTED = "misrouted"
 UNSUPPORTED_CONFIRMATION = "unsupported_confirmation"
 CIRCULAR_CONFIRMATION = "circular_confirmation"
+DEFERRED_CONFIRMATION = "deferred_confirmation"
 UNNAMED_CONTROL = "unnamed_control"
+
+
+def _evidence_gate_failures(entry: Mapping[str, Any]) -> List[Tuple[str, Any]]:
+    """Return why ``entry`` does not carry independent confirmation.
+
+    The evidence gate: telemetry alone never reaches ``confirmed``. Confirmation
+    from outside the log corpus is mandatory, and it has to say what was checked —
+    ``n/a`` and ``ok`` are how you spell "I didn't confirm this" while still
+    satisfying a truthiness check.
+    """
+    unusable = [f for f in ("evidence", "confirmation") if not is_substantive(entry.get(f))]
+    if unusable:
+        return [(UNSUPPORTED_CONFIRMATION, unusable)]
+
+    confirmation = entry.get("confirmation")
+    if cites_the_corpus(confirmation):
+        return [(CIRCULAR_CONFIRMATION, confirmation)]
+    if defers_confirmation(confirmation):
+        return [(DEFERRED_CONFIRMATION, confirmation)]
+    return []
 
 
 def gate_failures(key: str, entry: Any) -> List[Tuple[str, Any]]:
@@ -277,16 +418,8 @@ def gate_failures(key: str, entry: Any) -> List[Tuple[str, Any]]:
     if expected != key:
         failures.append((MISROUTED, (verdict, expected)))
 
-    # The evidence gate: telemetry alone never reaches confirmed. An independent
-    # confirmation from outside the log corpus is mandatory, and it has to say
-    # what was checked — 'n/a' and 'ok' are how you spell "I didn't confirm this"
-    # while still satisfying a truthiness check.
     if requires_evidence(verdict):
-        unusable = [f for f in ("evidence", "confirmation") if not is_substantive(entry.get(f))]
-        if unusable:
-            failures.append((UNSUPPORTED_CONFIRMATION, unusable))
-        elif is_self_referential(entry.get("confirmation")):
-            failures.append((CIRCULAR_CONFIRMATION, entry.get("confirmation")))
+        failures.extend(_evidence_gate_failures(entry))
 
     if verdict == ATTEMPTED_NOT_VULNERABLE and not is_substantive(entry.get("control")):
         failures.append((UNNAMED_CONTROL, entry.get("control")))
@@ -350,7 +483,8 @@ __all__ = [
     "counts_as_negative",
     "EXPECTED_LIST",
     "is_substantive",
-    "is_self_referential",
+    "cites_the_corpus",
+    "defers_confirmation",
     "gate_failures",
     "entry_fails_gate",
     "NOT_A_MAPPING",
@@ -360,6 +494,7 @@ __all__ = [
     "MISROUTED",
     "UNSUPPORTED_CONFIRMATION",
     "CIRCULAR_CONFIRMATION",
+    "DEFERRED_CONFIRMATION",
     "UNNAMED_CONTROL",
     "tally_frontmatter_verdicts",
     "precision_pair",

--- a/athf/core/verdicts.py
+++ b/athf/core/verdicts.py
@@ -358,29 +358,155 @@ UNSUPPORTED_CONFIRMATION = "unsupported_confirmation"
 CIRCULAR_CONFIRMATION = "circular_confirmation"
 DEFERRED_CONFIRMATION = "deferred_confirmation"
 UNNAMED_CONTROL = "unnamed_control"
+MISSING_PROVENANCE = "missing_provenance"
+UNKNOWN_PRODUCER = "unknown_producer"
+METHOD_EXCEEDS_CAPABILITY = "method_exceeds_capability"
+CORPUS_ONLY_METHOD = "corpus_only_method"
+SELF_DECLARED_CAPABILITY = "self_declared_capability"
+UNATTESTED = "unattested"
+
+# Ways of filling ``attested_by`` without naming anyone answerable. The first is
+# not hypothetical: ``athf hunt new`` defaults ``--hunter`` to "AI Assistant", so
+# the placeholder ships with the tool. A role, a team, or the automation itself
+# cannot vouch for out-of-corpus work — only a person can.
+_UNATTRIBUTABLE = frozenset(
+    {
+        "agent",
+        "ai",
+        "ai assistant",
+        "assistant",
+        "athf",
+        "automation",
+        "bot",
+        "claude",
+        "llm",
+        "pipeline",
+        "robot",
+        "script",
+        "system",
+        "team",
+        "the team",
+    }
+)
+
+# Shortest string that can name a person. "Jo" is two.
+_MIN_NAME_LEN = 2
 
 
-def _evidence_gate_failures(entry: Mapping[str, Any]) -> List[Tuple[str, Any]]:
+def is_attributable(value: Any) -> bool:
+    """Return ``True`` when ``value`` names someone who could be asked about it.
+
+    Deliberately permissive about *shape* — "J. Halloran" and an email address
+    both name a person, and a name-shaped pattern would reject real people. It
+    only refuses the placeholders and role words that name nobody.
+    """
+    if not isinstance(value, str):
+        return False
+    candidate = " ".join(value.split())
+    if len(candidate) < _MIN_NAME_LEN:
+        return False
+    folded = candidate.lower().rstrip(".")
+    return folded not in _UNATTRIBUTABLE and folded not in _PLACEHOLDERS
+
+
+def _provenance_failures(confirmation: Any, registry: Any) -> List[Tuple[str, Any]]:
+    """Return why ``confirmation`` does not establish out-of-corpus provenance.
+
+    Net-new ``confirmed`` requires a confirmation mapping: ``method``,
+    ``produced_by``, ``attested_by``, ``detail``. Prose alone carries no producer,
+    so it cannot clear this gate however well it reads — that is the point. The
+    measured ceiling on reading confirmations is why the producer, not the
+    sentence, decides whether ``confirmed`` is reachable.
+    """
+    from athf.core.provenance import CORPUS_ONLY_CAPABILITIES, SELF_DECLARATION_KEYS
+
+    if not isinstance(confirmation, Mapping):
+        return [(MISSING_PROVENANCE, confirmation)]
+
+    failures: List[Tuple[str, Any]] = []
+
+    # Capability declared inside the finding is the forgeable field this gate
+    # replaces. Refused rather than ignored, so nobody believes it counted.
+    self_declared = [k for k in SELF_DECLARATION_KEYS if k in confirmation]
+    if self_declared:
+        failures.append((SELF_DECLARED_CAPABILITY, self_declared))
+
+    producer = confirmation.get("produced_by")
+    method = confirmation.get("method")
+
+    if not is_substantive(confirmation.get("detail")):
+        failures.append((UNSUPPORTED_CONFIRMATION, ["confirmation.detail"]))
+    else:
+        detail = confirmation["detail"]
+        if cites_the_corpus(detail):
+            failures.append((CIRCULAR_CONFIRMATION, detail))
+        elif defers_confirmation(detail):
+            failures.append((DEFERRED_CONFIRMATION, detail))
+
+    if not is_attributable(confirmation.get("attested_by")):
+        failures.append((UNATTESTED, confirmation.get("attested_by")))
+
+    if not isinstance(method, str) or not method.strip():
+        failures.append((MISSING_PROVENANCE, "confirmation.method"))
+        return failures
+
+    normalized = method.strip().lower()
+
+    # Querying is real work and still cannot confirm: the corpus cannot
+    # corroborate itself. Checked before capability so that declaring a
+    # corpus-only capability never unlocks ``confirmed``.
+    if normalized in CORPUS_ONLY_CAPABILITIES:
+        failures.append((CORPUS_ONLY_METHOD, method))
+        return failures
+
+    if registry is None or not registry.knows(producer):
+        failures.append((UNKNOWN_PRODUCER, producer))
+        return failures
+
+    if normalized not in registry.capabilities_for(producer):
+        failures.append((METHOD_EXCEEDS_CAPABILITY, (producer, method)))
+
+    return failures
+
+
+def _evidence_gate_failures(
+    entry: Mapping[str, Any], registry: Any = None
+) -> List[Tuple[str, Any]]:
     """Return why ``entry`` does not carry independent confirmation.
 
     The evidence gate: telemetry alone never reaches ``confirmed``. Confirmation
     from outside the log corpus is mandatory, and it has to say what was checked —
     ``n/a`` and ``ok`` are how you spell "I didn't confirm this" while still
     satisfying a truthiness check.
+
+    Net-new ``confirmed`` carries a confirmation *mapping* and is judged on
+    provenance. A string confirmation is the pre-provenance shape: it is held to
+    the prose check it was written against, and cannot reach ``confirmed``,
+    because no sentence identifies who produced it.
     """
-    unusable = [f for f in ("evidence", "confirmation") if not is_substantive(entry.get(f))]
-    if unusable:
-        return [(UNSUPPORTED_CONFIRMATION, unusable)]
+    if not is_substantive(entry.get("evidence")):
+        return [(UNSUPPORTED_CONFIRMATION, ["evidence"])]
 
     confirmation = entry.get("confirmation")
+
+    if isinstance(confirmation, Mapping):
+        return _provenance_failures(confirmation, registry)
+
+    if not is_substantive(confirmation):
+        return [(UNSUPPORTED_CONFIRMATION, ["confirmation"])]
+
+    # Prose confirmation. Still checked for circularity and deferral so the
+    # hunter gets the specific reason, then refused for lacking provenance.
+    failures: List[Tuple[str, Any]] = []
     if cites_the_corpus(confirmation):
-        return [(CIRCULAR_CONFIRMATION, confirmation)]
-    if defers_confirmation(confirmation):
-        return [(DEFERRED_CONFIRMATION, confirmation)]
-    return []
+        failures.append((CIRCULAR_CONFIRMATION, confirmation))
+    elif defers_confirmation(confirmation):
+        failures.append((DEFERRED_CONFIRMATION, confirmation))
+    failures.append((MISSING_PROVENANCE, confirmation))
+    return failures
 
 
-def gate_failures(key: str, entry: Any) -> List[Tuple[str, Any]]:
+def gate_failures(key: str, entry: Any, registry: Any = None) -> List[Tuple[str, Any]]:
     """Return the reasons ``entry`` in list ``key`` does not earn its verdict.
 
     The single source of truth behind both enforcement surfaces. Validation
@@ -419,21 +545,30 @@ def gate_failures(key: str, entry: Any) -> List[Tuple[str, Any]]:
         failures.append((MISROUTED, (verdict, expected)))
 
     if requires_evidence(verdict):
-        failures.extend(_evidence_gate_failures(entry))
+        failures.extend(_evidence_gate_failures(entry, registry))
 
     if verdict == ATTEMPTED_NOT_VULNERABLE and not is_substantive(entry.get("control")):
         failures.append((UNNAMED_CONTROL, entry.get("control")))
 
+    # Capability declared at the top level of the finding, rather than inside the
+    # confirmation. Same forgery, one level up.
+    if requires_evidence(verdict):
+        from athf.core.provenance import SELF_DECLARATION_KEYS
+
+        stray = [k for k in SELF_DECLARATION_KEYS if k in entry]
+        if stray and not any(code == SELF_DECLARED_CAPABILITY for code, _ in failures):
+            failures.append((SELF_DECLARED_CAPABILITY, stray))
+
     return failures
 
 
-def entry_fails_gate(key: str, entry: Any) -> bool:
+def entry_fails_gate(key: str, entry: Any, registry: Any = None) -> bool:
     """Return ``True`` when ``entry`` in list ``key`` does not earn its verdict."""
-    return bool(gate_failures(key, entry))
+    return bool(gate_failures(key, entry, registry))
 
 
 def tally_frontmatter_verdicts(
-    frontmatter: Mapping[str, Any]
+    frontmatter: Mapping[str, Any], registry: Any = None
 ) -> Optional[Dict[str, int]]:
     """Tally verdicts across the ``findings`` / ``ruled_out`` frontmatter lists.
 
@@ -454,7 +589,7 @@ def tally_frontmatter_verdicts(
             continue
         found = found or bool(value)
         for entry in value:
-            if entry_fails_gate(key, entry):
+            if entry_fails_gate(key, entry, registry):
                 continue
             counts[_soften(entry.get("verdict"))] += 1
 
@@ -496,6 +631,13 @@ __all__ = [
     "CIRCULAR_CONFIRMATION",
     "DEFERRED_CONFIRMATION",
     "UNNAMED_CONTROL",
+    "MISSING_PROVENANCE",
+    "UNKNOWN_PRODUCER",
+    "METHOD_EXCEEDS_CAPABILITY",
+    "CORPUS_ONLY_METHOD",
+    "SELF_DECLARED_CAPABILITY",
+    "UNATTESTED",
+    "is_attributable",
     "tally_frontmatter_verdicts",
     "precision_pair",
 ]

--- a/athf/data/docs/CLI_REFERENCE.md
+++ b/athf/data/docs/CLI_REFERENCE.md
@@ -731,8 +731,8 @@ data_sources:
   - edr-telemetry
 severity: high
 tags: []
-true_positives: 0
-false_positives: 0
+findings: []      # confirmed | suspected (populate during KEEP)
+ruled_out: []     # attempted_not_vulnerable | benign (populate during KEEP)
 ---
 
 ## LEARN
@@ -933,6 +933,14 @@ Summary: 3 valid, 1 invalid
 
 **Status values**:
 - Must be one of: `in-progress`, `completed`, `paused`, `archived`
+
+**Verdicts** (when `findings` / `ruled_out` are present):
+- Every entry must carry a `verdict` from: `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`
+- **Evidence gate:** `verdict: confirmed` requires a non-empty `confirmation` field. Telemetry in `evidence` alone caps the entry at `suspected`
+- **Routing rule:** `attempted_not_vulnerable` and `benign` must appear in `ruled_out`, never in `findings`
+- `attempted_not_vulnerable` entries must name the control that held
+
+See [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) → The Verdict Ladder for entry shapes.
 
 ### Exit Codes
 
@@ -2213,9 +2221,14 @@ athf metrics extract --output /tmp/snapshot.json      # capture a snapshot
 
 Append a single event manually. Useful for closing out hunts (TP / FP) and for plugin / scripting use.
 
+Valid `outcome` values are the five verdicts — `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`. Legacy `tp` / `fp` still parse.
+
 ```bash
 # Record a hunt outcome
-athf metrics record --type hunt_outcome --hunt H-0019 --field outcome=tp
+athf metrics record --type hunt_outcome --hunt H-0019 --field outcome=confirmed
+
+# The control held — record it, don't drop it
+athf metrics record --type hunt_outcome --hunt H-0020 --field outcome=attempted_not_vulnerable
 
 # Record a custom step
 athf metrics record --type manual --hunt H-0019 \
@@ -2234,7 +2247,7 @@ athf metrics record --type query --hunt H-0019 --field duration_ms=42 --field ro
 athf metrics extract                       # refresh aggregates
 athf metrics summary                       # overall view
 athf metrics show --hunt H-0019            # zoom into one hunt
-athf metrics record --type hunt_outcome --hunt H-0019 --field outcome=tp
+athf metrics record --type hunt_outcome --hunt H-0019 --field outcome=confirmed
 ```
 
 ### Exit Codes

--- a/athf/data/docs/CLI_REFERENCE.md
+++ b/athf/data/docs/CLI_REFERENCE.md
@@ -936,7 +936,7 @@ Summary: 3 valid, 1 invalid
 
 **Verdicts** (when `findings` / `ruled_out` are present):
 - Every entry must carry a `verdict` from: `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`
-- **Evidence gate:** `verdict: confirmed` requires `confirmation` to be a mapping — not a scalar — carrying a supported `method`, a `produced_by` declared in the workspace-root `.athfconfig.yaml`, an `attested_by` naming a person distinct from the producer, and a non-empty `detail`. Telemetry in `evidence` alone caps the entry at `suspected`
+- **Evidence gate:** `verdict: confirmed` requires `confirmation` to be a mapping — not a scalar — carrying a supported `method`, a `produced_by` declared in the workspace-root `.athfconfig.yaml` whose declared capabilities include that `method` and reach beyond query-only access, an `attested_by` naming a person distinct from the producer, and a non-empty `detail`. Telemetry in `evidence` alone — or a producer that can only read the corpus — caps the entry at `suspected`
 - **Routing rule:** `attempted_not_vulnerable`, `benign`, and `inconclusive` must appear in `ruled_out`, never in `findings`
 - `attempted_not_vulnerable` entries must name the control that held
 

--- a/athf/data/docs/CLI_REFERENCE.md
+++ b/athf/data/docs/CLI_REFERENCE.md
@@ -2223,9 +2223,11 @@ Append a single event manually. Useful for closing out hunts (TP / FP) and for p
 
 Valid `outcome` values are the five verdicts — `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`. Legacy `tp` / `fp` still parse.
 
+> **`confirmed` is stored but not counted here.** A `hunt_outcome` event names no producer, so it cannot pass the provenance gate — `outcome=confirmed` records for audit but never increments the `confirmed` / `true_positives` aggregates. To have a confirmed result count, write it as a `findings` entry in the hunt file, with its `confirmation` mapping, and let `athf metrics extract` pick it up. See [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) → The Verdict Ladder.
+
 ```bash
 # Record a hunt outcome
-athf metrics record --type hunt_outcome --hunt H-0019 --field outcome=confirmed
+athf metrics record --type hunt_outcome --hunt H-0019 --field outcome=suspected
 
 # The control held — record it, don't drop it
 athf metrics record --type hunt_outcome --hunt H-0020 --field outcome=attempted_not_vulnerable
@@ -2247,7 +2249,7 @@ athf metrics record --type query --hunt H-0019 --field duration_ms=42 --field ro
 athf metrics extract                       # refresh aggregates
 athf metrics summary                       # overall view
 athf metrics show --hunt H-0019            # zoom into one hunt
-athf metrics record --type hunt_outcome --hunt H-0019 --field outcome=confirmed
+athf metrics record --type hunt_outcome --hunt H-0019 --field outcome=suspected
 ```
 
 ### Exit Codes

--- a/athf/data/docs/CLI_REFERENCE.md
+++ b/athf/data/docs/CLI_REFERENCE.md
@@ -595,7 +595,7 @@ Creates a new hunt file with proper YAML frontmatter and LOCK structure. Automat
 | `--tactics` | String | - | Comma-separated tactics (e.g., credential-access,defense-evasion) |
 | `--platforms` | String | - | Comma-separated platforms (e.g., windows,linux,macos) |
 | `--data-sources` | String | - | Comma-separated data sources |
-| `--hunter` | String | AI Assistant | Your name or handle |
+| `--hunter` | String | config `hunter`, else unfilled | Your name or handle. Set `hunter:` in `.athfconfig.yaml` to stop repeating it |
 | `--severity` | Choice | medium | Severity: `low`, `medium`, `high`, `critical` |
 
 **Rich Content Options (for AI assistants & automation):**
@@ -685,7 +685,7 @@ athf hunt new \
   --behavior "Shell execution from unusual parents performing reconnaissance or accessing sensitive files" \
   --location "macOS endpoints (developer workstations, CI/CD infrastructure)" \
   --evidence "EDR process telemetry - Fields: process.name, process.parent.name, process.command_line" \
-  --hunter "Your Name" \
+  --hunter "Sydney Marrone" \
   --non-interactive
 ```
 

--- a/athf/data/docs/CLI_REFERENCE.md
+++ b/athf/data/docs/CLI_REFERENCE.md
@@ -685,7 +685,7 @@ athf hunt new \
   --behavior "Shell execution from unusual parents performing reconnaissance or accessing sensitive files" \
   --location "macOS endpoints (developer workstations, CI/CD infrastructure)" \
   --evidence "EDR process telemetry - Fields: process.name, process.parent.name, process.command_line" \
-  --hunter "Sydney Marrone" \
+  --hunter "Your Name" \
   --non-interactive
 ```
 

--- a/athf/data/docs/CLI_REFERENCE.md
+++ b/athf/data/docs/CLI_REFERENCE.md
@@ -627,7 +627,7 @@ Hunt Title: Kerberoasting Detection via Unusual TGS Requests
 Primary Tactic [credential-access]: credential-access
 Target Platforms (comma-separated) [windows]: windows
 Data Sources (comma-separated) [windows-event-logs]: windows-event-logs,edr-telemetry
-Your Name [Your Name]: Jane Doe
+6. Hunter (your name): Jane Doe
 Severity [medium]: high
 ```
 
@@ -732,7 +732,7 @@ data_sources:
 severity: high
 tags: []
 findings: []      # confirmed | suspected (populate during KEEP)
-ruled_out: []     # attempted_not_vulnerable | benign (populate during KEEP)
+ruled_out: []     # attempted_not_vulnerable | benign | inconclusive (populate during KEEP)
 ---
 
 ## LEARN
@@ -936,8 +936,8 @@ Summary: 3 valid, 1 invalid
 
 **Verdicts** (when `findings` / `ruled_out` are present):
 - Every entry must carry a `verdict` from: `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`
-- **Evidence gate:** `verdict: confirmed` requires a non-empty `confirmation` field. Telemetry in `evidence` alone caps the entry at `suspected`
-- **Routing rule:** `attempted_not_vulnerable` and `benign` must appear in `ruled_out`, never in `findings`
+- **Evidence gate:** `verdict: confirmed` requires `confirmation` to be a mapping — not a scalar — carrying a supported `method`, a `produced_by` declared in the workspace-root `.athfconfig.yaml`, an `attested_by` naming a person distinct from the producer, and a non-empty `detail`. Telemetry in `evidence` alone caps the entry at `suspected`
+- **Routing rule:** `attempted_not_vulnerable`, `benign`, and `inconclusive` must appear in `ruled_out`, never in `findings`
 - `attempted_not_vulnerable` entries must name the control that held
 
 See [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) → The Verdict Ladder for entry shapes.

--- a/athf/data/docs/getting-started.md
+++ b/athf/data/docs/getting-started.md
@@ -252,8 +252,15 @@ techniques: [T1053.003]
 data_sources: [Auditd, Syslog]
 related_hunts: []
 findings_count: 3
-true_positives: 1
-false_positives: 1
+findings:
+  - subject: web-prod-04
+    verdict: confirmed
+    evidence: auditd execve showed sh writing /var/spool/cron/crontabs/svc_deploy
+    confirmation: host triage recovered the crontab entry and the dropper on disk
+ruled_out:
+  - subject: svc_backup
+    verdict: benign
+    reason: nightly backup job, matched the change-management window
 customer_deliverables: []
 tags: [linux, cron, persistence]
 ---

--- a/athf/data/docs/getting-started.md
+++ b/athf/data/docs/getting-started.md
@@ -254,9 +254,9 @@ related_hunts: []
 findings_count: 3
 findings:
   - subject: web-prod-04
-    verdict: confirmed
+    verdict: suspected
     evidence: auditd execve showed sh writing /var/spool/cron/crontabs/svc_deploy
-    confirmation: host triage recovered the crontab entry and the dropper on disk
+    confirmation: null  # telemetry only — see FORMAT_GUIDELINES for reaching 'confirmed'
 ruled_out:
   - subject: svc_backup
     verdict: benign

--- a/athf/data/docs/lock-pattern.md
+++ b/athf/data/docs/lock-pattern.md
@@ -64,11 +64,27 @@ Record findings and lessons learned.
 
 **What to include:**
 
-- Results (found/not found)
-- True positives and false positives
+- A verdict for every result (see below)
 - Lessons learned
 - Next steps or follow-up actions
 - Links to related hunts
+
+**Verdicts:** "found / not found" throws away the interesting middle. ATHF records one of five verdicts per result:
+
+| Verdict | Meaning | Where it goes |
+|---------|---------|---------------|
+| `confirmed` | Malicious activity established — telemetry **plus** independent confirmation | `findings` |
+| `suspected` | Telemetry evidence only, nothing independent | `findings` |
+| `attempted_not_vulnerable` | The behavior happened; the named control held | `ruled_out` |
+| `benign` | Explained as legitimate activity | `ruled_out` |
+| `inconclusive` | Not enough telemetry to decide | `ruled_out` |
+
+Two rules carry the weight:
+
+1. **Telemetry alone never reaches `confirmed`.** A query showing the behavior is what surfaced it, not proof of what happened. Getting to `confirmed` takes something outside the log corpus — a controlled reproduction in an attack range, host-level forensic artifacts, or a configuration review. Otherwise the verdict is `suspected`, and that's a complete answer.
+2. **`attempted_not_vulnerable` and `benign` belong in `ruled_out`, never `findings`.** A hunt that proves three controls held has produced real output. The old TP/FP vocabulary erased that distinction by filing "we watched an attack get blocked" under the same label as "nothing was there."
+
+Full field reference: [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) → The Verdict Ladder.
 
 ## Example Hunt Using LOCK
 
@@ -97,8 +113,8 @@ Detected two accounts showing lateral movement patterns:
 - `svc_backup` executed PowerShell sessions on five hosts in under ten minutes
 - `itadmin-temp` invoked wmiprvse.exe from a workstation instead of a jump server
 
-Confirmed `svc_backup` activity as legitimate backup automation.
-Marked `itadmin-temp` as suspicious; account disabled pending review.
+`svc_backup` → `benign` (ruled_out): legitimate Veeam backup automation, matched the nightly change window.
+`itadmin-temp` → `suspected` (findings): PowerShell remoting from a workstation instead of the jump server. Telemetry only — no host triage yet, so not `confirmed`. Account disabled pending review.
 
 Next iteration: expand to include remote registry and PSExec telemetry for broader coverage.
 ```
@@ -131,7 +147,8 @@ Next iteration: expand to include remote registry and PSExec telemetry for broad
 
 **For Keep:**
 
-- Be honest about false positives
+- Assign a verdict to every result, and don't reach for `confirmed` without confirmation outside the logs
+- Record what your controls stopped — `attempted_not_vulnerable` is a finding-grade result
 - Document what worked and what didn't
 - Include next steps for iteration
 - Link to related hunts

--- a/athf/data/docs/metrics.md
+++ b/athf/data/docs/metrics.md
@@ -11,7 +11,7 @@ This page is the canonical reference. If you're integrating a new tool or vault,
 You can't improve what you can't see. The metrics core answers:
 
 - **What did this hunt cost me?** — LLM tokens, dollar cost, query time, web searches, similarity searches.
-- **What did the program produce?** — true / false positives, hunts completed, coverage by tactic / technique / data source.
+- **What did the program produce?** — per-verdict outcome counts, hunts completed, coverage by tactic / technique / data source.
 - **Where is the time going?** — per-hunt and workspace-wide rollups.
 
 ATHF auto-records the things it owns (LLM calls, web search, similarity search). Anything else — query latency from your data source, manual outcomes, custom events — is one function call away.
@@ -47,7 +47,7 @@ Every event has an `event_type` from this closed set:
 | `query`              | Data-source query (Splunk, Elasticsearch, Athena, …) | Vault-side     |
 | `web_search`         | Tavily / web search                                 | Yes            |
 | `similarity_search`  | TF-IDF similarity (`athf similar`)                  | Yes            |
-| `hunt_outcome`       | Hunt-level TP / FP / inconclusive                   | Manual         |
+| `hunt_outcome`       | Hunt-level verdict (see the ladder below)           | Manual         |
 | `manual`             | Anything else (custom plugins, scripts)             | Manual         |
 
 Canonical fields (all optional except `event_type`):
@@ -72,12 +72,50 @@ events_analyzed   : int  | None
 rows_returned     : int  | None
 status            : str  | None  # success | error | timeout | inconclusive
 
-outcome           : str  | None  # tp | fp | inconclusive (hunt_outcome)
+outcome           : str  | None  # verdict for hunt_outcome events (see below);
+                                 # legacy tp | fp | inconclusive still accepted
 
 custom            : dict         # anything that doesn't fit the above
 ```
 
 Fields that are `None` are dropped from the JSONL line, keeping the file compact.
+
+---
+
+## Outcome Verdicts
+
+`outcome` on a `hunt_outcome` event takes one of five verdicts. The old `tp` / `fp` / `inconclusive` values still parse, so nothing in an existing workspace breaks.
+
+| Verdict | Counter in `totals` | Meaning |
+| ------- | ------------------- | ------- |
+| `confirmed` | `confirmed` | Malicious activity established — telemetry **plus** independent confirmation (reproduction, host forensics, or config review) |
+| `suspected` | `suspected` | Telemetry evidence only. The ceiling when you can't independently confirm |
+| `attempted_not_vulnerable` | `attempted_not_vulnerable` | Attack behavior observed; the named control held |
+| `benign` | `benign` | Explained as legitimate activity |
+| `inconclusive` | `inconclusive` | Insufficient telemetry to decide |
+
+Telemetry alone never records `confirmed`. See [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) for the evidence gate and the routing rule.
+
+### Why `attempted_not_vulnerable` Gets Its Own Counter
+
+Because it's the number that used to disappear. Under `TP` / `FP`, a hunt that watched an adversary attempt credential theft and get stopped by SELinux recorded an `fp` — indistinguishable from a hunt that found nothing at all. For a managed-service report those are opposite results, and the first one is frequently the most valuable thing in the deliverable. Now it counts as itself.
+
+### Precision Is Deliberately Narrow
+
+`suspected` and `attempted_not_vulnerable` are **not** folded into precision:
+
+```text
+precision = positives / (positives + negatives)
+          = confirmed  / (confirmed  + benign)
+```
+
+Only verdicts that made an actual malicious/not-malicious call participate. Rationale:
+
+- **`suspected` never passed the evidence gate.** Counting it as a positive imports unverified findings into a quality number, which is exactly the laundering the gate exists to stop.
+- **`attempted_not_vulnerable` isn't a hunting error.** The behavior was really there — the hunt was right. Scoring it as a false positive would punish hunters for a control working, and the fastest way to make people stop reporting blocked attacks is to make reporting them look bad on a dashboard.
+- **`inconclusive` is a telemetry problem, not a precision problem.** It belongs in coverage and data-quality reporting, not in the ratio.
+
+Track the other three tiers as their own counters and read them alongside precision. A program with 40 `attempted_not_vulnerable` results is in good shape; a diluted precision figure would have hidden that.
 
 ---
 
@@ -108,7 +146,10 @@ m.record_web_search(query="lsass dumping", duration_ms=900, result_count=5)
 m.record_similarity_search(query="kerberoast", duration_ms=12)
 
 # Hunt outcomes — call this when you close a hunt
-m.record_hunt_outcome(hunt_id="H-0019", outcome="TP")
+m.record_hunt_outcome(hunt_id="H-0019", outcome="confirmed")
+
+# The control held — this is a result, not an absence of one
+m.record_hunt_outcome(hunt_id="H-0020", outcome="attempted_not_vulnerable")
 
 # Generic escape hatch
 m.record("manual", hunt_id="H-0019", duration_ms=300, custom={"step": "triage"})
@@ -120,7 +161,7 @@ m.record("manual", hunt_id="H-0019", duration_ms=300, custom={"step": "triage"})
 - **Active-session lookup.** If `hunt_id` / `session_id` are omitted, the helpers ask whatever context provider was registered via `athf.metrics.register_context_provider` for the active session and fill them in. Plugins register their own session manager at import time; ATHF core ships no provider, so without a registration the helpers leave both fields `None`.
 - **Cost is automatic.** `record_llm_call` defers to `athf.core.cost_tracker.estimate_cost` when `cost_usd` is not passed.
 - **Search text is hashed, not stored.** `record_query`, `record_web_search`, and `record_similarity_search` write a SHA-256 prefix of the input text (`custom.sql_hash` / `custom.query_hash`) so patterns can be grouped without leaking hunt content, IOCs, or user prose into the metrics log.
-- **Outcomes are canonicalized.** `record_hunt_outcome` accepts `TP`, `tp`, `FP`, `fp`, or `inconclusive` and stores lowercase.
+- **Outcomes are canonicalized.** `record_hunt_outcome` lowercases whatever it's given. The five ladder verdicts (`confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`) and the legacy values (`TP`, `tp`, `FP`, `fp`, `inconclusive`) are all accepted. Legacy `tp` is counted as legacy — it is **not** silently rewritten to `confirmed`, because those events predate the evidence gate.
 
 ---
 
@@ -173,6 +214,16 @@ Vault plugins are responsible for `record_query` (every vault has its own data-s
     "events_analyzed": 1_840_000,
     "web_searches": 11,
     "similarity_searches": 6,
+
+    // verdict ladder counters
+    "confirmed": 3,
+    "suspected": 5,
+    "attempted_not_vulnerable": 4,
+    "benign": 9,
+    "inconclusive": 2,
+
+    // legacy counters — still populated from older hunts, never derived
+    // from the ladder counters above
     "true_positives": 3,
     "false_positives": 4
   },
@@ -191,7 +242,9 @@ Vault plugins are responsible for `record_query` (every vault has its own data-s
 The extractor blends two sources:
 
 1. **`events.jsonl`** — sums per-hunt `llm_calls`, `queries`, etc.
-2. **Hunt files** — pulls frontmatter (`true_positives`, `events_analyzed`, etc.) and falls back to body regexes (`**Total Queries Executed:** N`) for older hunts. Frontmatter wins when both are present.
+2. **Hunt files** — pulls frontmatter (`findings`, `ruled_out`, `true_positives`, `events_analyzed`, etc.) and falls back to body regexes (`**Total Queries Executed:** N`) for older hunts. Frontmatter wins when both are present.
+
+Verdict counters come from the `findings` and `ruled_out` frontmatter lists: each entry's `verdict` increments its counter. Hunts that only carry `true_positives` / `false_positives` contribute to the legacy counters only — the two sets sit side by side rather than one being inferred from the other.
 
 `extract` is idempotent and uses an atomic `mkstemp` + `os.replace` write, so it's safe to run while other processes are reading the file.
 
@@ -222,6 +275,13 @@ If you have an older workspace with a legacy `metrics/execution_metrics.json`:
 - `aggregates.json` replaces it. The numbers should match within rounding.
 - New code should call `athf.metrics.record_*` directly. Vault plugins that previously shipped a `MetricsTracker` class can keep one as a thin in-plugin shim, but ATHF core no longer provides one.
 - `events.jsonl` is the new source of truth — if you want to backfill from a legacy execution log, `Aggregator.extract_from_hunt_file()` reads the same hunt-file regexes the old tracker used.
+
+If you're moving a workspace onto the verdict ladder:
+
+- Nothing needs to change. `true_positives` / `false_positives` keep working and keep aggregating.
+- Start writing `findings` / `ruled_out` on new hunts. Old hunts can stay as they are indefinitely.
+- Do **not** script a bulk `true_positives → confirmed` migration. Those findings never passed the evidence gate, so promoting them would put unverified results in the top tier. Re-read the hunts you care about and assign verdicts by hand; most legacy TPs are honestly `suspected`.
+- Legacy `false_positives` mixes `benign` with `attempted_not_vulnerable`. Splitting it requires reading the hunt — that's the whole reason the ladder exists.
 
 ---
 

--- a/athf/data/docs/metrics.md
+++ b/athf/data/docs/metrics.md
@@ -146,10 +146,15 @@ m.record_web_search(query="lsass dumping", duration_ms=900, result_count=5)
 m.record_similarity_search(query="kerberoast", duration_ms=12)
 
 # Hunt outcomes — call this when you close a hunt
-m.record_hunt_outcome(hunt_id="H-0019", outcome="confirmed")
+m.record_hunt_outcome(hunt_id="H-0019", outcome="suspected")
 
 # The control held — this is a result, not an absence of one
 m.record_hunt_outcome(hunt_id="H-0020", outcome="attempted_not_vulnerable")
+
+# `confirmed` is accepted and stored, but a bare outcome event has no
+# producer to check, so it never reaches the gated confirmed / true_positives
+# aggregates. Record confirmed results as findings entries in the hunt file,
+# where the confirmation mapping names a declared producer.
 
 # Generic escape hatch
 m.record("manual", hunt_id="H-0019", duration_ms=300, custom={"step": "triage"})
@@ -162,6 +167,7 @@ m.record("manual", hunt_id="H-0019", duration_ms=300, custom={"step": "triage"})
 - **Cost is automatic.** `record_llm_call` defers to `athf.core.cost_tracker.estimate_cost` when `cost_usd` is not passed.
 - **Search text is hashed, not stored.** `record_query`, `record_web_search`, and `record_similarity_search` write a SHA-256 prefix of the input text (`custom.sql_hash` / `custom.query_hash`) so patterns can be grouped without leaking hunt content, IOCs, or user prose into the metrics log.
 - **Outcomes are canonicalized.** `record_hunt_outcome` lowercases whatever it's given. The five ladder verdicts (`confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`) and the legacy values (`TP`, `tp`, `FP`, `fp`, `inconclusive`) are all accepted. Legacy `tp` is counted as legacy — it is **not** silently rewritten to `confirmed`, because those events predate the evidence gate.
+- **`confirmed` events are stored but never aggregated.** The provenance gate lives on the hunt-file path, where a `findings` entry names a producer that config declared. A bare `outcome=confirmed` event carries no producer, so aggregation drops it from the `confirmed` / `true_positives` tiers rather than crediting an unprovable positive through a side door. It still appears in the per-hunt `outcomes` list for audit. Legacy `tp` still counts — it never claimed a producer, so there is nothing to check.
 
 ---
 

--- a/athf/data/docs/metrics.md
+++ b/athf/data/docs/metrics.md
@@ -94,7 +94,7 @@ Fields that are `None` are dropped from the JSONL line, keeping the file compact
 | `benign` | `benign` | Explained as legitimate activity |
 | `inconclusive` | `inconclusive` | Insufficient telemetry to decide |
 
-Telemetry alone never records `confirmed`. See [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) for the evidence gate and the routing rule.
+Telemetry alone never counts toward the gated `confirmed` aggregate. A bare `outcome=confirmed` event is still stored for audit, but aggregation drops it unless a provenance-backed `findings` entry earns it (see [Behavior contract](#behavior-contract) below). See [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) for the evidence gate and the routing rule.
 
 ### Why `attempted_not_vulnerable` Gets Its Own Counter
 

--- a/athf/data/hunts/FORMAT_GUIDELINES.md
+++ b/athf/data/hunts/FORMAT_GUIDELINES.md
@@ -561,6 +561,8 @@ Results, lessons, and follow-up actions.
 
 **Counts:** one per verdict — see [The Verdict Ladder](#the-verdict-ladder)
 
+The counts line is a human summary. Metrics read `suspected`, `attempted_not_vulnerable`, `benign`, and `inconclusive` from it when a hunt has no `findings` / `ruled_out` frontmatter, but **`confirmed` is never counted from the body** — a markdown sentence carries no producer to check against, so honoring it would be a route around [Rule 3](#rule-3-confirmed-requires-provenance-not-prose). To have a `confirmed` counted, put it in `findings` with its `confirmation` mapping.
+
 **Detection Logic:**
 
 - Could this become automated detection?

--- a/athf/data/hunts/FORMAT_GUIDELINES.md
+++ b/athf/data/hunts/FORMAT_GUIDELINES.md
@@ -199,6 +199,8 @@ Six ways a `confirmed` entry fails this gate:
 
 **Restrictive by default.** A workspace with no `provenance` section declares no producers, so nothing reaches `confirmed`. An unparseable config yields an empty registry for the same reason — a broken config must not become the reason `confirmed` starts passing.
 
+**Config must live above `hunts/`.** Either `.athfconfig.yaml` or `config/.athfconfig.yaml` at the workspace root. A config placed *inside* the hunt tree is ignored, because that directory is somewhere the finding author writes — a producer declared next to `H-0042.md` would be a self-declaration with a different filename, and the grant has to sit somewhere the claim cannot reach.
+
 **What remains forgeable.** A human can edit `.athfconfig.yaml` to declare a capability their producer doesn't have. That is the accepted residual: the lie moves out of unfalsifiable prose into a separate file, in its own commit, contradicted by source an auditor can read.
 
 ### Entry Shapes

--- a/athf/data/hunts/FORMAT_GUIDELINES.md
+++ b/athf/data/hunts/FORMAT_GUIDELINES.md
@@ -78,8 +78,13 @@ techniques: [T1003.001]            # MITRE ATT&CK technique IDs (required)
 data_sources: [Splunk]             # SIEM/log platforms used (required)
 related_hunts: []                  # Related hunt IDs (optional)
 findings_count: 0                  # Total findings discovered (optional)
-true_positives: 0                  # Confirmed malicious activity (optional)
-false_positives: 0                 # Benign activity flagged (optional)
+findings: []                       # Verdict-tagged findings (optional) - see Verdict Ladder
+ruled_out: []                      # Results that closed the question (optional) - see Verdict Ladder
+# Legacy counters. Omit them when using findings/ruled_out: an explicit value
+# overrides the ladder-derived counts, so `true_positives: 0` masks a real
+# confirmed finding. Only set them by hand if you are not using the ladder.
+# true_positives: 0
+# false_positives: 0
 customer_deliverables: []          # For MSPs tracking deliverables (optional)
 tags: [credential-theft]           # Freeform categorization tags (optional)
 ---
@@ -106,11 +111,116 @@ tags: [credential-theft]           # Freeform categorization tags (optional)
 | Field | Type | Purpose | Example | When to Use |
 |-------|------|---------|---------|-------------|
 | `related_hunts` | array | Hunt IDs that relate to this hunt | `[H-0015, H-0038]` | When building on past work or pivoting |
-| `findings_count` | integer | Total findings (TP + FP + suspicious) | `15` | Post-execution or during KEEP phase |
-| `true_positives` | integer | Confirmed malicious activity | `3` | Post-execution summary |
-| `false_positives` | integer | Benign activity flagged | `12` | Post-execution summary |
+| `findings_count` | integer | Total findings across all verdicts | `15` | Post-execution or during KEEP phase |
+| `true_positives` | integer | Legacy count of malicious activity | `3` | Post-execution summary (superseded by `findings`) |
+| `false_positives` | integer | Legacy count of benign activity | `12` | Post-execution summary (superseded by `ruled_out`) |
+| `findings` | array of maps | Things you're reporting as malicious — `confirmed` or `suspected` only | see below | Post-execution, KEEP phase |
+| `ruled_out` | array of maps | Results that closed the question — `attempted_not_vulnerable` or `benign` | see below | Post-execution, KEEP phase |
 | `customer_deliverables` | array | Client report references (for MSPs) | `[CUST-2025-Q1-001]` | Managed service providers |
 | `tags` | array | Freeform categorization keywords | `[supply-chain, living-off-the-land]` | Additional context beyond ATT&CK |
+
+---
+
+## The Verdict Ladder
+
+`TP` / `FP` / `inconclusive` throws away information. It collapses two completely different outcomes into "false positive": *we saw the attack behavior and our control held* — which proves a defense works and is often the most valuable thing in a customer report — and *the thing we hunted for wasn't there*. It also treats a finding backed only by log data the same as one where root cause was independently established.
+
+The verdict ladder fixes both. Five verdicts, each with a gate:
+
+| Verdict | Meaning | Gate |
+|---------|---------|------|
+| `confirmed` | Malicious activity established | Telemetry evidence **plus** independent confirmation — controlled reproduction, host forensics, or configuration review |
+| `suspected` | Telemetry evidence only, no independent confirmation | This is the ceiling when you cannot confirm. Not a failure state |
+| `attempted_not_vulnerable` | Attack behavior observed; the control demonstrably held | Must name the control and say how you verified it held |
+| `benign` | Explained as legitimate activity | Name the legitimate activity, not just "looks normal" |
+| `inconclusive` | Insufficient telemetry to decide | Name the missing or sparse field / source |
+
+### Rule 1: Telemetry alone never reaches `confirmed`
+
+Query results are what surfaced the behavior, not proof of what happened. Reaching `confirmed` requires something from outside the log corpus:
+
+- **Controlled reproduction** — you reproduced the behavior in an attack range or lab and it does what you claimed
+- **Host forensics** — you pulled the artifact (crontab entry, LaunchAgent plist, binary on disk, registry key)
+- **Configuration review** — you inspected the actual config and it proves the activity was possible and occurred
+
+If none of those happened, the verdict is `suspected`. Writing `confirmed` off the back of query output is the exact failure this ladder exists to prevent — reading logs back and calling it confirmation is the cheapest path to satisfying a loose criterion, and it produces reports nobody should trust.
+
+### Rule 2: Routing — negative results are first-class output
+
+| Verdict | Goes in |
+|---------|---------|
+| `confirmed` | `findings` |
+| `suspected` | `findings` |
+| `attempted_not_vulnerable` | `ruled_out` |
+| `benign` | `ruled_out` |
+| `inconclusive` | `ruled_out` (or the telemetry-gaps section if hunt-wide) |
+
+`attempted_not_vulnerable` and `benign` never appear in `findings`. A hunt that finds nothing malicious but proves three controls held has produced real output — `ruled_out` is where that lands. `athf hunt validate` enforces both the routing rule and the evidence gate.
+
+### Entry Shapes
+
+**`findings` entries** carry `subject`, `verdict`, `evidence`, and — for `confirmed` — `confirmation`:
+
+```yaml
+findings:
+  - subject: "web-prod-04 / svc_deploy"
+    verdict: confirmed
+    technique: T1053.003
+    ticket: INC-4471
+    evidence: >-
+      OCSF process_activity: python3 spawned by sh writing to
+      /tmp/.cache/kworker, followed by outbound TLS to 185.243.x.x:443
+    confirmation: >-
+      Host triage recovered /var/spool/cron/crontabs/svc_deploy with the
+      matching @reboot entry and the dropper still on disk
+  - subject: "fin-laptop-11 / jhalloran"
+    verdict: suspected
+    technique: T1110.003
+    ticket: INC-4472
+    evidence: >-
+      OCSF authentication: 14 failed then 1 successful Okta auth from a
+      new ASN within 90 seconds
+    confirmation: null  # no endpoint agent on this host - nothing outside the IdP logs
+```
+
+**`ruled_out` entries** carry `subject`, `verdict`, and `reason`:
+
+```yaml
+ruled_out:
+  - subject: "build-runner-02"
+    verdict: attempted_not_vulnerable
+    technique: T1003.007
+    control: "SELinux enforcing mode"
+    reason: >-
+      gcore attach against sssd denied by SELinux (avc: denied { ptrace }
+      in audit log). Verified enforcing mode is fleet-wide, not host-local
+  - subject: "svc_backup across 5 Windows hosts"
+    verdict: benign
+    reason: >-
+      Nightly Veeam agent invoking PowerShell remoting at 02:00, inside the
+      change-management window with a signed parent binary
+  - subject: "macOS fleet (38 hosts)"
+    verdict: inconclusive
+    reason: >-
+      process.command_line populated on only 12% of macOS EDR events in the
+      hunt window, so shell argument patterns could not be evaluated
+```
+
+`control` is **required** for `attempted_not_vulnerable` and enforced by `athf hunt validate` — "the control held" means nothing if you can't name which one. `reason` does not substitute for it, since every `ruled_out` entry carries a reason.
+
+`evidence` and `confirmation` on a `confirmed` finding must actually describe what was checked. Validation rejects placeholders (`n/a`, `none`, `tbd`, `ok`, `-`), non-string values, and anything too short to be an account — `confirmation: n/a` is how you spell "I did not confirm this," so it fails the gate rather than satisfying it.
+
+`confirmation` must also point somewhere other than the logs. Validation rejects self-referential answers — `see telemetry above`, `as shown in the logs`, `per the query results`, `confirmed by the telemetry`, `same as evidence` — because the corpus cannot confirm itself; citing it is restating the evidence field, not corroborating it. Mentioning telemetry is fine when you did work outside it: `forensic image shows the crontab entry matching the process_activity log` passes, because the forensic image is the independent source.
+
+### Migration from `true_positives` / `false_positives`
+
+Both keys remain valid. The ladder is **additive** — nothing breaks, and there's no flag day.
+
+- **Existing hunts:** leave them alone. `true_positives` / `false_positives` still parse, still roll up into metrics, still pass validation.
+- **New hunts:** use `findings` and `ruled_out` and omit the legacy keys. ATHF derives `true_positives` / `false_positives` from the ladder for you (`confirmed` counts positive, `benign` counts negative; `suspected`, `attempted_not_vulnerable`, and `inconclusive` count as neither).
+- **An explicit legacy key always wins.** Precedence exists so a hand-maintained number is never silently overwritten — but it cuts both ways: writing `true_positives: 0` next to a `confirmed` finding reports zero positives. Omit the key unless you mean to override.
+- **Legacy `true_positives` is NOT auto-promoted to `confirmed`.** Those counts were recorded before the evidence gate existed, so nobody can say retroactively whether independent confirmation happened. Auto-promoting would launder unverified findings into the strongest verdict in the ladder. If you want an old hunt on the ladder, re-read it and assign verdicts by hand — most legacy TPs land at `suspected`.
+- **Old `false_positives` are ambiguous by design.** That single number mixed "control held" with "benign activity." Splitting it requires reading the hunt. Don't guess.
 
 ### MITRE ATT&CK Tactic Reference
 
@@ -158,8 +268,8 @@ techniques: [T1005]
 data_sources: [Splunk]
 related_hunts: []
 findings_count: 0
-true_positives: 0
-false_positives: 0
+findings: []
+ruled_out: []
 customer_deliverables: []
 tags: [macos, applescript]
 ---
@@ -180,8 +290,19 @@ techniques: [T1558.003]
 data_sources: [Splunk, Windows Event Logs]
 related_hunts: [H-0015, H-0038]
 findings_count: 15
-true_positives: 3
-false_positives: 12
+findings:
+  - subject: "SQL01 / svc_sqlagent"
+    verdict: suspected
+    technique: T1558.003
+    ticket: INC-3310
+    evidence: >-
+      Event 4769 with RC4 encryption type (0x17) for three SPNs from one
+      workstation inside 40 seconds
+    confirmation: null  # no host triage completed before hunt closeout
+ruled_out:
+  - subject: "DC02 / vuln-scanner"
+    verdict: benign
+    reason: "Authenticated Tenable scan, matched the scan window and source IP allowlist"
 customer_deliverables: []
 tags: [kerberos, active-directory, credential-theft, service-accounts]
 ---
@@ -202,8 +323,8 @@ techniques: [T1059.007]
 data_sources: [EDR, Sysmon]
 related_hunts: [H-0004]
 findings_count: 0
-true_positives: 0
-false_positives: 0
+findings: []
+ruled_out: []
 customer_deliverables: []
 tags: [javascript, node-js, living-off-the-land, supply-chain]
 ---
@@ -371,15 +492,21 @@ Results, lessons, and follow-up actions.
 **Executive Summary:**
 3-5 sentences: What was found? Hypothesis proved/disproved?
 
-**Findings Table:**
+**Findings Table** (`confirmed` / `suspected` only):
 
-| Finding | Ticket | Description |
-|---------|--------|-------------|
-| [TP/FP/Suspicious] | [INC-####] | [Brief description] |
+| Verdict | Subject | Ticket | Evidence | Independent Confirmation |
+|---------|---------|--------|----------|--------------------------|
+| `confirmed` | [Host/account] | [INC-####] | [Telemetry] | [Reproduction, forensics, or config review] |
+| `suspected` | [Host/account] | [INC-####] | [Telemetry] | None — telemetry only |
 
-**True Positives:** Count and summary
-**False Positives:** Count and patterns
-**Suspicious Events:** Count requiring investigation
+**Ruled Out Table** (`attempted_not_vulnerable` / `benign` / `inconclusive`):
+
+| Verdict | Subject | What Closed It |
+|---------|---------|----------------|
+| `attempted_not_vulnerable` | [Host/account] | [The control that held, and how you verified it] |
+| `benign` | [Host/account] | [Legitimate activity that explains it] |
+
+**Counts:** one per verdict — see [The Verdict Ladder](#the-verdict-ladder)
 
 **Detection Logic:**
 
@@ -441,7 +568,8 @@ Results, lessons, and follow-up actions.
 
 **Purpose:** Capture outcomes and enable improvement.
 
-- Summarize findings (TP/FP/Suspicious)
+- Assign a verdict to every result — `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, or `inconclusive`
+- Route findings vs. ruled-out correctly (see [The Verdict Ladder](#the-verdict-ladder))
 - Extract lessons learned
 - Identify detection opportunities
 - Plan follow-up actions and hunts

--- a/athf/data/hunts/FORMAT_GUIDELINES.md
+++ b/athf/data/hunts/FORMAT_GUIDELINES.md
@@ -282,6 +282,8 @@ Both keys remain valid. The ladder is **additive** — nothing breaks, and there
 - **Old `false_positives` are ambiguous by design.** That single number mixed "control held" with "benign activity." Splitting it requires reading the hunt. Don't guess.
 - **Provenance applies to net-new `confirmed` only.** Legacy `true_positives` never claimed a producer, so there is nothing to check; those counts keep rolling up untouched. The provenance mapping is required the moment you write `verdict: confirmed`.
 
+> The instinct behind this gate — trust what a producer is *allowed* to do, declared out of band, over what any single message *claims* to have done — owes something to the way Anthropic's open agent harness reasons about capability and tool access. We adapted it to hunt verdicts.
+
 ### MITRE ATT&CK Tactic Reference
 
 Use these **lowercase hyphenated** values for the `tactics` field:

--- a/athf/data/hunts/FORMAT_GUIDELINES.md
+++ b/athf/data/hunts/FORMAT_GUIDELINES.md
@@ -145,6 +145,8 @@ Query results are what surfaced the behavior, not proof of what happened. Reachi
 
 If none of those happened, the verdict is `suspected`. Writing `confirmed` off the back of query output is the exact failure this ladder exists to prevent — reading logs back and calling it confirmation is the cheapest path to satisfying a loose criterion, and it produces reports nobody should trust.
 
+Which is why the gate does not grade your description of the work. It checks **who produced the confirmation and whether they could have done it** — see [Rule 3](#rule-3-confirmed-requires-provenance-not-prose).
+
 ### Rule 2: Routing — negative results are first-class output
 
 | Verdict | Goes in |
@@ -157,9 +159,51 @@ If none of those happened, the verdict is `suspected`. Writing `confirmed` off t
 
 `attempted_not_vulnerable` and `benign` never appear in `findings`. A hunt that finds nothing malicious but proves three controls held has produced real output — `ruled_out` is where that lands. `athf hunt validate` enforces both the routing rule and the evidence gate.
 
+### Rule 3: `confirmed` requires provenance, not prose
+
+Earlier versions of this gate read the `confirmation` text and judged whether it described real work. That was measured against a labeled corpus and hit a floor it cannot cross: `cross-validated by running a second query against the same table` is grammatically indistinguishable from genuine corroboration. No pattern set separates them, because **reading a confirmation cannot establish that the work behind it happened.**
+
+So `confirmation` is now a mapping, and the gate checks the producer:
+
+| Field | What it is |
+|-------|-----------|
+| `method` | How the confirmation was obtained (e.g. `host_forensics`, `range_reproduction`, `configuration_review`) |
+| `produced_by` | The producer — an analyst, team, or agent — declared in `.athfconfig.yaml` |
+| `attested_by` | A **named person** answerable for the out-of-corpus work |
+| `detail` | Prose account of what was done. Still required, still checked, no longer load-bearing |
+
+Capabilities live in workspace config, **never in the finding**:
+
+```yaml
+# .athfconfig.yaml
+provenance:
+  producers:
+    ir-team:
+      capabilities: [clickhouse_query, host_forensics, configuration_review]
+    deep-baseline-investigator:
+      capabilities: [clickhouse_query]      # capped at suspected, permanently
+```
+
+That separation is the whole gate. An agent emits `verdict` / `evidence` / `confirmation`; it cannot rewrite the config that says what its producer can reach. A producer declaring only query access is structurally incapable of `confirmed` — not because its prose was graded and found wanting, but because the capability it would need was never declared.
+
+Six ways a `confirmed` entry fails this gate:
+
+| Failure | Cause |
+|---------|-------|
+| **missing provenance** | `confirmation` is a string, or the mapping has no `method` |
+| **unknown producer** | `produced_by` names something absent from `provenance.producers` |
+| **method exceeds capability** | The producer never declared the `method` it claims to have used |
+| **corpus-only method** | The `method` only reads the log corpus (`clickhouse_query`, `siem_search`, `log_review`, …). Querying is real work and still caps at `suspected` |
+| **self-declared capability** | The finding carries `capabilities` / `analyst_capabilities` / `producer_capabilities`. Refused rather than ignored — a claim and the licence to make it cannot travel together |
+| **unattested** | `attested_by` names a role, a team, or the automation (`the team`, `AI assistant`, `pipeline`) instead of a person |
+
+**Restrictive by default.** A workspace with no `provenance` section declares no producers, so nothing reaches `confirmed`. An unparseable config yields an empty registry for the same reason — a broken config must not become the reason `confirmed` starts passing.
+
+**What remains forgeable.** A human can edit `.athfconfig.yaml` to declare a capability their producer doesn't have. That is the accepted residual: the lie moves out of unfalsifiable prose into a separate file, in its own commit, contradicted by source an auditor can read.
+
 ### Entry Shapes
 
-**`findings` entries** carry `subject`, `verdict`, `evidence`, and — for `confirmed` — `confirmation`:
+**`findings` entries** carry `subject`, `verdict`, `evidence`, and — for `confirmed` — a `confirmation` **mapping**:
 
 ```yaml
 findings:
@@ -170,9 +214,13 @@ findings:
     evidence: >-
       OCSF process_activity: python3 spawned by sh writing to
       /tmp/.cache/kworker, followed by outbound TLS to 185.243.x.x:443
-    confirmation: >-
-      Host triage recovered /var/spool/cron/crontabs/svc_deploy with the
-      matching @reboot entry and the dropper still on disk
+    confirmation:
+      method: host_forensics
+      produced_by: ir-team
+      attested_by: J. Halloran
+      detail: >-
+        Host triage recovered /var/spool/cron/crontabs/svc_deploy with the
+        matching @reboot entry and the dropper still on disk
   - subject: "fin-laptop-11 / jhalloran"
     verdict: suspected
     technique: T1110.003
@@ -208,13 +256,13 @@ ruled_out:
 
 `control` is **required** for `attempted_not_vulnerable` and enforced by `athf hunt validate` — "the control held" means nothing if you can't name which one. `reason` does not substitute for it, since every `ruled_out` entry carries a reason.
 
-`evidence` and `confirmation` on a `confirmed` finding must actually describe what was checked. Validation rejects placeholders (`n/a`, `none`, `tbd`, `ok`, `-`), non-string values, and anything too short to be an account — `confirmation: n/a` is how you spell "I did not confirm this," so it fails the gate rather than satisfying it.
+`evidence` and `confirmation.detail` on a `confirmed` finding must actually describe what was checked. Validation rejects placeholders (`n/a`, `none`, `tbd`, `ok`, `-`), non-string values, and anything too short to be an account — `detail: n/a` is how you spell "I did not confirm this," so it fails the gate rather than satisfying it.
 
-`confirmation` must also point somewhere other than the logs. Validation rejects answers that cite the corpus as their own source — `see telemetry above`, `as shown in the logs`, `per the query results`, `confirmed by the telemetry`, `same as evidence` — because the corpus cannot confirm itself; citing it is restating the evidence field, not corroborating it. What matters is whether the thing being cited is the corpus, not how the sentence opens: `as documented in the range runbook, we replayed the technique on a sacrificial host` passes, and so does `forensic image shows the crontab entry matching the process_activity log`. Both name an independent source, and mentioning telemetry alongside it is fine.
+`confirmation.detail` must also point somewhere other than the logs. Validation rejects answers that cite the corpus as their own source — `see telemetry above`, `as shown in the logs`, `per the query results`, `confirmed by the telemetry`, `same as evidence` — because the corpus cannot confirm itself; citing it is restating the evidence field, not corroborating it. What matters is whether the thing being cited is the corpus, not how the sentence opens: `as documented in the range runbook, we replayed the technique on a sacrificial host` passes, and so does `forensic image shows the crontab entry matching the process_activity log`. Both name an independent source, and mentioning telemetry alongside it is fine.
 
-Validation separately rejects a `confirmation` that says the work hasn't happened — `pending host forensics`, `unable to confirm independently`, `will confirm once the host is available`, `assumed confirmed based on prior hunts`. That note is accurate and worth keeping; it's the verdict that's wrong. Downgrade to `suspected` and leave the note in place.
+Validation separately rejects a `detail` that says the work hasn't happened — `pending host forensics`, `unable to confirm independently`, `will confirm once the host is available`, `assumed confirmed based on prior hunts`. That note is accurate and worth keeping; it's the verdict that's wrong. Downgrade to `suspected` and leave the note in place.
 
-**What this check cannot do:** it reads phrasing, so it catches the cheap ways of writing a circular confirmation and misses the careful ones. `cross-validated by running a second query against the same table` describes no work outside the corpus and passes anyway — measured miss rate is roughly 1 in 9 on deliberately circular prose. A `confirmed` verdict that validates is a verdict nobody caught lying, not a verdict anybody verified.
+**These prose checks are no longer what holds the gate.** They catch the cheap ways of writing a circular confirmation and miss the careful ones — `cross-validated by running a second query against the same table` describes no work outside the corpus and passes all three, at a measured miss rate of roughly 1 in 9 on deliberately circular prose. That ceiling is why [Rule 3](#rule-3-confirmed-requires-provenance-not-prose) exists: the same sentence attached to a producer declaring only `clickhouse_query` is refused regardless of how it reads.
 
 ### Migration from `true_positives` / `false_positives`
 
@@ -225,6 +273,7 @@ Both keys remain valid. The ladder is **additive** — nothing breaks, and there
 - **An explicit legacy key always wins.** Precedence exists so a hand-maintained number is never silently overwritten — but it cuts both ways: writing `true_positives: 0` next to a `confirmed` finding reports zero positives. Omit the key unless you mean to override.
 - **Legacy `true_positives` is NOT auto-promoted to `confirmed`.** Those counts were recorded before the evidence gate existed, so nobody can say retroactively whether independent confirmation happened. Auto-promoting would launder unverified findings into the strongest verdict in the ladder. If you want an old hunt on the ladder, re-read it and assign verdicts by hand — most legacy TPs land at `suspected`.
 - **Old `false_positives` are ambiguous by design.** That single number mixed "control held" with "benign activity." Splitting it requires reading the hunt. Don't guess.
+- **Provenance applies to net-new `confirmed` only.** Legacy `true_positives` never claimed a producer, so there is nothing to check; those counts keep rolling up untouched. The provenance mapping is required the moment you write `verdict: confirmed`.
 
 ### MITRE ATT&CK Tactic Reference
 

--- a/athf/data/hunts/FORMAT_GUIDELINES.md
+++ b/athf/data/hunts/FORMAT_GUIDELINES.md
@@ -169,7 +169,7 @@ So `confirmation` is now a mapping, and the gate checks the producer:
 |-------|-----------|
 | `method` | How the confirmation was obtained (e.g. `host_forensics`, `range_reproduction`, `configuration_review`) |
 | `produced_by` | The producer — an analyst, team, or agent — declared in `.athfconfig.yaml` |
-| `attested_by` | A **named person** answerable for the out-of-corpus work |
+| `attested_by` | A **named person** answerable for the out-of-corpus work. Never the producer itself — an attestation is a second party vouching for the work |
 | `detail` | Prose account of what was done. Still required, still checked, no longer load-bearing |
 
 Capabilities live in workspace config, **never in the finding**:
@@ -186,7 +186,7 @@ provenance:
 
 That separation is the whole gate. An agent emits `verdict` / `evidence` / `confirmation`; it cannot rewrite the config that says what its producer can reach. A producer declaring only query access is structurally incapable of `confirmed` — not because its prose was graded and found wanting, but because the capability it would need was never declared.
 
-Six ways a `confirmed` entry fails this gate:
+Seven ways a `confirmed` entry fails this gate:
 
 | Failure | Cause |
 |---------|-------|
@@ -196,12 +196,17 @@ Six ways a `confirmed` entry fails this gate:
 | **corpus-only method** | The `method` only reads the log corpus (`clickhouse_query`, `siem_search`, `log_review`, …). Querying is real work and still caps at `suspected` |
 | **self-declared capability** | The finding carries `capabilities` / `analyst_capabilities` / `producer_capabilities`. Refused rather than ignored — a claim and the licence to make it cannot travel together |
 | **unattested** | `attested_by` names a role, a team, or the automation (`the team`, `AI assistant`, `pipeline`) instead of a person |
+| **self-attested** | `attested_by` names a declared producer — the same one as `produced_by`, or another. A producer cannot vouch for itself, and nothing in config can be asked what it saw |
 
 **Restrictive by default.** A workspace with no `provenance` section declares no producers, so nothing reaches `confirmed`. An unparseable config yields an empty registry for the same reason — a broken config must not become the reason `confirmed` starts passing.
 
 **Config must live above `hunts/`.** Either `.athfconfig.yaml` or `config/.athfconfig.yaml` at the workspace root. A config placed *inside* the hunt tree is ignored, because that directory is somewhere the finding author writes — a producer declared next to `H-0042.md` would be a self-declaration with a different filename, and the grant has to sit somewhere the claim cannot reach.
 
-**What remains forgeable.** A human can edit `.athfconfig.yaml` to declare a capability their producer doesn't have. That is the accepted residual: the lie moves out of unfalsifiable prose into a separate file, in its own commit, contradicted by source an auditor can read.
+**What remains forgeable.** Two things, both accepted rather than overlooked.
+
+A human can edit `.athfconfig.yaml` to declare a capability their producer doesn't have. That is the accepted residual for capability: the lie moves out of unfalsifiable prose into a separate file, in its own commit, contradicted by source an auditor can read.
+
+And `attested_by` is a free-text field an agent can fill with a colleague's name. Naming someone who did not do the work is a claim about a *person*, checkable by asking them — which is the point of requiring a name, and the reason the field refuses roles (`the team`), automation (`AI assistant`), and producers. It is not the reason `confirmed` is hard to reach: capability is. The denylist behind the role check is also open by construction — `SOC`, `Tier 2`, and `Analyst 7` pass it. Enumerating more role words raises the cost of the cheapest placeholder without closing the class, exactly as it did for corpus nouns.
 
 ### Entry Shapes
 

--- a/athf/data/hunts/FORMAT_GUIDELINES.md
+++ b/athf/data/hunts/FORMAT_GUIDELINES.md
@@ -282,7 +282,7 @@ Both keys remain valid. The ladder is **additive** — nothing breaks, and there
 - **Old `false_positives` are ambiguous by design.** That single number mixed "control held" with "benign activity." Splitting it requires reading the hunt. Don't guess.
 - **Provenance applies to net-new `confirmed` only.** Legacy `true_positives` never claimed a producer, so there is nothing to check; those counts keep rolling up untouched. The provenance mapping is required the moment you write `verdict: confirmed`.
 
-> The instinct behind this gate — trust what a producer is *allowed* to do, declared out of band, over what any single message *claims* to have done — owes something to the way Anthropic's open agent harness reasons about capability and tool access. We adapted it to hunt verdicts.
+> The instinct behind this gate — trust what a producer is *allowed* to do, declared out of band, over what any single message *claims* to have done — owes something to Anthropic's open [defending-code reference harness](https://github.com/anthropics/defending-code-reference-harness) and the way it reasons about capability and tool access in a security workflow. We adapted it to hunt verdicts.
 
 ### MITRE ATT&CK Tactic Reference
 

--- a/athf/data/hunts/FORMAT_GUIDELINES.md
+++ b/athf/data/hunts/FORMAT_GUIDELINES.md
@@ -210,7 +210,11 @@ ruled_out:
 
 `evidence` and `confirmation` on a `confirmed` finding must actually describe what was checked. Validation rejects placeholders (`n/a`, `none`, `tbd`, `ok`, `-`), non-string values, and anything too short to be an account — `confirmation: n/a` is how you spell "I did not confirm this," so it fails the gate rather than satisfying it.
 
-`confirmation` must also point somewhere other than the logs. Validation rejects self-referential answers — `see telemetry above`, `as shown in the logs`, `per the query results`, `confirmed by the telemetry`, `same as evidence` — because the corpus cannot confirm itself; citing it is restating the evidence field, not corroborating it. Mentioning telemetry is fine when you did work outside it: `forensic image shows the crontab entry matching the process_activity log` passes, because the forensic image is the independent source.
+`confirmation` must also point somewhere other than the logs. Validation rejects answers that cite the corpus as their own source — `see telemetry above`, `as shown in the logs`, `per the query results`, `confirmed by the telemetry`, `same as evidence` — because the corpus cannot confirm itself; citing it is restating the evidence field, not corroborating it. What matters is whether the thing being cited is the corpus, not how the sentence opens: `as documented in the range runbook, we replayed the technique on a sacrificial host` passes, and so does `forensic image shows the crontab entry matching the process_activity log`. Both name an independent source, and mentioning telemetry alongside it is fine.
+
+Validation separately rejects a `confirmation` that says the work hasn't happened — `pending host forensics`, `unable to confirm independently`, `will confirm once the host is available`, `assumed confirmed based on prior hunts`. That note is accurate and worth keeping; it's the verdict that's wrong. Downgrade to `suspected` and leave the note in place.
+
+**What this check cannot do:** it reads phrasing, so it catches the cheap ways of writing a circular confirmation and misses the careful ones. `cross-validated by running a second query against the same table` describes no work outside the corpus and passes anyway — measured miss rate is roughly 1 in 9 on deliberately circular prose. A `confirmed` verdict that validates is a verdict nobody caught lying, not a verdict anybody verified.
 
 ### Migration from `true_positives` / `false_positives`
 

--- a/athf/data/templates/HUNT_LOCK.md
+++ b/athf/data/templates/HUNT_LOCK.md
@@ -10,8 +10,14 @@ techniques: [T1003.001, T1059.001]  # MITRE ATT&CK technique IDs
 data_sources: [Splunk, Elasticsearch, Sentinel]  # SIEM/log platforms used (add more entries as needed; keep each as a concrete platform name)
 related_hunts: []  # Hunt IDs that relate to this hunt (e.g., [H-0001, H-0005])
 findings_count: 0  # Total findings discovered (optional - can update post-execution)
-true_positives: 0  # Count of confirmed malicious activity (optional)
-false_positives: 0  # Count of benign activity flagged (optional)
+findings: []  # Verdict-tagged findings: confirmed | suspected. Each entry: subject, verdict, evidence, confirmation
+ruled_out: []  # Results that closed the question: attempted_not_vulnerable | benign. Each entry: subject, verdict, reason
+# Legacy counters, still read for hunts predating the verdict ladder. Leave them
+# commented out: an explicit value overrides the counts derived from
+# findings/ruled_out above, so `true_positives: 0` would mask a real confirmed
+# finding. Only uncomment if you maintain counts by hand without the ladder.
+# true_positives: 0
+# false_positives: 0
 customer_deliverables: []  # For managed service providers tracking client reports (optional)
 tags: [supply-chain, credential-theft, living-off-the-land]  # Freeform tags for categorization
 ---
@@ -161,15 +167,43 @@ Define your hunt scope using the ABLE framework:
 
 ### Findings
 
-| **Finding** | **Ticket** | **Description** |
-|-------------|-----------|-----------------|
-| [True Positive / False Positive / Suspicious] | [INC-####] | [Brief description of finding and impact] |
-| [Finding type] | [Ticket] | [Description] |
-| [Finding type] | [Ticket] | [Description] |
+Findings are things you're reporting as malicious. Two verdicts belong here — nothing else.
 
-**True Positives:** [Count and summary]
-**False Positives:** [Count and common patterns]
-**Suspicious Events:** [Count requiring further investigation]
+| **Verdict** | **Subject** | **Ticket** | **Evidence** | **Independent Confirmation** |
+|-------------|-------------|-----------|--------------|------------------------------|
+| `confirmed` | [Host, account, or resource] | [INC-####] | [Telemetry that surfaced it — source, fields, event IDs] | [What established root cause outside the logs: controlled reproduction, host forensics, or config review] |
+| `suspected` | [Host, account, or resource] | [INC-####] | [Telemetry that surfaced it] | None — telemetry only |
+
+**The evidence gate:** `confirmed` requires telemetry **plus** something from outside the log corpus — a controlled reproduction (attack range), host-level forensic artifacts, or a configuration review that proves the activity was possible and occurred. Telemetry alone never reaches `confirmed`. If you couldn't confirm, the verdict is `suspected`, and that's an honest answer, not a downgrade.
+
+**Findings Example:**
+
+| **Verdict** | **Subject** | **Ticket** | **Evidence** | **Independent Confirmation** |
+|-------------|-------------|-----------|--------------|------------------------------|
+| `confirmed` | `web-prod-04` / `svc_deploy` | INC-4471 | OCSF `process_activity` — `python3` spawned by `sh` writing to `/tmp/.cache/kworker`, then outbound TLS to 185.243.x.x on :443 (T1053.003 cron persistence) | Host triage pulled `/var/spool/cron/crontabs/svc_deploy` with the matching `@reboot` entry and the dropper binary still on disk |
+| `suspected` | `fin-laptop-11` / `jhalloran` | INC-4472 | OCSF `authentication` — 14 failed then 1 successful Okta auth from a new ASN inside 90 seconds (T1110.003) | None — no endpoint agent on this host, so nothing outside the IdP logs to corroborate |
+
+### Ruled Out
+
+Results that closed the question. These are output, not the absence of output — for customer-facing reports, `attempted_not_vulnerable` is often the most valuable row in the hunt.
+
+| **Verdict** | **Subject** | **What Closed It** |
+|-------------|-------------|--------------------|
+| `attempted_not_vulnerable` | [Host, account, or resource] | [Name the control that held and how you verified it held] |
+| `benign` | [Host, account, or resource] | [The legitimate activity that explains it] |
+| `inconclusive` | [Host, account, or resource] | [Which telemetry was missing or too sparse to decide] |
+
+**Ruled Out Example:**
+
+| **Verdict** | **Subject** | **What Closed It** |
+|-------------|-------------|--------------------|
+| `attempted_not_vulnerable` | `build-runner-02` | LSASS-equivalent credential read attempted via `gcore` against `sssd`; SELinux enforcing mode denied the ptrace attach (`avc: denied { ptrace }` in audit log). Control held — verified policy is enforcing across the fleet, not just this host |
+| `benign` | `svc_backup` on 5 Windows hosts | Scheduled Veeam agent invoking PowerShell remoting nightly at 02:00; matched the change-management window and the signed parent binary |
+| `inconclusive` | macOS fleet (38 hosts) | `process.command_line` populated on only 12% of macOS EDR events in the hunt window, so shell argument patterns couldn't be evaluated |
+
+**Routing rule:** `attempted_not_vulnerable` and `benign` go in `ruled_out`, never in `findings`. Keeping them separate means a report can say "we looked, here's what we found, and here's what your controls stopped" instead of collapsing both into one number.
+
+**Counts:** `confirmed` [N] · `suspected` [N] · `attempted_not_vulnerable` [N] · `benign` [N] · `inconclusive` [N]
 
 ### Detection Logic
 
@@ -207,7 +241,8 @@ Define your hunt scope using the ABLE framework:
 
 ### Follow-up Actions
 
-- [ ] [Escalate true positives to incident response]
+- [ ] [Escalate `confirmed` findings to incident response]
+- [ ] [Pursue confirmation for `suspected` findings — reproduction, host forensics, or config review]
 - [ ] [Create detection rule from hunt logic]
 - [ ] [Update hypothesis with learnings]
 - [ ] [Address telemetry gaps with engineering team]

--- a/athf/data/templates/HUNT_LOCK.md
+++ b/athf/data/templates/HUNT_LOCK.md
@@ -11,7 +11,7 @@ data_sources: [Splunk, Elasticsearch, Sentinel]  # SIEM/log platforms used (add 
 related_hunts: []  # Hunt IDs that relate to this hunt (e.g., [H-0001, H-0005])
 findings_count: 0  # Total findings discovered (optional - can update post-execution)
 findings: []  # Verdict-tagged findings: confirmed | suspected. Each entry: subject, verdict, evidence, confirmation
-ruled_out: []  # Results that closed the question: attempted_not_vulnerable | benign. Each entry: subject, verdict, reason
+ruled_out: []  # Results that closed the question: attempted_not_vulnerable | benign | inconclusive. Each entry: subject, verdict, reason
 # Legacy counters, still read for hunts predating the verdict ladder. Leave them
 # commented out: an explicit value overrides the counts derived from
 # findings/ruled_out above, so `true_positives: 0` would mask a real confirmed

--- a/athf/data/templates/HUNT_LOCK.md
+++ b/athf/data/templates/HUNT_LOCK.md
@@ -11,7 +11,7 @@ data_sources: [Splunk, Elasticsearch, Sentinel]  # SIEM/log platforms used (add 
 related_hunts: []  # Hunt IDs that relate to this hunt (e.g., [H-0001, H-0005])
 findings_count: 0  # Total findings discovered (optional - can update post-execution)
 findings: []  # Verdict-tagged findings: confirmed | suspected. Each entry: subject, verdict, evidence, confirmation
-ruled_out: []  # Results that closed the question: attempted_not_vulnerable | benign | inconclusive. Each entry: subject, verdict, reason
+ruled_out: []  # Results that closed the question: attempted_not_vulnerable | benign | inconclusive. Each entry: subject, verdict, reason (attempted_not_vulnerable also requires control naming the control that held)
 # Legacy counters, still read for hunts predating the verdict ladder. Leave them
 # commented out: an explicit value overrides the counts derived from
 # findings/ruled_out above, so `true_positives: 0` would mask a real confirmed

--- a/athf/mcp/tools/hunt_tools.py
+++ b/athf/mcp/tools/hunt_tools.py
@@ -128,11 +128,12 @@ def register_hunt_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined]  
         behavior: Optional[str] = None,
         location: Optional[str] = None,
         evidence: Optional[str] = None,
-        hunter: str = "AI Assistant",
+        hunter: Optional[str] = None,
         research_id: Optional[str] = None,
     ) -> str:
         from athf.core.hunt_manager import HuntManager
         from athf.core.template_engine import render_hunt_template
+        from athf.core.verdicts import UNFILLED_HUNTER
 
         workspace = get_workspace()
         manager = HuntManager(hunts_dir=workspace / "hunts")
@@ -155,7 +156,7 @@ def register_hunt_tools(mcp: "FastMCP") -> None:  # type: ignore[name-defined]  
             behavior=behavior,
             location=location,
             evidence=evidence,
-            hunter=hunter,
+            hunter=hunter or UNFILLED_HUNTER,
             spawned_from=research_id,
         )
 

--- a/athf/metrics/__init__.py
+++ b/athf/metrics/__init__.py
@@ -25,7 +25,7 @@ Typical use::
     m.record_query(sql="SELECT 1", duration_ms=15, rows=1)
     m.record_web_search(query="lsass dumping", duration_ms=900)
     m.record_similarity_search(query="kerberoast", duration_ms=12)
-    m.record_hunt_outcome(hunt_id="H-0001", outcome="TP")
+    m.record_hunt_outcome(hunt_id="H-0001", outcome="confirmed")
 
 Each helper takes optional explicit ``hunt_id`` / ``session_id``. If
 omitted, they look up the current active session via
@@ -49,6 +49,7 @@ from athf.core.metrics import (
     EventStore,
     MetricEvent,
 )
+from athf.core.verdicts import normalize_verdict
 
 logger = logging.getLogger(__name__)
 
@@ -315,16 +316,15 @@ def record_hunt_outcome(
     workspace: Optional[Union[str, Path]] = None,
     custom: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Record a hunt outcome (TP / FP / inconclusive).
+    """Record a hunt outcome from the verdict ladder.
 
-    ``outcome`` is canonicalized to lowercase. Anything other than
-    ``tp``, ``fp``, or ``inconclusive`` raises ``ValueError``.
+    ``outcome`` accepts the five ladder verdicts (``confirmed``,
+    ``suspected``, ``attempted_not_vulnerable``, ``benign``,
+    ``inconclusive``) plus the legacy ``tp`` / ``fp`` values, and is
+    canonicalized to lowercase. Legacy values are stored as-is rather than
+    remapped onto the ladder. Anything else raises ``ValueError``.
     """
-    canonical = outcome.strip().lower()
-    if canonical not in {"tp", "fp", "inconclusive"}:
-        raise ValueError(
-            "outcome must be one of 'TP', 'FP', 'inconclusive'; got {!r}".format(outcome)
-        )
+    canonical = normalize_verdict(outcome)
 
     if session_id is None or organization_id is None:
         _, ctx_session, ctx_org = _resolve_active_context()

--- a/athf/metrics/__init__.py
+++ b/athf/metrics/__init__.py
@@ -323,6 +323,12 @@ def record_hunt_outcome(
     ``inconclusive``) plus the legacy ``tp`` / ``fp`` values, and is
     canonicalized to lowercase. Legacy values are stored as-is rather than
     remapped onto the ladder. Anything else raises ``ValueError``.
+
+    A ``confirmed`` outcome is stored for audit but never credited to the
+    gated ``confirmed`` / ``true_positives`` aggregates: the event names no
+    producer, and provenance is checked on the hunt-file path where a
+    ``findings`` entry does. Record the finding in the hunt file — with its
+    ``confirmation`` mapping — to have a confirmed result count.
     """
     canonical = normalize_verdict(outcome)
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -944,8 +944,8 @@ Summary: 3 valid, 1 invalid
 
 **Verdicts** (when `findings` / `ruled_out` are present):
 - Every entry must carry a `verdict` from: `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`
-- **Evidence gate:** `verdict: confirmed` requires a non-empty `confirmation` field. Telemetry in `evidence` alone caps the entry at `suspected`
-- **Routing rule:** `attempted_not_vulnerable` and `benign` must appear in `ruled_out`, never in `findings`
+- **Evidence gate:** `verdict: confirmed` requires `confirmation` to be a mapping — not a scalar — carrying a supported `method`, a `produced_by` declared in the workspace-root `.athfconfig.yaml`, an `attested_by` naming a person distinct from the producer, and a non-empty `detail`. Telemetry in `evidence` alone caps the entry at `suspected`
+- **Routing rule:** `attempted_not_vulnerable`, `benign`, and `inconclusive` must appear in `ruled_out`, never in `findings`
 - `attempted_not_vulnerable` entries must name the control that held
 
 See [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) → The Verdict Ladder for entry shapes.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -594,7 +594,7 @@ Creates a new hunt file with proper YAML frontmatter and LOCK structure. Automat
 | `--tactics` | String | - | Comma-separated tactics (e.g., credential-access,defense-evasion) |
 | `--platforms` | String | - | Comma-separated platforms (e.g., windows,linux,macos) |
 | `--data-sources` | String | - | Comma-separated data sources |
-| `--hunter` | String | AI Assistant | Your name or handle |
+| `--hunter` | String | config `hunter`, else unfilled | Your name or handle. Set `hunter:` in `.athfconfig.yaml` to stop repeating it |
 | `--severity` | Choice | medium | Severity: `low`, `medium`, `high`, `critical` |
 
 **Rich Content Options (for AI assistants & automation):**
@@ -684,7 +684,7 @@ athf hunt new \
   --behavior "Shell execution from unusual parents performing reconnaissance or accessing sensitive files" \
   --location "macOS endpoints (developer workstations, CI/CD infrastructure)" \
   --evidence "EDR process telemetry - Fields: process.name, process.parent.name, process.command_line" \
-  --hunter "Your Name" \
+  --hunter "Sydney Marrone" \
   --non-interactive
 ```
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -730,8 +730,8 @@ data_sources:
   - edr-telemetry
 severity: high
 tags: []
-true_positives: 0
-false_positives: 0
+findings: []
+ruled_out: []
 ---
 
 ## LEARN
@@ -941,6 +941,14 @@ Summary: 3 valid, 1 invalid
 
 **Status values**:
 - Must be one of: `in-progress`, `completed`, `paused`, `archived`
+
+**Verdicts** (when `findings` / `ruled_out` are present):
+- Every entry must carry a `verdict` from: `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`
+- **Evidence gate:** `verdict: confirmed` requires a non-empty `confirmation` field. Telemetry in `evidence` alone caps the entry at `suspected`
+- **Routing rule:** `attempted_not_vulnerable` and `benign` must appear in `ruled_out`, never in `findings`
+- `attempted_not_vulnerable` entries must name the control that held
+
+See [FORMAT_GUIDELINES.md](../hunts/FORMAT_GUIDELINES.md) → The Verdict Ladder for entry shapes.
 
 ### Exit Codes
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -684,7 +684,7 @@ athf hunt new \
   --behavior "Shell execution from unusual parents performing reconnaissance or accessing sensitive files" \
   --location "macOS endpoints (developer workstations, CI/CD infrastructure)" \
   --evidence "EDR process telemetry - Fields: process.name, process.parent.name, process.command_line" \
-  --hunter "Sydney Marrone" \
+  --hunter "Your Name" \
   --non-interactive
 ```
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -944,7 +944,7 @@ Summary: 3 valid, 1 invalid
 
 **Verdicts** (when `findings` / `ruled_out` are present):
 - Every entry must carry a `verdict` from: `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive`
-- **Evidence gate:** `verdict: confirmed` requires `confirmation` to be a mapping — not a scalar — carrying a supported `method`, a `produced_by` declared in the workspace-root `.athfconfig.yaml`, an `attested_by` naming a person distinct from the producer, and a non-empty `detail`. Telemetry in `evidence` alone caps the entry at `suspected`
+- **Evidence gate:** `verdict: confirmed` requires `confirmation` to be a mapping — not a scalar — carrying a supported `method`, a `produced_by` declared in the workspace-root `.athfconfig.yaml` whose declared capabilities include that `method` and reach beyond query-only access, an `attested_by` naming a person distinct from the producer, and a non-empty `detail`. Telemetry in `evidence` alone — or a producer that can only read the corpus — caps the entry at `suspected`
 - **Routing rule:** `attempted_not_vulnerable`, `benign`, and `inconclusive` must appear in `ruled_out`, never in `findings`
 - `attempted_not_vulnerable` entries must name the control that held
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -286,9 +286,9 @@ related_hunts: []
 findings_count: 3
 findings:
   - subject: web-prod-04
-    verdict: confirmed
+    verdict: suspected
     evidence: auditd execve showed sh writing /var/spool/cron/crontabs/svc_deploy
-    confirmation: host triage recovered the crontab entry and the dropper on disk
+    confirmation: null  # telemetry only — see FORMAT_GUIDELINES for reaching 'confirmed'
 ruled_out:
   - subject: svc_backup
     verdict: benign

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -284,8 +284,15 @@ techniques: [T1053.003]
 data_sources: [Auditd, Syslog]
 related_hunts: []
 findings_count: 3
-true_positives: 1
-false_positives: 1
+findings:
+  - subject: web-prod-04
+    verdict: confirmed
+    evidence: auditd execve showed sh writing /var/spool/cron/crontabs/svc_deploy
+    confirmation: host triage recovered the crontab entry and the dropper on disk
+ruled_out:
+  - subject: svc_backup
+    verdict: benign
+    reason: nightly backup job, matched the change-management window
 customer_deliverables: []
 tags: [linux, cron, persistence]
 ---

--- a/hunts/FORMAT_GUIDELINES.md
+++ b/hunts/FORMAT_GUIDELINES.md
@@ -78,8 +78,13 @@ techniques: [T1003.001]            # MITRE ATT&CK technique IDs (required)
 data_sources: [Splunk]             # SIEM/log platforms used (required)
 related_hunts: []                  # Related hunt IDs (optional)
 findings_count: 0                  # Total findings discovered (optional)
-true_positives: 0                  # Confirmed malicious activity (optional)
-false_positives: 0                 # Benign activity flagged (optional)
+findings: []                       # Verdict-tagged findings (optional) - see Verdict Ladder
+ruled_out: []                      # Results that closed the question (optional) - see Verdict Ladder
+# Legacy counters. Omit them when using findings/ruled_out: an explicit value
+# overrides the ladder-derived counts, so `true_positives: 0` masks a real
+# confirmed finding. Only set them by hand if you are not using the ladder.
+# true_positives: 0
+# false_positives: 0
 customer_deliverables: []          # For MSPs tracking deliverables (optional)
 tags: [credential-theft]           # Freeform categorization tags (optional)
 ---
@@ -106,11 +111,116 @@ tags: [credential-theft]           # Freeform categorization tags (optional)
 | Field | Type | Purpose | Example | When to Use |
 |-------|------|---------|---------|-------------|
 | `related_hunts` | array | Hunt IDs that relate to this hunt | `[H-0015, H-0038]` | When building on past work or pivoting |
-| `findings_count` | integer | Total findings (TP + FP + suspicious) | `15` | Post-execution or during KEEP phase |
-| `true_positives` | integer | Confirmed malicious activity | `3` | Post-execution summary |
-| `false_positives` | integer | Benign activity flagged | `12` | Post-execution summary |
+| `findings_count` | integer | Total findings across all verdicts | `15` | Post-execution or during KEEP phase |
+| `true_positives` | integer | Legacy count of malicious activity | `3` | Post-execution summary (superseded by `findings`) |
+| `false_positives` | integer | Legacy count of benign activity | `12` | Post-execution summary (superseded by `ruled_out`) |
+| `findings` | array of maps | Things you're reporting as malicious — `confirmed` or `suspected` only | see below | Post-execution, KEEP phase |
+| `ruled_out` | array of maps | Results that closed the question — `attempted_not_vulnerable` or `benign` | see below | Post-execution, KEEP phase |
 | `customer_deliverables` | array | Client report references (for MSPs) | `[CUST-2025-Q1-001]` | Managed service providers |
 | `tags` | array | Freeform categorization keywords | `[supply-chain, living-off-the-land]` | Additional context beyond ATT&CK |
+
+---
+
+## The Verdict Ladder
+
+`TP` / `FP` / `inconclusive` throws away information. It collapses two completely different outcomes into "false positive": *we saw the attack behavior and our control held* — which proves a defense works and is often the most valuable thing in a customer report — and *the thing we hunted for wasn't there*. It also treats a finding backed only by log data the same as one where root cause was independently established.
+
+The verdict ladder fixes both. Five verdicts, each with a gate:
+
+| Verdict | Meaning | Gate |
+|---------|---------|------|
+| `confirmed` | Malicious activity established | Telemetry evidence **plus** independent confirmation — controlled reproduction, host forensics, or configuration review |
+| `suspected` | Telemetry evidence only, no independent confirmation | This is the ceiling when you cannot confirm. Not a failure state |
+| `attempted_not_vulnerable` | Attack behavior observed; the control demonstrably held | Must name the control and say how you verified it held |
+| `benign` | Explained as legitimate activity | Name the legitimate activity, not just "looks normal" |
+| `inconclusive` | Insufficient telemetry to decide | Name the missing or sparse field / source |
+
+### Rule 1: Telemetry alone never reaches `confirmed`
+
+Query results are what surfaced the behavior, not proof of what happened. Reaching `confirmed` requires something from outside the log corpus:
+
+- **Controlled reproduction** — you reproduced the behavior in an attack range or lab and it does what you claimed
+- **Host forensics** — you pulled the artifact (crontab entry, LaunchAgent plist, binary on disk, registry key)
+- **Configuration review** — you inspected the actual config and it proves the activity was possible and occurred
+
+If none of those happened, the verdict is `suspected`. Writing `confirmed` off the back of query output is the exact failure this ladder exists to prevent — reading logs back and calling it confirmation is the cheapest path to satisfying a loose criterion, and it produces reports nobody should trust.
+
+### Rule 2: Routing — negative results are first-class output
+
+| Verdict | Goes in |
+|---------|---------|
+| `confirmed` | `findings` |
+| `suspected` | `findings` |
+| `attempted_not_vulnerable` | `ruled_out` |
+| `benign` | `ruled_out` |
+| `inconclusive` | `ruled_out` (or the telemetry-gaps section if hunt-wide) |
+
+`attempted_not_vulnerable` and `benign` never appear in `findings`. A hunt that finds nothing malicious but proves three controls held has produced real output — `ruled_out` is where that lands. `athf hunt validate` enforces both the routing rule and the evidence gate.
+
+### Entry Shapes
+
+**`findings` entries** carry `subject`, `verdict`, `evidence`, and — for `confirmed` — `confirmation`:
+
+```yaml
+findings:
+  - subject: "web-prod-04 / svc_deploy"
+    verdict: confirmed
+    technique: T1053.003
+    ticket: INC-4471
+    evidence: >-
+      OCSF process_activity: python3 spawned by sh writing to
+      /tmp/.cache/kworker, followed by outbound TLS to 185.243.x.x:443
+    confirmation: >-
+      Host triage recovered /var/spool/cron/crontabs/svc_deploy with the
+      matching @reboot entry and the dropper still on disk
+  - subject: "fin-laptop-11 / jhalloran"
+    verdict: suspected
+    technique: T1110.003
+    ticket: INC-4472
+    evidence: >-
+      OCSF authentication: 14 failed then 1 successful Okta auth from a
+      new ASN within 90 seconds
+    confirmation: null  # no endpoint agent on this host - nothing outside the IdP logs
+```
+
+**`ruled_out` entries** carry `subject`, `verdict`, and `reason`:
+
+```yaml
+ruled_out:
+  - subject: "build-runner-02"
+    verdict: attempted_not_vulnerable
+    technique: T1003.007
+    control: "SELinux enforcing mode"
+    reason: >-
+      gcore attach against sssd denied by SELinux (avc: denied { ptrace }
+      in audit log). Verified enforcing mode is fleet-wide, not host-local
+  - subject: "svc_backup across 5 Windows hosts"
+    verdict: benign
+    reason: >-
+      Nightly Veeam agent invoking PowerShell remoting at 02:00, inside the
+      change-management window with a signed parent binary
+  - subject: "macOS fleet (38 hosts)"
+    verdict: inconclusive
+    reason: >-
+      process.command_line populated on only 12% of macOS EDR events in the
+      hunt window, so shell argument patterns could not be evaluated
+```
+
+`control` is **required** for `attempted_not_vulnerable` and enforced by `athf hunt validate` — "the control held" means nothing if you can't name which one. `reason` does not substitute for it, since every `ruled_out` entry carries a reason.
+
+`evidence` and `confirmation` on a `confirmed` finding must actually describe what was checked. Validation rejects placeholders (`n/a`, `none`, `tbd`, `ok`, `-`), non-string values, and anything too short to be an account — `confirmation: n/a` is how you spell "I did not confirm this," so it fails the gate rather than satisfying it.
+
+`confirmation` must also point somewhere other than the logs. Validation rejects self-referential answers — `see telemetry above`, `as shown in the logs`, `per the query results`, `confirmed by the telemetry`, `same as evidence` — because the corpus cannot confirm itself; citing it is restating the evidence field, not corroborating it. Mentioning telemetry is fine when you did work outside it: `forensic image shows the crontab entry matching the process_activity log` passes, because the forensic image is the independent source.
+
+### Migration from `true_positives` / `false_positives`
+
+Both keys remain valid. The ladder is **additive** — nothing breaks, and there's no flag day.
+
+- **Existing hunts:** leave them alone. `true_positives` / `false_positives` still parse, still roll up into metrics, still pass validation.
+- **New hunts:** use `findings` and `ruled_out` and omit the legacy keys. ATHF derives `true_positives` / `false_positives` from the ladder for you (`confirmed` counts positive, `benign` counts negative; `suspected`, `attempted_not_vulnerable`, and `inconclusive` count as neither).
+- **An explicit legacy key always wins.** Precedence exists so a hand-maintained number is never silently overwritten — but it cuts both ways: writing `true_positives: 0` next to a `confirmed` finding reports zero positives. Omit the key unless you mean to override.
+- **Legacy `true_positives` is NOT auto-promoted to `confirmed`.** Those counts were recorded before the evidence gate existed, so nobody can say retroactively whether independent confirmation happened. Auto-promoting would launder unverified findings into the strongest verdict in the ladder. If you want an old hunt on the ladder, re-read it and assign verdicts by hand — most legacy TPs land at `suspected`.
+- **Old `false_positives` are ambiguous by design.** That single number mixed "control held" with "benign activity." Splitting it requires reading the hunt. Don't guess.
 
 ### MITRE ATT&CK Tactic Reference
 
@@ -158,8 +268,8 @@ techniques: [T1005]
 data_sources: [Splunk]
 related_hunts: []
 findings_count: 0
-true_positives: 0
-false_positives: 0
+findings: []
+ruled_out: []
 customer_deliverables: []
 tags: [macos, applescript]
 ---
@@ -180,8 +290,19 @@ techniques: [T1558.003]
 data_sources: [Splunk, Windows Event Logs]
 related_hunts: [H-0015, H-0038]
 findings_count: 15
-true_positives: 3
-false_positives: 12
+findings:
+  - subject: "SQL01 / svc_sqlagent"
+    verdict: suspected
+    technique: T1558.003
+    ticket: INC-3310
+    evidence: >-
+      Event 4769 with RC4 encryption type (0x17) for three SPNs from one
+      workstation inside 40 seconds
+    confirmation: null  # no host triage completed before hunt closeout
+ruled_out:
+  - subject: "DC02 / vuln-scanner"
+    verdict: benign
+    reason: "Authenticated Tenable scan, matched the scan window and source IP allowlist"
 customer_deliverables: []
 tags: [kerberos, active-directory, credential-theft, service-accounts]
 ---
@@ -200,10 +321,10 @@ platform: [Windows, macOS, Linux]  # Cross-platform TTP
 tactics: [execution]
 techniques: [T1059.007]
 data_sources: [EDR, Sysmon]
-related_hunts: []
+related_hunts: [H-0004]
 findings_count: 0
-true_positives: 0
-false_positives: 0
+findings: []
+ruled_out: []
 customer_deliverables: []
 tags: [javascript, node-js, living-off-the-land, supply-chain]
 ---
@@ -371,15 +492,21 @@ Results, lessons, and follow-up actions.
 **Executive Summary:**
 3-5 sentences: What was found? Hypothesis proved/disproved?
 
-**Findings Table:**
+**Findings Table** (`confirmed` / `suspected` only):
 
-| Finding | Ticket | Description |
-|---------|--------|-------------|
-| [TP/FP/Suspicious] | [INC-####] | [Brief description] |
+| Verdict | Subject | Ticket | Evidence | Independent Confirmation |
+|---------|---------|--------|----------|--------------------------|
+| `confirmed` | [Host/account] | [INC-####] | [Telemetry] | [Reproduction, forensics, or config review] |
+| `suspected` | [Host/account] | [INC-####] | [Telemetry] | None — telemetry only |
 
-**True Positives:** Count and summary
-**False Positives:** Count and patterns
-**Suspicious Events:** Count requiring investigation
+**Ruled Out Table** (`attempted_not_vulnerable` / `benign` / `inconclusive`):
+
+| Verdict | Subject | What Closed It |
+|---------|---------|----------------|
+| `attempted_not_vulnerable` | [Host/account] | [The control that held, and how you verified it] |
+| `benign` | [Host/account] | [Legitimate activity that explains it] |
+
+**Counts:** one per verdict — see [The Verdict Ladder](#the-verdict-ladder)
 
 **Detection Logic:**
 
@@ -441,7 +568,8 @@ Results, lessons, and follow-up actions.
 
 **Purpose:** Capture outcomes and enable improvement.
 
-- Summarize findings (TP/FP/Suspicious)
+- Assign a verdict to every result — `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, or `inconclusive`
+- Route findings vs. ruled-out correctly (see [The Verdict Ladder](#the-verdict-ladder))
 - Extract lessons learned
 - Identify detection opportunities
 - Plan follow-up actions and hunts

--- a/hunts/FORMAT_GUIDELINES.md
+++ b/hunts/FORMAT_GUIDELINES.md
@@ -170,9 +170,13 @@ findings:
     evidence: >-
       OCSF process_activity: python3 spawned by sh writing to
       /tmp/.cache/kworker, followed by outbound TLS to 185.243.x.x:443
-    confirmation: >-
-      Host triage recovered /var/spool/cron/crontabs/svc_deploy with the
-      matching @reboot entry and the dropper still on disk
+    confirmation:
+      method: host_forensics
+      produced_by: ir-team
+      attested_by: J. Halloran
+      detail: >-
+        Host triage recovered /var/spool/cron/crontabs/svc_deploy with the
+        matching @reboot entry and the dropper still on disk
   - subject: "fin-laptop-11 / jhalloran"
     verdict: suspected
     technique: T1110.003

--- a/templates/HUNT_LOCK.md
+++ b/templates/HUNT_LOCK.md
@@ -11,7 +11,7 @@ data_sources: [SIEM, EDR, etc.]
 related_hunts: []
 findings_count: 0
 findings: []  # confirmed | suspected — each entry: subject, verdict, evidence, confirmation
-ruled_out: []  # attempted_not_vulnerable | benign — each entry: subject, verdict, reason
+ruled_out: []  # attempted_not_vulnerable | benign | inconclusive — each entry: subject, verdict, reason
 # Legacy counters, kept for hunts predating the ladder. Leave commented out: an
 # explicit value overrides the counts derived from findings/ruled_out above, so
 # `true_positives: 0` would mask a real confirmed finding.

--- a/templates/HUNT_LOCK.md
+++ b/templates/HUNT_LOCK.md
@@ -10,8 +10,13 @@ techniques: [T1003.001, T1005, etc.]
 data_sources: [SIEM, EDR, etc.]
 related_hunts: []
 findings_count: 0
-true_positives: 0
-false_positives: 0
+findings: []  # confirmed | suspected — each entry: subject, verdict, evidence, confirmation
+ruled_out: []  # attempted_not_vulnerable | benign — each entry: subject, verdict, reason
+# Legacy counters, kept for hunts predating the ladder. Leave commented out: an
+# explicit value overrides the counts derived from findings/ruled_out above, so
+# `true_positives: 0` would mask a real confirmed finding.
+# true_positives: 0
+# false_positives: 0
 customer_deliverables: []
 tags: []
 ---
@@ -135,13 +140,26 @@ tags: []
 
 ### Findings
 
-| **Finding** | **Ticket** | **Description** |
-|-------------|-----------|-----------------|
-| True Positive | [Ticket] | [Description] |
-| False Positive | N/A | [Description] |
+Only `confirmed` and `suspected` belong here.
 
-**True Positives:** [Count]
-**False Positives:** [Count]
+| **Verdict** | **Subject** | **Ticket** | **Evidence** | **Independent Confirmation** |
+|-------------|-------------|-----------|--------------|------------------------------|
+| `confirmed` | [Host/account] | [Ticket] | [Telemetry — source and fields] | [Reproduction, host forensics, or config review] |
+| `suspected` | [Host/account] | [Ticket] | [Telemetry — source and fields] | None — telemetry only |
+
+`confirmed` needs telemetry **plus** confirmation from outside the log corpus. Telemetry alone caps at `suspected`.
+
+### Ruled Out
+
+| **Verdict** | **Subject** | **What Closed It** |
+|-------------|-------------|--------------------|
+| `attempted_not_vulnerable` | [Host/account] | [Name the control that held and how you verified it] |
+| `benign` | [Host/account] | [Legitimate activity that explains it] |
+| `inconclusive` | [Host/account] | [Telemetry that was missing] |
+
+`attempted_not_vulnerable` and `benign` always go here, never in Findings.
+
+**Counts:** `confirmed` [N] · `suspected` [N] · `attempted_not_vulnerable` [N] · `benign` [N] · `inconclusive` [N]
 
 ### Detection Logic
 

--- a/templates/HUNT_LOCK.md
+++ b/templates/HUNT_LOCK.md
@@ -11,7 +11,7 @@ data_sources: [SIEM, EDR, etc.]
 related_hunts: []
 findings_count: 0
 findings: []  # confirmed | suspected — each entry: subject, verdict, evidence, confirmation
-ruled_out: []  # attempted_not_vulnerable | benign | inconclusive — each entry: subject, verdict, reason
+ruled_out: []  # attempted_not_vulnerable | benign | inconclusive — each entry: subject, verdict, reason (attempted_not_vulnerable also needs control)
 # Legacy counters, kept for hunts predating the ladder. Leave commented out: an
 # explicit value overrides the counts derived from findings/ruled_out above, so
 # `true_positives: 0` would mask a real confirmed finding.

--- a/tests/commands/test_hunt_validate_exit_code.py
+++ b/tests/commands/test_hunt_validate_exit_code.py
@@ -1,0 +1,145 @@
+"""`athf hunt validate` must fail the process when the evidence gate refuses.
+
+AGENTS.md tells hunters to run this before closeout and CI runs it as a check,
+but the command printed refusals and exited 0 — so a hunt claiming ``confirmed``
+by a means its producer cannot perform merged green. The gate has to be
+observable to a shell, not only to a human reading scrollback.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from athf.commands.hunt import hunt
+from athf.commands.init import init
+
+CONFIRMED_FINDING = {
+    "subject": "web-prod-04",
+    "verdict": "confirmed",
+    "evidence": "OCSF process_activity shows sh writing /var/spool/cron/crontabs/svc_deploy",
+    "confirmation": {
+        "method": "host_forensics",
+        "produced_by": "ir-team",
+        "attested_by": "J. Halloran",
+        "detail": "Recovered the crontab entry and the dropper binary from the imaged disk",
+    },
+}
+
+
+def _write_config(producers: dict[str, object]) -> None:
+    """Declare a producer registry at the workspace root."""
+    Path(".athfconfig.yaml").write_text(
+        yaml.safe_dump({"provenance": {"producers": producers}}, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _write_hunt(hunt_id: str, **extra: object) -> None:
+    """Overwrite a hunt file's frontmatter, keeping the LOCK body intact."""
+    hunt_file = next(Path("hunts").rglob(f"{hunt_id}.md"))
+    body = hunt_file.read_text(encoding="utf-8").split("---", 2)[2]
+    frontmatter = {
+        "hunt_id": hunt_id,
+        "title": "Gate probe",
+        "status": "completed",
+        "date": "2026-09-02",
+        "hunter": "Sydney Marrone",
+        "platform": ["Linux"],
+        "tactics": ["persistence"],
+        "techniques": ["T1053.003"],
+        "customer_deliverables": [],
+        **extra,
+    }
+    hunt_file.write_text(
+        f"---\n{yaml.safe_dump(frontmatter, sort_keys=False)}---{body}",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """An initialized workspace containing one hunt, as the CLI would create it."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        runner.invoke(init, ["--non-interactive"])
+        runner.invoke(hunt, ["new", "--title", "Gate probe", "--non-interactive"])
+        yield runner
+
+
+class TestValidateSignalsRefusalToTheShell:
+    """A refused hunt must exit nonzero so CI and `&&` chains observe it."""
+
+    def test_single_hunt_refusal_exits_nonzero(self, workspace):
+        _write_config({"query-agent": {"capabilities": ["clickhouse_query"]}})
+        _write_hunt("H-0001", findings=[CONFIRMED_FINDING], ruled_out=[])
+
+        result = workspace.invoke(hunt, ["validate", "H-0001"])
+
+        assert result.exit_code != 0, result.output
+
+    def test_valid_hunt_still_exits_zero(self, workspace):
+        _write_config({"ir-team": {"capabilities": ["host_forensics"]}})
+        _write_hunt("H-0001", findings=[CONFIRMED_FINDING], ruled_out=[])
+
+        result = workspace.invoke(hunt, ["validate", "H-0001"])
+
+        assert result.exit_code == 0, result.output
+
+    def test_validate_all_exits_nonzero_when_any_hunt_is_refused(self, workspace):
+        _write_config({"query-agent": {"capabilities": ["clickhouse_query"]}})
+        _write_hunt("H-0001", findings=[CONFIRMED_FINDING], ruled_out=[])
+
+        result = workspace.invoke(hunt, ["validate"])
+
+        assert result.exit_code != 0, result.output
+
+    def test_missing_hunt_exits_nonzero(self, workspace):
+        result = workspace.invoke(hunt, ["validate", "H-9999"])
+
+        assert result.exit_code != 0, result.output
+        assert "not found" in result.output.lower()
+
+    def test_malformed_hunt_id_exits_nonzero(self, workspace):
+        result = workspace.invoke(hunt, ["validate", "not-a-hunt-id"])
+
+        assert result.exit_code != 0, result.output
+
+
+class TestRootConfigIsNotShadowedByInitConfig:
+    """The root ``.athfconfig.yaml`` is the documented place to declare producers.
+
+    ``athf init`` writes ``config/.athfconfig.yaml``, so a workspace routinely has
+    both. Reading the init copy first meant a hunter who followed AGENTS.md and
+    edited the root file had their declaration silently ignored, and every
+    ``confirmed`` was refused as an undeclared producer with no hint why.
+    """
+
+    def test_root_declaration_wins_over_init_config(self, workspace):
+        Path("config").mkdir(exist_ok=True)
+        Path("config/.athfconfig.yaml").write_text(
+            yaml.safe_dump({"hunt_prefix": "H-"}, sort_keys=False), encoding="utf-8"
+        )
+        _write_config({"ir-team": {"capabilities": ["host_forensics"]}})
+        _write_hunt("H-0001", findings=[CONFIRMED_FINDING], ruled_out=[])
+
+        result = workspace.invoke(hunt, ["validate", "H-0001"])
+
+        assert result.exit_code == 0, result.output
+
+    def test_init_config_still_read_when_root_absent(self, workspace):
+        Path("config").mkdir(exist_ok=True)
+        Path("config/.athfconfig.yaml").write_text(
+            yaml.safe_dump(
+                {"provenance": {"producers": {"ir-team": {"capabilities": ["host_forensics"]}}}},
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        Path(".athfconfig.yaml").unlink(missing_ok=True)
+        _write_hunt("H-0001", findings=[CONFIRMED_FINDING], ruled_out=[])
+
+        result = workspace.invoke(hunt, ["validate", "H-0001"])
+
+        assert result.exit_code == 0, result.output

--- a/tests/commands/test_hunt_validate_exit_code.py
+++ b/tests/commands/test_hunt_validate_exit_code.py
@@ -6,6 +6,8 @@ by a means its producer cannot perform merged green. The gate has to be
 observable to a shell, not only to a human reading scrollback.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/commands/test_investigate_nested.py
+++ b/tests/commands/test_investigate_nested.py
@@ -49,3 +49,30 @@ class TestNestedInvestigationCommands:
             assert result.exit_code == 0, result.output
             assert "not found" not in result.output
             assert "Promoted I-0001" in result.output
+
+
+class TestPromotedHuntStartsOffTheLegacyCounters:
+    """A promoted hunt must not be born with ``true_positives: 0``.
+
+    The legacy counters override the tally derived from verdicts, so seeding
+    them at creation arms a fuse: the hunter later writes a properly attested
+    ``confirmed`` finding, validation accepts it, and every count still reports
+    zero because a key nobody chose outranks the ladder.
+    """
+
+    def test_promote_does_not_seed_legacy_counters(self, tmp_path):
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(investigate_new, ["--title", "Nested", "--non-interactive"])
+
+            result = runner.invoke(
+                investigate_promote,
+                ["I-0001", "--technique", "T1059.001", "--non-interactive"],
+            )
+            assert result.exit_code == 0, result.output
+
+            hunt = sorted(Path("hunts").rglob("H-*.md"))[-1].read_text(encoding="utf-8")
+            assert "true_positives:" not in hunt, (
+                "promotion seeded a legacy counter that will shadow verdict counts"
+            )
+            assert "false_positives:" not in hunt

--- a/tests/commands/test_metrics_cli.py
+++ b/tests/commands/test_metrics_cli.py
@@ -148,6 +148,52 @@ class TestMetricsShow:
 
 
 @pytest.mark.unit
+class TestVerdictLadderDisplay:
+    """The ladder is only useful if a hunter can see each tier from the CLI."""
+
+    def _seed_ladder(self, workspace: Path) -> None:
+        store = EventStore(workspace / "metrics" / "events.jsonl")
+        for outcome in ("confirmed", "suspected", "attempted_not_vulnerable", "benign"):
+            store.append(
+                MetricEvent(event_type="hunt_outcome", hunt_id="H-0020", outcome=outcome)
+            )
+
+    def test_show_renders_every_tier(self, tmp_path: Path) -> None:
+        self._seed_ladder(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            metrics, ["show", "--hunt", "H-0020", "--workspace", str(tmp_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        for label in ("Confirmed", "Suspected", "Benign", "Inconclusive"):
+            assert label in result.output
+        assert "Attempted" in result.output
+
+    def test_summary_renders_every_tier(self, tmp_path: Path) -> None:
+        self._seed_ladder(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(metrics, ["summary", "--workspace", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        for label in ("Confirmed", "Suspected", "Benign", "Inconclusive"):
+            assert label in result.output
+
+    def test_legacy_only_hunt_still_shows_legacy_counters(self, tmp_path: Path) -> None:
+        _seed_events(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            metrics, ["show", "--hunt", "H-0019", "--workspace", str(tmp_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "True positives" in result.output
+
+
+@pytest.mark.unit
 class TestMetricsSummary:
     def test_summary_table(self, tmp_path: Path) -> None:
         _seed_events(tmp_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,22 @@
 Pytest configuration and shared fixtures for ATHF tests.
 """
 
+import os
 import shutil
 import tempfile
 from pathlib import Path
 
 import pytest
+
+# Rich's module-level Console() singletons in athf.commands.* honor FORCE_COLOR
+# at construction time. A developer shell that exports it (Ghostty sets
+# FORCE_COLOR=3) makes those consoles emit ANSI codes even though CliRunner
+# writes to a pipe, splitting IDs like "I-0001" into "I-\x1b[..m0001" and
+# breaking plain-substring assertions. CI has no FORCE_COLOR, so the suite is
+# green there. Neutralize color here — before the command modules are imported
+# and their consoles built — so the run is deterministic in any shell.
+os.environ.pop("FORCE_COLOR", None)
+os.environ["NO_COLOR"] = "1"
 
 
 @pytest.fixture

--- a/tests/core/test_hunt_manager_verdicts.py
+++ b/tests/core/test_hunt_manager_verdicts.py
@@ -21,7 +21,11 @@ LADDER_FRONTMATTER = (
     "  - subject: web-prod-04\n"
     "    verdict: confirmed\n"
     "    evidence: OCSF process_activity\n"
-    "    confirmation: host triage recovered the crontab\n"
+    "    confirmation:\n"
+    "      method: host_forensics\n"
+    "      produced_by: analyst\n"
+    "      attested_by: Sydney Marrone\n"
+    "      detail: host triage recovered the crontab entry from disk\n"
     "  - subject: fin-laptop-11\n"
     "    verdict: suspected\n"
     "    evidence: authentication burst\n"
@@ -34,9 +38,22 @@ LADDER_FRONTMATTER = (
     "    reason: nightly Veeam agent"
 )
 
+# Workspace config at the root above ``hunts/``, which is where the rollup loads
+# producer capabilities from. Declared here rather than in the hunt file on
+# purpose: an agent writing a finding can emit the confirmation mapping but cannot
+# grant its producer the reach that makes ``confirmed`` available.
+WORKSPACE_CONFIG = """provenance:
+  producers:
+    analyst:
+      capabilities:
+        - clickhouse_query
+        - host_forensics
+"""
+
 
 def _write(hunts: Path, hunt_id: str, extra: str = "") -> None:
     hunts.mkdir(parents=True, exist_ok=True)
+    (hunts.parent / ".athfconfig.yaml").write_text(WORKSPACE_CONFIG, encoding="utf-8")
     body = (
         f"hunt_id: {hunt_id}\ntitle: {hunt_id}\nstatus: completed\ndate: 2026-08-25"
         + (f"\n{extra}" if extra else "")

--- a/tests/core/test_hunt_manager_verdicts.py
+++ b/tests/core/test_hunt_manager_verdicts.py
@@ -110,6 +110,38 @@ class TestListHunts:
         assert len(hunts) == 1
         assert all(hunts[0][tier] == 0 for tier in LADDER)
 
+    def test_rollup_does_not_credit_what_validate_rejects(self, tmp_path: Path) -> None:
+        """The rollup and `athf hunt validate` must agree on what counts.
+
+        Previously validate reported two errors on this file while list_hunts
+        reported confirmed=2 / true_positives=2 — the dashboard credited
+        findings the gate had already refused.
+        """
+        from athf.core.hunt_parser import HuntParser
+
+        ungated = (
+            "findings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: process_activity rows show crontab spawned by curl\n"
+            "    confirmation: ok\n"
+            "  - subject: host-b\n"
+            "    verdict: confirmed\n"
+            "    evidence: process_activity rows show crontab spawned by curl\n"
+            "    confirmation: tbd\n"
+        )
+        _write(tmp_path / "hunts", "H-0006", ungated)
+        hunt_file = tmp_path / "hunts" / "H-0006.md"
+
+        parser = HuntParser(hunt_file)
+        parser.parse()
+        ok, _ = parser.validate()
+        assert not ok, "fixture must be a file validate rejects"
+
+        hunt = HuntManager(tmp_path / "hunts").list_hunts()[0]
+        assert hunt["confirmed"] == 0
+        assert hunt["true_positives"] == 0
+
 
 class TestCalculateStats:
     def test_tiers_roll_up_across_hunts(self, tmp_path: Path) -> None:
@@ -152,3 +184,36 @@ class TestCalculateStats:
         stats = HuntManager(hunts).calculate_stats()
         assert stats["completed_hunts"] == 2
         assert stats["success_rate"] == pytest.approx(50.0)
+
+    def test_non_numeric_legacy_counter_does_not_crash(self, tmp_path: Path) -> None:
+        """`athf hunt stats` runs right after validate in CI, over old files.
+
+        A hand-typed `true_positives: "three"` is malformed, but aggregation
+        reports over whatever is already on disk — only validate is allowed to
+        object, so this must degrade rather than raise.
+        """
+        hunts = tmp_path / "hunts"
+        _write(hunts, "H-0001", 'true_positives: "three"\nfalse_positives: 1')
+        _write(hunts, "H-0002", "true_positives: 2\nfalse_positives: 1")
+
+        stats = HuntManager(hunts).calculate_stats()
+        assert stats["true_positives"] == 2
+        assert stats["false_positives"] == 2
+
+    def test_null_legacy_counter_does_not_crash(self, tmp_path: Path) -> None:
+        _write(tmp_path / "hunts", "H-0003", "true_positives:\nfalse_positives:")
+
+        stats = HuntManager(tmp_path / "hunts").calculate_stats()
+        assert stats["true_positives"] == 0
+        assert stats["false_positives"] == 0
+
+    def test_numeric_string_legacy_counter_is_honored(self, tmp_path: Path) -> None:
+        """Inverse case: coercion must not discard a recoverable number.
+
+        YAML quoting is a common hand-editing artifact, so `"3"` is a real count
+        typed by a hunter, not junk to zero out.
+        """
+        _write(tmp_path / "hunts", "H-0004", 'true_positives: "3"')
+
+        stats = HuntManager(tmp_path / "hunts").calculate_stats()
+        assert stats["true_positives"] == 3

--- a/tests/core/test_hunt_manager_verdicts.py
+++ b/tests/core/test_hunt_manager_verdicts.py
@@ -1,0 +1,154 @@
+"""Tests for verdict-ladder rollup in HuntManager listing and stats."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athf.core.hunt_manager import HuntManager
+
+LADDER = (
+    "confirmed",
+    "suspected",
+    "attempted_not_vulnerable",
+    "benign",
+    "inconclusive",
+)
+
+LADDER_FRONTMATTER = (
+    "findings:\n"
+    "  - subject: web-prod-04\n"
+    "    verdict: confirmed\n"
+    "    evidence: OCSF process_activity\n"
+    "    confirmation: host triage recovered the crontab\n"
+    "  - subject: fin-laptop-11\n"
+    "    verdict: suspected\n"
+    "    evidence: authentication burst\n"
+    "ruled_out:\n"
+    "  - subject: build-runner-02\n"
+    "    verdict: attempted_not_vulnerable\n"
+    "    control: SELinux enforcing\n"
+    "  - subject: svc_backup\n"
+    "    verdict: benign\n"
+    "    reason: nightly Veeam agent"
+)
+
+
+def _write(hunts: Path, hunt_id: str, extra: str = "") -> None:
+    hunts.mkdir(parents=True, exist_ok=True)
+    body = (
+        f"hunt_id: {hunt_id}\ntitle: {hunt_id}\nstatus: completed\ndate: 2026-08-25"
+        + (f"\n{extra}" if extra else "")
+    )
+    (hunts / f"{hunt_id}.md").write_text(f"---\n{body}\n---\n\n# {hunt_id}\n", encoding="utf-8")
+
+
+class TestListHunts:
+    def test_ladder_counts_surface_per_hunt(self, tmp_path: Path) -> None:
+        _write(tmp_path / "hunts", "H-0001", LADDER_FRONTMATTER)
+
+        hunt = HuntManager(tmp_path / "hunts").list_hunts()[0]
+        assert hunt["confirmed"] == 1
+        assert hunt["suspected"] == 1
+        assert hunt["attempted_not_vulnerable"] == 1
+        assert hunt["benign"] == 1
+        assert hunt["inconclusive"] == 0
+
+    def test_ladder_drives_legacy_counters(self, tmp_path: Path) -> None:
+        """A ladder hunt needs no hand-maintained true/false positive counts."""
+        _write(tmp_path / "hunts", "H-0001", LADDER_FRONTMATTER)
+
+        hunt = HuntManager(tmp_path / "hunts").list_hunts()[0]
+        assert hunt["true_positives"] == 1
+        assert hunt["false_positives"] == 1
+
+    def test_legacy_hunt_keeps_its_own_counters(self, tmp_path: Path) -> None:
+        _write(tmp_path / "hunts", "H-0002", "true_positives: 2\nfalse_positives: 5")
+
+        hunt = HuntManager(tmp_path / "hunts").list_hunts()[0]
+        assert hunt["true_positives"] == 2
+        assert hunt["false_positives"] == 5
+        assert all(hunt[tier] == 0 for tier in LADDER)
+
+    def test_explicit_legacy_counters_win_over_ladder(self, tmp_path: Path) -> None:
+        """Never silently overwrite a number a hunter typed by hand."""
+        _write(
+            tmp_path / "hunts",
+            "H-0003",
+            LADDER_FRONTMATTER + "\ntrue_positives: 9\nfalse_positives: 9",
+        )
+
+        hunt = HuntManager(tmp_path / "hunts").list_hunts()[0]
+        assert hunt["true_positives"] == 9
+        assert hunt["confirmed"] == 1
+
+    def test_generated_template_does_not_shadow_the_ladder(self, tmp_path: Path) -> None:
+        """A freshly generated hunt must not ship legacy zeros that mask verdicts.
+
+        `athf hunt new` frontmatter is the input here, so if the template emits
+        `true_positives: 0` every new ladder hunt silently reports no positives.
+        """
+        from athf.core.template_engine import HUNT_TEMPLATE
+
+        assert "true_positives: 0" not in HUNT_TEMPLATE
+        assert "findings: []" in HUNT_TEMPLATE
+        assert "ruled_out: []" in HUNT_TEMPLATE
+
+    def test_hunt_without_any_counts_reports_zeros(self, tmp_path: Path) -> None:
+        _write(tmp_path / "hunts", "H-0004")
+
+        hunt = HuntManager(tmp_path / "hunts").list_hunts()[0]
+        assert hunt["true_positives"] == 0
+        assert all(hunt[tier] == 0 for tier in LADDER)
+
+    def test_malformed_ladder_does_not_drop_the_hunt(self, tmp_path: Path) -> None:
+        """list_hunts swallows parse errors, so junk must not hide a hunt."""
+        _write(tmp_path / "hunts", "H-0005", "findings: not-a-list\nruled_out:\n  - a string")
+
+        hunts = HuntManager(tmp_path / "hunts").list_hunts()
+        assert len(hunts) == 1
+        assert all(hunts[0][tier] == 0 for tier in LADDER)
+
+
+class TestCalculateStats:
+    def test_tiers_roll_up_across_hunts(self, tmp_path: Path) -> None:
+        hunts = tmp_path / "hunts"
+        _write(hunts, "H-0001", LADDER_FRONTMATTER)
+        _write(
+            hunts,
+            "H-0002",
+            "ruled_out:\n"
+            "  - subject: host-x\n"
+            "    verdict: inconclusive\n",
+        )
+
+        stats = HuntManager(hunts).calculate_stats()
+        assert stats["confirmed"] == 1
+        assert stats["suspected"] == 1
+        assert stats["attempted_not_vulnerable"] == 1
+        assert stats["benign"] == 1
+        assert stats["inconclusive"] == 1
+
+    def test_precision_excludes_ungraded_tiers(self, tmp_path: Path) -> None:
+        """suspected and attempted_not_vulnerable must not move the ratio."""
+        hunts = tmp_path / "hunts"
+        _write(hunts, "H-0001", LADDER_FRONTMATTER)
+
+        stats = HuntManager(hunts).calculate_stats()
+        assert stats["true_positives"] == 1
+        assert stats["false_positives"] == 1
+        assert stats["tp_fp_ratio"] == pytest.approx(1.0)
+
+    def test_empty_workspace_still_reports_every_tier(self, tmp_path: Path) -> None:
+        stats = HuntManager(tmp_path / "hunts").calculate_stats()
+        assert all(stats[tier] == 0 for tier in LADDER)
+
+    def test_success_rate_counts_confirmed_hunts(self, tmp_path: Path) -> None:
+        hunts = tmp_path / "hunts"
+        _write(hunts, "H-0001", LADDER_FRONTMATTER)
+        _write(hunts, "H-0002")
+
+        stats = HuntManager(hunts).calculate_stats()
+        assert stats["completed_hunts"] == 2
+        assert stats["success_rate"] == pytest.approx(50.0)

--- a/tests/core/test_hunt_parser_verdicts.py
+++ b/tests/core/test_hunt_parser_verdicts.py
@@ -29,7 +29,23 @@ Summary.
 """
 
 
+# Workspace config, written next to the hunt file so the parser loads it the way
+# it would in a real workspace. Capabilities live here and never in the hunt file:
+# an agent authoring a finding can emit `confirmation`, but it cannot grant itself
+# the reach that makes `confirmed` available.
+WORKSPACE_CONFIG = """provenance:
+  producers:
+    analyst:
+      capabilities:
+        - clickhouse_query
+        - host_forensics
+        - range_reproduction
+        - configuration_review
+"""
+
+
 def _hunt(tmp_path: Path, frontmatter: str) -> HuntParser:
+    (tmp_path / ".athfconfig.yaml").write_text(WORKSPACE_CONFIG, encoding="utf-8")
     path = tmp_path / "H-0100.md"
     path.write_text(f"---\n{frontmatter}\n---\n{LOCK_BODY}", encoding="utf-8")
     parser = HuntParser(path)
@@ -38,6 +54,22 @@ def _hunt(tmp_path: Path, frontmatter: str) -> HuntParser:
 
 
 BASE = "hunt_id: H-0100\ntitle: Ladder hunt\nstatus: completed\ndate: 2026-08-25"
+
+
+def _confirmation(detail: str, method: str = "host_forensics", indent: str = "    ") -> str:
+    """Render a confirmation mapping as hunt frontmatter YAML.
+
+    ``produced_by`` has to name a producer the config above declared, and the
+    method has to be one that producer can reach — that pairing is what the gate
+    checks instead of grading ``detail``.
+    """
+    return (
+        f"{indent}confirmation:\n"
+        f"{indent}  method: {method}\n"
+        f"{indent}  produced_by: analyst\n"
+        f"{indent}  attested_by: Sydney Marrone\n"
+        f"{indent}  detail: {detail}\n"
+    )
 
 
 def _errors(tmp_path: Path, frontmatter: str) -> list[str]:
@@ -118,7 +150,7 @@ class TestEvidenceGate:
             "  - subject: host-a\n"
             "    verdict: confirmed\n"
             "    evidence: OCSF process_activity showed the spawn chain\n"
-            "    confirmation: recovered the dropper binary from disk",
+            + _confirmation("recovered the dropper binary from disk"),
         ).validate()
         assert ok, errors
 
@@ -227,18 +259,29 @@ class TestEvidenceGate:
         assert any("host-a" in e for e in errors), f"{value!r} slipped through the gate"
 
     @pytest.mark.parametrize(
-        "value",
+        "method,value",
         [
-            "host triage recovered the dropper binary from disk",
-            "reproduced the spawn chain in the attack range",
-            "config review confirmed the cron entry was writable",
-            "forensic image shows the crontab entry matching the process_activity log",
+            ("host_forensics", "host triage recovered the dropper binary from disk"),
+            ("range_reproduction", "reproduced the spawn chain in the attack range"),
+            (
+                "configuration_review",
+                "config review confirmed the cron entry was writable",
+            ),
+            (
+                "host_forensics",
+                "forensic image shows the crontab entry matching the process_activity log",
+            ),
         ],
     )
     def test_genuine_independent_confirmation_passes(
-        self, tmp_path: Path, value: str
+        self, tmp_path: Path, method: str, value: str
     ) -> None:
-        """The gate must not block real work, including mentioning telemetry."""
+        """The gate must not block real work, including mentioning telemetry.
+
+        Each detail is paired with the method that actually produced it, declared
+        by a producer the workspace config says can reach it. Real work has to keep
+        passing — a gate that refuses everything is not a gate.
+        """
         ok, errors = _hunt(
             tmp_path,
             BASE
@@ -246,7 +289,7 @@ class TestEvidenceGate:
             "  - subject: host-a\n"
             "    verdict: confirmed\n"
             "    evidence: OCSF process_activity showed the spawn chain\n"
-            f'    confirmation: "{value}"',
+            + _confirmation(value, method=method),
         ).validate()
         assert ok, errors
 

--- a/tests/core/test_hunt_parser_verdicts.py
+++ b/tests/core/test_hunt_parser_verdicts.py
@@ -1,0 +1,425 @@
+"""Tests for verdict-ladder parsing and the evidence gate in HuntParser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athf.core.hunt_parser import HuntParser
+
+LOCK_BODY = """
+# H-0100: Ladder hunt
+
+## LEARN: Prepare the Hunt
+
+Hypothesis.
+
+## OBSERVE: Expected Behaviors
+
+Baseline.
+
+## CHECK: Execute & Analyze
+
+Query.
+
+## KEEP: Findings & Response
+
+Summary.
+"""
+
+
+def _hunt(tmp_path: Path, frontmatter: str) -> HuntParser:
+    path = tmp_path / "H-0100.md"
+    path.write_text(f"---\n{frontmatter}\n---\n{LOCK_BODY}", encoding="utf-8")
+    parser = HuntParser(path)
+    parser.parse()
+    return parser
+
+
+BASE = "hunt_id: H-0100\ntitle: Ladder hunt\nstatus: completed\ndate: 2026-08-25"
+
+
+def _errors(tmp_path: Path, frontmatter: str) -> list[str]:
+    return _hunt(tmp_path, frontmatter).validate()[1]
+
+
+class TestBackwardsCompatibility:
+    def test_hunt_without_ladder_keys_validates_clean(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(tmp_path, BASE).validate()
+        assert ok, errors
+
+    def test_legacy_counters_validate_clean(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(
+            tmp_path, BASE + "\ntrue_positives: 1\nfalse_positives: 0"
+        ).validate()
+        assert ok, errors
+
+    def test_empty_ladder_lists_validate_clean(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(tmp_path, BASE + "\nfindings: []\nruled_out: []").validate()
+        assert ok, errors
+
+
+class TestParseExposesLadder:
+    def test_findings_and_ruled_out_surface_in_parse(self, tmp_path: Path) -> None:
+        parser = _hunt(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: web-prod-04\n"
+            "    verdict: confirmed\n"
+            "    evidence: OCSF process_activity\n"
+            "    confirmation: host triage recovered the crontab\n"
+            "ruled_out:\n"
+            "  - subject: svc_backup\n"
+            "    verdict: benign\n"
+            "    reason: nightly Veeam agent",
+        )
+        parsed = parser.parse()
+        assert len(parsed["findings"]) == 1
+        assert parsed["findings"][0]["verdict"] == "confirmed"
+        assert len(parsed["ruled_out"]) == 1
+
+    def test_absent_keys_parse_as_empty_lists(self, tmp_path: Path) -> None:
+        parsed = _hunt(tmp_path, BASE).parse()
+        assert parsed["findings"] == []
+        assert parsed["ruled_out"] == []
+
+
+class TestEvidenceGate:
+    def test_confirmed_without_evidence_or_confirmation_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        errors = _errors(
+            tmp_path,
+            BASE + "\nfindings:\n  - subject: host-a\n    verdict: confirmed",
+        )
+        assert any("confirmed" in e and "host-a" in e for e in errors)
+
+    def test_confirmed_with_evidence_but_no_confirmation_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """Telemetry alone never reaches confirmed — that is the whole gate."""
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: OCSF process_activity showed the spawn chain",
+        )
+        assert any("confirmed" in e and "host-a" in e for e in errors)
+
+    def test_confirmed_with_both_passes(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: OCSF process_activity showed the spawn chain\n"
+            "    confirmation: recovered the dropper binary from disk",
+        ).validate()
+        assert ok, errors
+
+    def test_empty_confirmation_string_does_not_satisfy_the_gate(
+        self, tmp_path: Path
+    ) -> None:
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: telemetry\n"
+            '    confirmation: "   "',
+        )
+        assert any("host-a" in e for e in errors)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "n/a",
+            "N/A",
+            "n\\a",
+            "na",
+            "none",
+            "None",
+            "null",
+            "tbd",
+            "TODO",
+            "pending",
+            "unknown",
+            "-",
+            "--",
+            ".",
+            "?",
+            "no",
+        ],
+    )
+    def test_placeholder_confirmations_do_not_satisfy_the_gate(
+        self, tmp_path: Path, value: str
+    ) -> None:
+        """'n/a' is how an agent spells 'I did not confirm this'.
+
+        A truthiness check would accept every one of these, which inverts the
+        gate: the two commonest natural spellings of "not confirmed" would pass
+        while only Python-falsy values failed.
+        """
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: OCSF process_activity showed the spawn chain\n"
+            f'    confirmation: "{value}"',
+        )
+        assert any("host-a" in e for e in errors), f"{value!r} slipped through the gate"
+
+    @pytest.mark.parametrize("value", ["true", "1", "[an item]", "{key: value}"])
+    def test_non_string_confirmation_does_not_satisfy_the_gate(
+        self, tmp_path: Path, value: str
+    ) -> None:
+        """Confirmation has to be a human-readable account of what was checked."""
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: OCSF process_activity showed the spawn chain\n"
+            f"    confirmation: {value}",
+        )
+        assert any("host-a" in e for e in errors), f"{value} slipped through the gate"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "see telemetry above",
+            "See the evidence field",
+            "as shown in the logs",
+            "per the query results",
+            "confirmed by the telemetry",
+            "the log data confirms it",
+            "see above",
+            "same as evidence",
+        ],
+    )
+    def test_pointing_back_at_telemetry_does_not_satisfy_the_gate(
+        self, tmp_path: Path, value: str
+    ) -> None:
+        """Restating the input is the exact shortcut this gate exists to refuse.
+
+        An agent asked to confirm a finding will reach for the cheapest passing
+        answer, and the cheapest is to cite the logs it just read. Independent
+        confirmation has to come from outside the log corpus.
+        """
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: OCSF process_activity showed the spawn chain\n"
+            f'    confirmation: "{value}"',
+        )
+        assert any("host-a" in e for e in errors), f"{value!r} slipped through the gate"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "host triage recovered the dropper binary from disk",
+            "reproduced the spawn chain in the attack range",
+            "config review confirmed the cron entry was writable",
+            "forensic image shows the crontab entry matching the process_activity log",
+        ],
+    )
+    def test_genuine_independent_confirmation_passes(
+        self, tmp_path: Path, value: str
+    ) -> None:
+        """The gate must not block real work, including mentioning telemetry."""
+        ok, errors = _hunt(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: OCSF process_activity showed the spawn chain\n"
+            f'    confirmation: "{value}"',
+        ).validate()
+        assert ok, errors
+
+    def test_terse_confirmation_does_not_satisfy_the_gate(self, tmp_path: Path) -> None:
+        """'ok' is not an account of independent confirmation."""
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: OCSF process_activity showed the spawn chain\n"
+            "    confirmation: ok",
+        )
+        assert any("host-a" in e for e in errors)
+
+    def test_suspected_needs_no_confirmation(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: host-b\n"
+            "    verdict: suspected\n"
+            "    evidence: 14 failed then 1 successful auth from a new ASN",
+        ).validate()
+        assert ok, errors
+
+
+class TestControlNaming:
+    def test_attempted_not_vulnerable_without_control_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nruled_out:\n  - subject: build-runner-02\n    verdict: attempted_not_vulnerable",
+        )
+        assert any("build-runner-02" in e for e in errors)
+
+    def test_attempted_not_vulnerable_with_control_passes(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(
+            tmp_path,
+            BASE
+            + "\nruled_out:\n"
+            "  - subject: build-runner-02\n"
+            "    verdict: attempted_not_vulnerable\n"
+            "    control: SELinux enforcing\n"
+            "    reason: ptrace attach denied in audit log",
+        ).validate()
+        assert ok, errors
+
+    def test_reason_alone_does_not_satisfy_control_naming(self, tmp_path: Path) -> None:
+        """`reason` is the generic field every ruled_out entry carries.
+
+        Accepting it would leave "name the control" unenforced for essentially
+        every entry, since benign rows use `reason` too.
+        """
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nruled_out:\n"
+            "  - subject: build-runner-02\n"
+            "    verdict: attempted_not_vulnerable\n"
+            "    reason: SELinux enforcing denied the ptrace attach",
+        )
+        assert any("build-runner-02" in e for e in errors)
+
+    @pytest.mark.parametrize("value", ["n/a", "none", "tbd", "-", "ok"])
+    def test_placeholder_control_is_rejected(self, tmp_path: Path, value: str) -> None:
+        errors = _errors(
+            tmp_path,
+            BASE
+            + "\nruled_out:\n"
+            "  - subject: build-runner-02\n"
+            "    verdict: attempted_not_vulnerable\n"
+            f'    control: "{value}"',
+        )
+        assert any("build-runner-02" in e for e in errors), f"{value!r} slipped through"
+
+
+class TestRoutingRule:
+    @pytest.mark.parametrize(
+        "verdict", ["attempted_not_vulnerable", "benign", "inconclusive"]
+    )
+    def test_closed_verdicts_may_not_appear_in_findings(
+        self, tmp_path: Path, verdict: str
+    ) -> None:
+        errors = _errors(
+            tmp_path,
+            BASE
+            + f"\nfindings:\n  - subject: host-c\n    verdict: {verdict}\n    reason: a control held",
+        )
+        assert any("ruled_out" in e for e in errors)
+
+    @pytest.mark.parametrize("verdict", ["confirmed", "suspected"])
+    def test_open_verdicts_may_not_appear_in_ruled_out(
+        self, tmp_path: Path, verdict: str
+    ) -> None:
+        """Routing has to be enforced both ways.
+
+        A `confirmed` entry hiding in ruled_out still counts toward precision,
+        which defeats the report separation the split exists for.
+        """
+        errors = _errors(
+            tmp_path,
+            BASE
+            + f"\nruled_out:\n"
+            f"  - subject: host-z\n"
+            f"    verdict: {verdict}\n"
+            f"    evidence: telemetry\n"
+            f"    confirmation: host forensics recovered the dropper binary",
+        )
+        assert any("findings" in e and "host-z" in e for e in errors)
+
+    @pytest.mark.parametrize("verdict", ["confirmed", "suspected"])
+    def test_open_verdicts_belong_in_findings(self, tmp_path: Path, verdict: str) -> None:
+        errors = _errors(
+            tmp_path,
+            BASE
+            + f"\nfindings:\n"
+            f"  - subject: host-d\n"
+            f"    verdict: {verdict}\n"
+            f"    evidence: telemetry\n"
+            f"    confirmation: host forensics",
+        )
+        assert not any("ruled_out" in e for e in errors)
+
+
+class TestMalformedInput:
+    def test_invalid_verdict_names_the_offender(self, tmp_path: Path) -> None:
+        errors = _errors(
+            tmp_path, BASE + "\nfindings:\n  - subject: host-e\n    verdict: totally-pwned"
+        )
+        assert any("totally-pwned" in e for e in errors)
+
+    def test_hyphenated_verdict_is_accepted(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(
+            tmp_path,
+            BASE
+            + "\nruled_out:\n"
+            "  - subject: host-f\n"
+            "    verdict: attempted-not-vulnerable\n"
+            "    control: WAF rule 942100",
+        ).validate()
+        assert ok, errors
+
+    @pytest.mark.parametrize("verdict", ["tp", "fp"])
+    def test_legacy_verdicts_are_rejected_inside_ladder_lists(
+        self, tmp_path: Path, verdict: str
+    ) -> None:
+        """Legacy values live in the legacy scalar keys, not in ladder entries.
+
+        Accepting them here validates clean but tallies zero everywhere, which
+        is a silent-undercount path rather than a compatibility win.
+        """
+        errors = _errors(
+            tmp_path,
+            BASE + f"\nfindings:\n  - subject: host-h\n    verdict: {verdict}",
+        )
+        assert any("host-h" in e for e in errors)
+
+    def test_missing_verdict_key_is_an_error_not_a_crash(self, tmp_path: Path) -> None:
+        errors = _errors(tmp_path, BASE + "\nfindings:\n  - subject: host-g")
+        assert any("verdict" in e for e in errors)
+
+    def test_non_list_findings_is_an_error_not_a_crash(self, tmp_path: Path) -> None:
+        errors = _errors(tmp_path, BASE + "\nfindings: not-a-list")
+        assert any("findings" in e for e in errors)
+
+    def test_non_mapping_entry_is_an_error_not_a_crash(self, tmp_path: Path) -> None:
+        errors = _errors(tmp_path, BASE + "\nruled_out:\n  - just a string")
+        assert any("ruled_out" in e for e in errors)
+
+    def test_null_ladder_key_does_not_crash(self, tmp_path: Path) -> None:
+        ok, _ = _hunt(tmp_path, BASE + "\nfindings:\nruled_out:").validate()
+        assert ok

--- a/tests/core/test_hunt_parser_verdicts.py
+++ b/tests/core/test_hunt_parser_verdicts.py
@@ -466,3 +466,63 @@ class TestMalformedInput:
     def test_null_ladder_key_does_not_crash(self, tmp_path: Path) -> None:
         ok, _ = _hunt(tmp_path, BASE + "\nfindings:\nruled_out:").validate()
         assert ok
+
+
+class TestSelfAttestationIsRejectedByValidate:
+    """A producer named as its own attestor must fail the real validator."""
+
+    def test_producer_attesting_to_itself_fails_validation(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: web-prod-04\n"
+            "    verdict: confirmed\n"
+            "    evidence: process_activity shows curl piping to sh\n"
+            "    confirmation:\n"
+            "      method: host_forensics\n"
+            "      produced_by: analyst\n"
+            "      attested_by: analyst\n"
+            "      detail: recovered the dropped binary at /usr/local/bin/.upd on disk\n",
+        ).validate()
+        assert not ok
+        assert any("attested_by" in e for e in errors)
+
+    def test_a_human_attestor_still_validates_clean(self, tmp_path: Path) -> None:
+        ok, errors = _hunt(
+            tmp_path,
+            BASE
+            + "\nfindings:\n"
+            "  - subject: web-prod-04\n"
+            "    verdict: confirmed\n"
+            "    evidence: process_activity shows curl piping to sh\n"
+            + _confirmation("recovered the dropped binary at /usr/local/bin/.upd on disk"),
+        ).validate()
+        assert ok, errors
+
+
+class TestEveryGateFailureRendersAMessage:
+    """A reason code with no message means validate reports the file clean.
+
+    ``HuntParser.validate`` derives validity from the rendered message list, so a
+    code the renderer does not recognize is not merely missing an explanation —
+    aggregation refuses the entry on that code while validation calls the file
+    valid, which is the divergence class 18272e8 closed for frontmatter and the
+    body-count fallback reopened. The renderer needs a floor, not a full branch
+    per code, because the failure mode is a code nobody thought to render.
+    """
+
+    def test_an_unrecognized_reason_code_still_fails_validation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from athf.core import hunt_parser
+
+        monkeypatch.setattr(
+            hunt_parser, "gate_failures", lambda *a, **k: [("code_from_the_future", None)]
+        )
+        ok, errors = _hunt(
+            tmp_path,
+            BASE + "\nfindings:\n  - subject: host-a\n    verdict: suspected\n",
+        ).validate()
+        assert not ok
+        assert errors

--- a/tests/core/test_metrics_verdicts.py
+++ b/tests/core/test_metrics_verdicts.py
@@ -249,11 +249,55 @@ class TestBodyCounts:
             "findings:\n"
             "  - subject: host-a\n"
             "    verdict: confirmed\n"
-            "    evidence: telemetry\n"
-            "    confirmation: forensics\n"
+            "    evidence: process_activity rows show crontab spawned by curl\n"
+            "    confirmation: host triage recovered the crontab entry from disk\n"
             "---\n\n"
             "**Counts:** `confirmed` 9 · `suspected` 0 · "
             "`attempted_not_vulnerable` 0 · `benign` 0 · `inconclusive` 0\n"
         )
         out = Aggregator.extract_from_hunt_file(content)
         assert out["confirmed"] == 1
+
+    def test_absurd_body_count_is_not_credited(self) -> None:
+        """An over-wide number is a paste artifact, not a finding count."""
+        content = (
+            "---\nhunt_id: H-0013\ntitle: Huge\n---\n\n"
+            "**Counts:** `confirmed` 99999999999999999999999 · `suspected` 0 · "
+            "`attempted_not_vulnerable` 0 · `benign` 0 · `inconclusive` 0\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out.get("confirmed", 0) == 0
+
+    def test_realistic_body_count_still_parses(self) -> None:
+        """Inverse case: the digit cap must not clip a real count."""
+        content = (
+            "---\nhunt_id: H-0014\ntitle: Normal\n---\n\n"
+            "**Counts:** `confirmed` 3 · `suspected` 127 · "
+            "`attempted_not_vulnerable` 0 · `benign` 4096 · `inconclusive` 0\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out["confirmed"] == 3
+        assert out["suspected"] == 127
+        assert out["benign"] == 4096
+
+    def test_body_counts_do_not_resurrect_an_ungated_entry(self) -> None:
+        """A rejected entry must not fall through to the body-count scraper.
+
+        Frontmatter presence is what suppresses the body counts, so a `confirmed`
+        entry that fails the gate has to report zero rather than handing the file
+        to a markdown line claiming nine.
+        """
+        content = (
+            "---\nhunt_id: H-0012\ntitle: Ungated\n"
+            "findings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: process_activity rows show crontab spawned by curl\n"
+            "    confirmation: ok\n"
+            "---\n\n"
+            "**Counts:** `confirmed` 9 · `suspected` 0 · "
+            "`attempted_not_vulnerable` 0 · `benign` 0 · `inconclusive` 0\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out["confirmed"] == 0
+        assert out["true_positives"] == 0

--- a/tests/core/test_metrics_verdicts.py
+++ b/tests/core/test_metrics_verdicts.py
@@ -53,7 +53,10 @@ def _write_hunt(workspace: Path, hunt_id: str, frontmatter: str, body: str = "")
 
 
 class TestEventAccumulation:
-    @pytest.mark.parametrize("verdict", LADDER)
+    # Every tier but confirmed gets its counter straight from a hunt_outcome
+    # event. confirmed is gated: the event carries no producer, so it never
+    # reaches the tier — see test_confirmed_event_is_never_credited.
+    @pytest.mark.parametrize("verdict", ["suspected", "attempted_not_vulnerable", "benign", "inconclusive"])
     def test_each_tier_gets_its_own_counter(self, tmp_path: Path, verdict: str) -> None:
         store = EventStore(tmp_path / "metrics" / "events.jsonl")
         store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome=verdict))
@@ -64,13 +67,23 @@ class TestEventAccumulation:
             if other != verdict:
                 assert h[other] == 0
 
-    def test_confirmed_also_counts_as_a_legacy_true_positive(self, tmp_path: Path) -> None:
+    def test_confirmed_event_is_never_credited(self, tmp_path: Path) -> None:
+        """A hunt_outcome event cannot reach confirmed — it has no producer.
+
+        The provenance gate lives on the hunt-file path, where a findings entry
+        names a producer that config must have declared. A bare `outcome:
+        confirmed` event carries no such thing, so crediting it would be a side
+        door around the gate. The raw outcome still lands in `outcomes` for
+        audit; it just does not increment the gated tiers.
+        """
         store = EventStore(tmp_path / "metrics" / "events.jsonl")
         store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="confirmed"))
 
         h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
-        assert h["true_positives"] == 1
+        assert h["confirmed"] == 0
+        assert h["true_positives"] == 0
         assert h["false_positives"] == 0
+        assert h["outcomes"] == ["confirmed"]
 
     def test_benign_also_counts_as_a_legacy_false_positive(self, tmp_path: Path) -> None:
         store = EventStore(tmp_path / "metrics" / "events.jsonl")
@@ -83,11 +96,10 @@ class TestEventAccumulation:
     @pytest.mark.parametrize("verdict", ["suspected", "attempted_not_vulnerable", "inconclusive"])
     def test_ungraded_tiers_do_not_dilute_precision(self, tmp_path: Path, verdict: str) -> None:
         store = EventStore(tmp_path / "metrics" / "events.jsonl")
-        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="confirmed"))
         store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome=verdict))
 
         h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
-        assert h["true_positives"] == 1
+        assert h["true_positives"] == 0
         assert h["false_positives"] == 0
         assert h[verdict] == 1
 
@@ -124,6 +136,7 @@ class TestEventAccumulation:
 class TestWorkspaceRollup:
     def test_tiers_roll_up_into_totals(self, tmp_path: Path) -> None:
         store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        # A confirmed event is gated out of the totals — it has no producer.
         store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="confirmed"))
         store.append(
             MetricEvent(
@@ -135,11 +148,11 @@ class TestWorkspaceRollup:
         store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-2", outcome="benign"))
 
         totals = Aggregator(workspace=tmp_path).extract()["totals"]
-        assert totals["confirmed"] == 1
+        assert totals["confirmed"] == 0
         assert totals["attempted_not_vulnerable"] == 1
         assert totals["benign"] == 1
         assert totals["suspected"] == 0
-        assert totals["true_positives"] == 1
+        assert totals["true_positives"] == 0
         assert totals["false_positives"] == 1
 
 

--- a/tests/core/test_metrics_verdicts.py
+++ b/tests/core/test_metrics_verdicts.py
@@ -234,18 +234,25 @@ class TestBodyCounts:
         assert out["precision"] == pytest.approx(0.75)
 
     def test_new_per_verdict_body_format(self) -> None:
+        """Body counts parse — except ``confirmed``, which is gate-only.
+
+        This test previously asserted ``confirmed == 3`` from the body. That was
+        the bypass: an agent with query-only access could skip the `findings`
+        list entirely and have the aggregate credit a number nobody gated, while
+        `athf hunt validate` reported the file clean. See
+        TestBodyCountsCannotBypassTheGate.
+        """
         content = (
             "---\nhunt_id: H-0008\ntitle: New format\n---\n\n"
             "**Counts:** `confirmed` 3 · `suspected` 2 · "
             "`attempted_not_vulnerable` 4 · `benign` 1 · `inconclusive` 5\n"
         )
         out = Aggregator.extract_from_hunt_file(content)
-        assert out["confirmed"] == 3
+        assert out["confirmed"] == 0
         assert out["suspected"] == 2
         assert out["attempted_not_vulnerable"] == 4
         assert out["benign"] == 1
         assert out["inconclusive"] == 5
-        assert out["precision"] == pytest.approx(0.75)
 
     def test_body_with_neither_format(self) -> None:
         content = (
@@ -307,9 +314,91 @@ class TestBodyCounts:
             "`attempted_not_vulnerable` 0 · `benign` 4096 · `inconclusive` 0\n"
         )
         out = Aggregator.extract_from_hunt_file(content)
-        assert out["confirmed"] == 3
         assert out["suspected"] == 127
         assert out["benign"] == 4096
+
+
+class TestBodyCountsCannotBypassTheGate:
+    """A prose line in the body is not a route around provenance.
+
+    The body counter reads a number a hunter typed in the KEEP section. Every
+    other verdict is a summary of work; ``confirmed`` is a claim that work
+    happened outside the log corpus, and there is no producer attached to a
+    markdown sentence to check that against. An agent that can only run queries
+    writes no ``findings`` list at all, types ```confirmed`` 3`` in the body, and
+    the aggregate credits it while ``athf hunt validate`` reports the file clean
+    — the exact validate/aggregate divergence 18272e8 closed for frontmatter.
+    """
+
+    def test_body_confirmed_is_never_credited(self) -> None:
+        content = (
+            "---\nhunt_id: H-0015\ntitle: Body-only confirmed\n---\n\n"
+            "## KEEP\n\n**Counts:** `confirmed` 3 · `suspected` 0 · "
+            "`attempted_not_vulnerable` 0 · `benign` 0 · `inconclusive` 0\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out.get("confirmed", 0) == 0
+        assert out.get("true_positives", 0) == 0
+
+    def test_body_confirmed_ignored_even_with_a_full_registry(self) -> None:
+        """A declared producer does not rescue it — nothing names a producer."""
+        content = (
+            "---\nhunt_id: H-0016\ntitle: Body-only confirmed\n---\n\n"
+            "**Counts:** `confirmed` 5 · `suspected` 0 · "
+            "`attempted_not_vulnerable` 0 · `benign` 0 · `inconclusive` 0\n"
+        )
+        out = Aggregator.extract_from_hunt_file(
+            content, ProducerRegistry.from_config(PRODUCER_CONFIG)
+        )
+        assert out.get("confirmed", 0) == 0
+
+    def test_other_verdicts_in_the_body_still_count(self) -> None:
+        """Inverse: only ``confirmed`` is gated, so the format stays usable.
+
+        Dropping the whole body format would punish hunters recording honest
+        negative results, which is the output this ladder exists to make
+        first-class.
+        """
+        content = (
+            "---\nhunt_id: H-0017\ntitle: Body counts\n---\n\n"
+            "**Counts:** `confirmed` 0 · `suspected` 7 · "
+            "`attempted_not_vulnerable` 2 · `benign` 4 · `inconclusive` 1\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out["suspected"] == 7
+        assert out["attempted_not_vulnerable"] == 2
+        assert out["benign"] == 4
+        assert out["inconclusive"] == 1
+
+    def test_body_confirmed_alone_does_not_fabricate_a_tally(self) -> None:
+        """A body whose only verdict line is ``confirmed`` yields no counts.
+
+        Otherwise suppressing the number would still leave a zeroed ladder
+        asserting the hunt was tallied, and ``precision`` computed off it.
+        """
+        content = (
+            "---\nhunt_id: H-0018\ntitle: Only confirmed\n---\n\n"
+            "**Counts:** `confirmed` 4\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        for tier in LADDER:
+            assert tier not in out
+        assert "precision" not in out
+
+    def test_gated_body_count_does_not_become_a_legacy_positive(self) -> None:
+        """The refused number must not reappear through the legacy key.
+
+        Same reasoning as tally_frontmatter_verdicts: falling back to a legacy
+        counter is how an ungated ``confirmed`` gets laundered into a true
+        positive.
+        """
+        content = (
+            "---\nhunt_id: H-0019\ntitle: Laundering attempt\n---\n\n"
+            "**Counts:** `confirmed` 6 · `suspected` 1 · "
+            "`attempted_not_vulnerable` 0 · `benign` 0 · `inconclusive` 0\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out.get("true_positives", 0) == 0
 
     def test_body_counts_do_not_resurrect_an_ungated_entry(self) -> None:
         """A rejected entry must not fall through to the body-count scraper.

--- a/tests/core/test_metrics_verdicts.py
+++ b/tests/core/test_metrics_verdicts.py
@@ -1,0 +1,259 @@
+"""Tests for verdict-ladder aggregation in the metrics core."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athf.core.metrics import Aggregator, EventStore, MetricEvent
+
+LADDER = (
+    "confirmed",
+    "suspected",
+    "attempted_not_vulnerable",
+    "benign",
+    "inconclusive",
+)
+
+
+def _write_hunt(workspace: Path, hunt_id: str, frontmatter: str, body: str = "") -> None:
+    hunts = workspace / "hunts"
+    hunts.mkdir(parents=True, exist_ok=True)
+    (hunts / f"{hunt_id}.md").write_text(
+        f"---\n{frontmatter}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+class TestEventAccumulation:
+    @pytest.mark.parametrize("verdict", LADDER)
+    def test_each_tier_gets_its_own_counter(self, tmp_path: Path, verdict: str) -> None:
+        store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome=verdict))
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
+        assert h[verdict] == 1
+        for other in LADDER:
+            if other != verdict:
+                assert h[other] == 0
+
+    def test_confirmed_also_counts_as_a_legacy_true_positive(self, tmp_path: Path) -> None:
+        store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="confirmed"))
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
+        assert h["true_positives"] == 1
+        assert h["false_positives"] == 0
+
+    def test_benign_also_counts_as_a_legacy_false_positive(self, tmp_path: Path) -> None:
+        store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="benign"))
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
+        assert h["false_positives"] == 1
+        assert h["true_positives"] == 0
+
+    @pytest.mark.parametrize("verdict", ["suspected", "attempted_not_vulnerable", "inconclusive"])
+    def test_ungraded_tiers_do_not_dilute_precision(self, tmp_path: Path, verdict: str) -> None:
+        store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="confirmed"))
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome=verdict))
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
+        assert h["true_positives"] == 1
+        assert h["false_positives"] == 0
+        assert h[verdict] == 1
+
+    def test_legacy_tp_still_accumulates_and_is_not_promoted(self, tmp_path: Path) -> None:
+        store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="tp"))
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
+        assert h["true_positives"] == 1
+        assert h["confirmed"] == 0
+
+    def test_hyphenated_outcome_normalizes(self, tmp_path: Path) -> None:
+        store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        store.append(
+            MetricEvent(
+                event_type="hunt_outcome",
+                hunt_id="H-1",
+                outcome="attempted-not-vulnerable",
+            )
+        )
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
+        assert h["attempted_not_vulnerable"] == 1
+
+    def test_unknown_outcome_is_ignored_not_fatal(self, tmp_path: Path) -> None:
+        store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="maybe"))
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-1"]
+        assert h["outcomes"] == ["maybe"]
+        assert all(h[tier] == 0 for tier in LADDER)
+
+
+class TestWorkspaceRollup:
+    def test_tiers_roll_up_into_totals(self, tmp_path: Path) -> None:
+        store = EventStore(tmp_path / "metrics" / "events.jsonl")
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-1", outcome="confirmed"))
+        store.append(
+            MetricEvent(
+                event_type="hunt_outcome",
+                hunt_id="H-2",
+                outcome="attempted_not_vulnerable",
+            )
+        )
+        store.append(MetricEvent(event_type="hunt_outcome", hunt_id="H-2", outcome="benign"))
+
+        totals = Aggregator(workspace=tmp_path).extract()["totals"]
+        assert totals["confirmed"] == 1
+        assert totals["attempted_not_vulnerable"] == 1
+        assert totals["benign"] == 1
+        assert totals["suspected"] == 0
+        assert totals["true_positives"] == 1
+        assert totals["false_positives"] == 1
+
+
+class TestFrontmatterVerdicts:
+    def test_findings_and_ruled_out_increment_tiers(self, tmp_path: Path) -> None:
+        _write_hunt(
+            tmp_path,
+            "H-0042",
+            "hunt_id: H-0042\n"
+            "title: Ladder hunt\n"
+            "findings:\n"
+            "  - subject: web-prod-04\n"
+            "    verdict: confirmed\n"
+            "    evidence: process_activity\n"
+            "    confirmation: host triage recovered the crontab\n"
+            "  - subject: fin-laptop-11\n"
+            "    verdict: suspected\n"
+            "    evidence: authentication burst\n"
+            "ruled_out:\n"
+            "  - subject: build-runner-02\n"
+            "    verdict: attempted_not_vulnerable\n"
+            "    control: SELinux enforcing\n"
+            "    reason: ptrace attach denied\n"
+            "  - subject: svc_backup\n"
+            "    verdict: benign\n"
+            "    reason: nightly Veeam agent",
+        )
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-0042"]
+        assert h["confirmed"] == 1
+        assert h["suspected"] == 1
+        assert h["attempted_not_vulnerable"] == 1
+        assert h["benign"] == 1
+        assert h["inconclusive"] == 0
+        assert h["precision"] == pytest.approx(0.5)
+
+    def test_legacy_only_hunt_contributes_legacy_counters_only(self, tmp_path: Path) -> None:
+        _write_hunt(
+            tmp_path,
+            "H-0043",
+            "hunt_id: H-0043\ntitle: Legacy\ntrue_positives: 1\nfalse_positives: 3",
+        )
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-0043"]
+        assert h["true_positives"] == 1
+        assert h["false_positives"] == 3
+        assert h["precision"] == pytest.approx(0.25)
+        assert all(h[tier] == 0 for tier in LADDER)
+
+    def test_misrouted_confirmed_does_not_inflate_precision(self, tmp_path: Path) -> None:
+        """A confirmed entry in ruled_out must not be counted as a positive.
+
+        `athf hunt validate` rejects this shape, but aggregation runs over
+        whatever is on disk, so it must not credit a misrouted verdict.
+        """
+        _write_hunt(
+            tmp_path,
+            "H-0045",
+            "hunt_id: H-0045\n"
+            "title: Misrouted\n"
+            "ruled_out:\n"
+            "  - subject: host-z\n"
+            "    verdict: confirmed\n"
+            "    evidence: telemetry\n"
+            "    confirmation: host forensics",
+        )
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-0045"]
+        assert h["true_positives"] == 0
+
+    def test_malformed_findings_do_not_raise(self, tmp_path: Path) -> None:
+        _write_hunt(
+            tmp_path,
+            "H-0044",
+            "hunt_id: H-0044\ntitle: Junk\nfindings: not-a-list\nruled_out:\n  - just a string",
+        )
+
+        h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-0044"]
+        assert all(h[tier] == 0 for tier in LADDER)
+
+
+class TestBodyCounts:
+    def test_legacy_body_format(self) -> None:
+        content = (
+            "---\nhunt_id: H-0007\ntitle: Old format\n---\n\n"
+            "**True Positives:** 3\n"
+            "**False Positives:** 1\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out["true_positives"] == 3
+        assert out["false_positives"] == 1
+        assert out["precision"] == pytest.approx(0.75)
+
+    def test_new_per_verdict_body_format(self) -> None:
+        content = (
+            "---\nhunt_id: H-0008\ntitle: New format\n---\n\n"
+            "**Counts:** `confirmed` 3 · `suspected` 2 · "
+            "`attempted_not_vulnerable` 4 · `benign` 1 · `inconclusive` 5\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out["confirmed"] == 3
+        assert out["suspected"] == 2
+        assert out["attempted_not_vulnerable"] == 4
+        assert out["benign"] == 1
+        assert out["inconclusive"] == 5
+        assert out["precision"] == pytest.approx(0.75)
+
+    def test_body_with_neither_format(self) -> None:
+        content = (
+            "---\nhunt_id: H-0009\ntitle: Nothing\n---\n\n"
+            "### Findings\n\nNo counts recorded here.\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert "true_positives" not in out
+        assert "false_positives" not in out
+        assert "precision" not in out
+        for tier in LADDER:
+            assert tier not in out
+
+    def test_unfilled_template_placeholders_are_not_counted(self) -> None:
+        content = (
+            "---\nhunt_id: H-0010\ntitle: Template\n---\n\n"
+            "**Counts:** `confirmed` [N] · `suspected` [N] · "
+            "`attempted_not_vulnerable` [N] · `benign` [N] · `inconclusive` [N]\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        for tier in LADDER:
+            assert tier not in out
+
+    def test_frontmatter_wins_over_body_counts(self) -> None:
+        content = (
+            "---\nhunt_id: H-0011\ntitle: Both\n"
+            "findings:\n"
+            "  - subject: host-a\n"
+            "    verdict: confirmed\n"
+            "    evidence: telemetry\n"
+            "    confirmation: forensics\n"
+            "---\n\n"
+            "**Counts:** `confirmed` 9 · `suspected` 0 · "
+            "`attempted_not_vulnerable` 0 · `benign` 0 · `inconclusive` 0\n"
+        )
+        out = Aggregator.extract_from_hunt_file(content)
+        assert out["confirmed"] == 1

--- a/tests/core/test_metrics_verdicts.py
+++ b/tests/core/test_metrics_verdicts.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from athf.core.metrics import Aggregator, EventStore, MetricEvent
+from athf.core.provenance import ProducerRegistry
 
 LADDER = (
     "confirmed",
@@ -16,10 +17,35 @@ LADDER = (
     "inconclusive",
 )
 
+# Producer capabilities as workspace config supplies them. Aggregation consults
+# the same registry as `athf hunt validate`, so a hunt whose producer the config
+# never declared tallies zero here — the reason these fixtures write the config
+# rather than putting capabilities in the hunt file.
+PRODUCER_CONFIG = {
+    "provenance": {"producers": {"analyst": {"capabilities": ["host_forensics"]}}}
+}
+
+WORKSPACE_CONFIG = """provenance:
+  producers:
+    analyst:
+      capabilities:
+        - host_forensics
+"""
+
+# The confirmation mapping in frontmatter YAML, indented for a `findings` entry.
+CONFIRMATION = (
+    "    confirmation:\n"
+    "      method: host_forensics\n"
+    "      produced_by: analyst\n"
+    "      attested_by: Sydney Marrone\n"
+    "      detail: host triage recovered the crontab entry from disk\n"
+)
+
 
 def _write_hunt(workspace: Path, hunt_id: str, frontmatter: str, body: str = "") -> None:
     hunts = workspace / "hunts"
     hunts.mkdir(parents=True, exist_ok=True)
+    (workspace / ".athfconfig.yaml").write_text(WORKSPACE_CONFIG, encoding="utf-8")
     (hunts / f"{hunt_id}.md").write_text(
         f"---\n{frontmatter}\n---\n\n{body}\n",
         encoding="utf-8",
@@ -128,8 +154,8 @@ class TestFrontmatterVerdicts:
             "  - subject: web-prod-04\n"
             "    verdict: confirmed\n"
             "    evidence: process_activity\n"
-            "    confirmation: host triage recovered the crontab\n"
-            "  - subject: fin-laptop-11\n"
+            + CONFIRMATION
+            + "  - subject: fin-laptop-11\n"
             "    verdict: suspected\n"
             "    evidence: authentication burst\n"
             "ruled_out:\n"
@@ -250,12 +276,17 @@ class TestBodyCounts:
             "  - subject: host-a\n"
             "    verdict: confirmed\n"
             "    evidence: process_activity rows show crontab spawned by curl\n"
-            "    confirmation: host triage recovered the crontab entry from disk\n"
-            "---\n\n"
+            + CONFIRMATION
+            + "---\n\n"
             "**Counts:** `confirmed` 9 · `suspected` 0 · "
             "`attempted_not_vulnerable` 0 · `benign` 0 · `inconclusive` 0\n"
         )
-        out = Aggregator.extract_from_hunt_file(content)
+        # Called directly rather than through a workspace, so the registry is
+        # passed in — the entry has to clear the gate for the frontmatter count to
+        # be the one that wins.
+        out = Aggregator.extract_from_hunt_file(
+            content, ProducerRegistry.from_config(PRODUCER_CONFIG)
+        )
         assert out["confirmed"] == 1
 
     def test_absurd_body_count_is_not_credited(self) -> None:

--- a/tests/core/test_metrics_verdicts.py
+++ b/tests/core/test_metrics_verdicts.py
@@ -209,6 +209,7 @@ class TestFrontmatterVerdicts:
 
         h = Aggregator(workspace=tmp_path).extract()["hunts"]["H-0045"]
         assert h["true_positives"] == 0
+        assert h["confirmed"] == 0
 
     def test_malformed_findings_do_not_raise(self, tmp_path: Path) -> None:
         _write_hunt(

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -293,3 +293,129 @@ class TestBackwardsCompatibility:
         assert UNKNOWN_PRODUCER in codes(
             gate_failures("findings", confirmed(), registry=reg)
         )
+
+
+class TestConfigCannotBeShadowedFromInsideTheHuntTree:
+    """A config an agent can write must not be the config that licenses it.
+
+    ``load_registry`` walks up from a starting directory and takes the first
+    config it finds. Handed a hunt file's own directory, that walk starts inside
+    the tree the finding author writes to — so an agent with file-write access
+    drops ``.athfconfig.yaml`` next to ``H-0042.md``, declares itself capable of
+    ``host_forensics``, and ``athf hunt validate`` accepts the ``confirmed``.
+
+    That collapses the whole design. The point of putting capabilities in config
+    was that an agent emitting findings cannot reach the file that grants them;
+    if the grant can sit in the same directory as the claim, it is a
+    self-declaration wearing a different filename.
+
+    Resolution has to be anchored above the hunt tree, and validation has to
+    agree with aggregation — a shadow config also made the two disagree, with
+    validate reporting the file clean while the tally credited nothing.
+    """
+
+    CONFIRMED_ENTRY = (
+        "findings:\n"
+        "  - subject: host dev-20\n"
+        "    verdict: confirmed\n"
+        "    evidence: process_activity rows show crontab spawned by curl\n"
+        "    confirmation:\n"
+        "      method: host_forensics\n"
+        "      produced_by: baseline-agent\n"
+        "      attested_by: Sydney Marrone\n"
+        "      detail: recovered the dropped binary from the imaged disk\n"
+    )
+
+    LOCK = "\n## LEARN\nx\n\n## OBSERVE\nx\n\n## CHECK\nx\n\n## KEEP\nx\n"
+
+    SHADOW = (
+        "provenance:\n"
+        "  producers:\n"
+        "    baseline-agent:\n"
+        "      capabilities: [clickhouse_query, host_forensics]\n"
+    )
+
+    def _workspace(self, tmp_path):
+        """Root config declares nothing; a shadow config sits by the hunt file."""
+        (tmp_path / ".athfconfig.yaml").write_text(
+            "workspace_name: shadow-test\n", encoding="utf-8"
+        )
+        deep = tmp_path / "hunts" / "production" / "2026" / "Q2"
+        deep.mkdir(parents=True)
+        (deep / ".athfconfig.yaml").write_text(self.SHADOW, encoding="utf-8")
+        hunt = deep / "H-0042.md"
+        hunt.write_text(
+            "---\nhunt_id: H-0042\ntitle: Shadowed\nstatus: completed\n"
+            f"date: 2026-08-26\n{self.CONFIRMED_ENTRY}---\n{self.LOCK}",
+            encoding="utf-8",
+        )
+        return hunt
+
+    def test_shadow_config_does_not_license_confirmed(self, tmp_path):
+        from athf.core.hunt_parser import HuntParser
+
+        hunt = self._workspace(tmp_path)
+        parser = HuntParser(hunt)
+        parser.parse()
+        _, errors = parser.validate()
+
+        assert any("baseline-agent" in e for e in errors), (
+            "a config inside the hunt tree must not declare a producer; "
+            f"got errors={errors!r}"
+        )
+
+    def test_root_config_still_licenses_confirmed(self, tmp_path):
+        """Inverse: anchoring must not break the legitimate case.
+
+        The same finding, with the producer declared at the workspace root
+        instead, has to keep validating — otherwise the fix just bans
+        ``confirmed`` everywhere and the gate looks like it works.
+        """
+        from athf.core.hunt_parser import HuntParser
+
+        hunt = self._workspace(tmp_path)
+        (hunt.parent / ".athfconfig.yaml").unlink()
+        (tmp_path / ".athfconfig.yaml").write_text(self.SHADOW, encoding="utf-8")
+
+        parser = HuntParser(hunt)
+        parser.parse()
+        is_valid, errors = parser.validate()
+        assert is_valid, errors
+
+    def test_config_subdirectory_at_root_still_works(self, tmp_path):
+        """``config/.athfconfig.yaml`` is the layout ``athf init`` creates."""
+        from athf.core.hunt_parser import HuntParser
+
+        hunt = self._workspace(tmp_path)
+        (hunt.parent / ".athfconfig.yaml").unlink()
+        (tmp_path / ".athfconfig.yaml").unlink()
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / ".athfconfig.yaml").write_text(
+            self.SHADOW, encoding="utf-8"
+        )
+
+        parser = HuntParser(hunt)
+        parser.parse()
+        is_valid, errors = parser.validate()
+        assert is_valid, errors
+
+    def test_validation_and_aggregation_resolve_the_same_registry(self, tmp_path):
+        """The two surfaces must not disagree about who is declared.
+
+        A shadow config previously gave validation a producer that aggregation
+        never saw, which is the divergence class that already shipped once.
+        """
+        from athf.core.hunt_manager import HuntManager
+        from athf.core.hunt_parser import HuntParser
+
+        hunt = self._workspace(tmp_path)
+        manager = HuntManager(tmp_path / "hunts")
+
+        parser = HuntParser(hunt)
+        parser.parse()
+        is_valid, _ = parser.validate()
+
+        counted = sum(h.get("confirmed", 0) for h in manager.list_hunts())
+        assert is_valid == bool(counted), (
+            f"validate says valid={is_valid} but tally counted {counted}"
+        )

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -32,6 +32,7 @@ from athf.core.verdicts import (
     SELF_ATTESTED,
     SELF_DECLARED_CAPABILITY,
     UNATTESTED,
+    UNFILLED_HUNTER,
     UNKNOWN_PRODUCER,
     gate_failures,
     tally_frontmatter_verdicts,
@@ -225,7 +226,7 @@ class TestAttestation:
     @pytest.mark.parametrize(
         "value",
         [
-            "AI Assistant",  # the athf hunt new default — a placeholder by shipping
+            "AI Assistant",  # the old athf hunt new default, still in old frontmatter
             "agent",
             "automation",
             "n/a",
@@ -244,6 +245,55 @@ class TestAttestation:
     def test_named_human_passes(self, registry):
         # The inverse, and a guard against a name-shaped regex rejecting people.
         for name in ("Sydney Marrone", "J. Halloran", "sydney@nebulock.ai"):
+            entry = confirmation(attested_by=name)
+            assert gate_failures("findings", entry, registry=registry) == [], name
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "[Your Name]",  # ships in HUNT_LOCK.md and the init template
+            "[your name]",
+            "<Your Name>",
+            "Your Name",
+            "{{hunter}}",  # an unrendered template variable
+            "{{ hunter }}",
+            "${USER}",
+            "$USER",
+            "TODO",
+            "FIXME",
+            "XXX",
+            "name here",
+            "insert name",
+            "hunter name",
+        ],
+    )
+    def test_unfilled_placeholder_attestation_is_refused(self, registry, value):
+        # `hunter: [Your Name]` is what the shipped template writes, so a hunter
+        # who copies it into attested_by is attesting to nobody. Every value here
+        # passed before: the field asked whether a *string* was there, and a
+        # bracketed instruction to type a name is a string.
+        entry = confirmation(attested_by=value)
+        assert UNATTESTED in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_a_real_name_in_brackets_is_not_treated_as_a_placeholder(self, registry):
+        # The inverse. Bracket syntax is how the templates mark a blank, but the
+        # rule has to be about the placeholder *words*, not the punctuation —
+        # otherwise a hunter writing "[Sydney Marrone]" is called anonymous.
+        entry = confirmation(attested_by="[Sydney Marrone]")
+        assert gate_failures("findings", entry, registry=registry) == []
+
+    def test_the_marker_generators_write_is_one_the_gate_refuses(self, registry):
+        # `athf hunt new` writes UNFILLED_HUNTER when nobody supplied a name. If
+        # that value ever became attributable the field would be forgeable by
+        # doing nothing, so bind the two together here rather than trusting that
+        # a future edit to the marker remembers the gate exists.
+        entry = confirmation(attested_by=UNFILLED_HUNTER)
+        assert UNATTESTED in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_a_person_named_hunter_still_passes(self, registry):
+        # Guard against matching the placeholder words as substrings anywhere:
+        # "Hunter" is a real surname and "Todd" contains no rule of its own.
+        for name in ("Hunter Davis", "Todd Nakamura", "Xu Xiaoxia"):
             entry = confirmation(attested_by=name)
             assert gate_failures("findings", entry, registry=registry) == [], name
 

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -1,0 +1,295 @@
+"""Provenance gate: who produced a confirmation, and could they have.
+
+The prose check on ``confirmation`` was measured to a floor it cannot cross —
+"cross-validated by running a second query against the same table" is
+grammatically indistinguishable from real corroboration. This gate stops reading
+the sentence and asks instead what the producer is capable of.
+
+The invariant every test here defends: **capabilities never travel in the same
+payload as the verdict.** An LLM agent emits finding fields; it cannot emit a new
+class attribute or rewrite workspace config. So a producer that can only run
+queries is capped at ``suspected`` by construction, not by grading its prose.
+
+Each rule is tested with its inverse. The last round shipped a synonym
+false-positive because the tests agreed with the implementation's assumptions
+instead of probing them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from athf.core.provenance import (
+    CORPUS_ONLY_CAPABILITIES,
+    ProducerRegistry,
+)
+from athf.core.verdicts import (
+    CIRCULAR_CONFIRMATION,
+    CORPUS_ONLY_METHOD,
+    LEGACY_VERDICT,
+    METHOD_EXCEEDS_CAPABILITY,
+    MISSING_PROVENANCE,
+    SELF_DECLARED_CAPABILITY,
+    UNATTESTED,
+    UNKNOWN_PRODUCER,
+    gate_failures,
+)
+
+
+def codes(failures):
+    """Reason codes only — details are asserted explicitly where they matter."""
+    return {code for code, _ in failures}
+
+
+# A registry shaped the way workspace config would supply it. ``analyst`` can do
+# outside-corpus work; ``query-bot`` is the deep_baseline_investigator case.
+CONFIG = {
+    "provenance": {
+        "producers": {
+            "analyst": {"capabilities": ["clickhouse_query", "host_forensics"]},
+            "query-bot": {"capabilities": ["clickhouse_query"]},
+            "mute": {"capabilities": []},
+            "shapeless": {},
+        }
+    }
+}
+
+
+@pytest.fixture
+def registry():
+    return ProducerRegistry.from_config(CONFIG)
+
+
+def confirmed(**overrides):
+    """A ``confirmed`` finding that passes every gate predating provenance."""
+    entry = {
+        "subject": "web-prod-04 / svc_deploy",
+        "verdict": "confirmed",
+        "evidence": "process_activity shows curl piping to sh under the deploy user",
+        "confirmation": {
+            "method": "host_forensics",
+            "produced_by": "analyst",
+            "attested_by": "Sydney Marrone",
+            "detail": "recovered the dropped binary at /usr/local/bin/.upd on disk",
+        },
+    }
+    entry.update(overrides)
+    return entry
+
+
+def confirmation(**overrides):
+    """Mutate only the confirmation mapping."""
+    body = dict(confirmed()["confirmation"])
+    body.update(overrides)
+    return confirmed(confirmation=body)
+
+
+class TestRestrictiveByDefault:
+    """No declaration means ``confirmed`` is refused — including for the author."""
+
+    def test_no_registry_refuses_confirmed(self):
+        # The decision: absence is restrictive. A permissive fallback would mean
+        # every producer that skips the declaration keeps writing confirmed.
+        #
+        # The reason code is UNKNOWN_PRODUCER rather than MISSING_PROVENANCE: the
+        # finding did supply provenance, the workspace just never declared the
+        # producer. Both refuse confirmed; this one points the hunter at config
+        # instead of blaming their finding.
+        assert UNKNOWN_PRODUCER in codes(gate_failures("findings", confirmed()))
+
+    def test_no_registry_still_allows_suspected(self):
+        # The inverse. The gate applies to confirmed only; capping suspected too
+        # would leave a corpus-only agent with nothing honest to emit.
+        entry = {
+            "subject": "fin-laptop-11",
+            "verdict": "suspected",
+            "evidence": "impossible-travel sign-ins 40 minutes apart from two ASNs",
+        }
+        assert gate_failures("findings", entry) == []
+
+    def test_prose_confirmation_no_longer_reaches_confirmed(self, registry):
+        # A string confirmation carries no producer, so it cannot clear the gate
+        # however well it reads. This is the measured-ceiling fix: perfect prose
+        # is not evidence that the work happened.
+        entry = confirmed(
+            confirmation="forensic image shows the crontab entry matching process_activity"
+        )
+        assert MISSING_PROVENANCE in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_empty_capability_list_refuses_confirmed(self, registry):
+        entry = confirmation(produced_by="mute", method="host_forensics")
+        assert METHOD_EXCEEDS_CAPABILITY in codes(
+            gate_failures("findings", entry, registry=registry)
+        )
+
+    def test_producer_without_capabilities_key_refuses_confirmed(self, registry):
+        # Registered but silent about capability is not the same as capable.
+        entry = confirmation(produced_by="shapeless")
+        assert METHOD_EXCEEDS_CAPABILITY in codes(
+            gate_failures("findings", entry, registry=registry)
+        )
+
+
+class TestCapabilityCeiling:
+    """A producer cannot claim a method it never declared."""
+
+    def test_method_outside_declared_capability_is_refused(self, registry):
+        # The structural heart. query-bot declares clickhouse_query only, so
+        # host_forensics is unreachable no matter what its detail prose says.
+        entry = confirmation(produced_by="query-bot", method="host_forensics")
+        assert METHOD_EXCEEDS_CAPABILITY in codes(
+            gate_failures("findings", entry, registry=registry)
+        )
+
+    def test_declared_method_passes(self, registry):
+        # The inverse. Without this the gate could pass by refusing everything.
+        assert gate_failures("findings", confirmed(), registry=registry) == []
+
+    def test_unregistered_producer_is_refused(self, registry):
+        entry = confirmation(produced_by="ghost-agent")
+        assert UNKNOWN_PRODUCER in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_missing_produced_by_is_refused(self, registry):
+        entry = confirmed()
+        del entry["confirmation"]["produced_by"]
+        assert gate_failures("findings", entry, registry=registry) != []
+
+    def test_capability_vocabulary_stays_open(self):
+        # Orgs must be able to declare confirming work the framework never
+        # enumerated. A closed enum would make the gate wrong for everyone else.
+        reg = ProducerRegistry.from_config(
+            {"provenance": {"producers": {"ir": {"capabilities": ["memory_forensics"]}}}}
+        )
+        entry = confirmation(produced_by="ir", method="memory_forensics")
+        assert gate_failures("findings", entry, registry=reg) == []
+
+    def test_querying_never_confirms_even_when_declared(self, registry):
+        # analyst really can run ClickHouse queries, and that is still not
+        # confirmation — the corpus cannot corroborate itself. Declaring a
+        # corpus-only capability must not unlock confirmed.
+        entry = confirmation(produced_by="analyst", method="clickhouse_query")
+        assert CORPUS_ONLY_METHOD in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_every_corpus_only_capability_is_refused_as_a_method(self):
+        reg = ProducerRegistry.from_config(
+            {
+                "provenance": {
+                    "producers": {
+                        "everything": {"capabilities": sorted(CORPUS_ONLY_CAPABILITIES)}
+                    }
+                }
+            }
+        )
+        for method in sorted(CORPUS_ONLY_CAPABILITIES):
+            entry = confirmation(produced_by="everything", method=method)
+            assert CORPUS_ONLY_METHOD in codes(
+                gate_failures("findings", entry, registry=reg)
+            ), f"{method} must not confirm"
+
+
+class TestSelfDeclarationIsIgnored:
+    """Capabilities in the finding are the forgeable field this replaces."""
+
+    def test_capabilities_in_the_entry_are_refused(self, registry):
+        # One token to forge, same authoring pass as the verdict. If this ever
+        # passes, the gate has become the field it was built to replace.
+        entry = confirmed()
+        entry["analyst_capabilities"] = ["host_forensics"]
+        entry["confirmation"] = dict(entry["confirmation"], produced_by="query-bot")
+        assert SELF_DECLARED_CAPABILITY in codes(
+            gate_failures("findings", entry, registry=registry)
+        )
+
+    def test_capabilities_inside_confirmation_are_refused(self, registry):
+        entry = confirmation(produced_by="query-bot", capabilities=["host_forensics"])
+        assert SELF_DECLARED_CAPABILITY in codes(
+            gate_failures("findings", entry, registry=registry)
+        )
+
+    def test_registry_is_not_mutated_by_a_finding(self, registry):
+        entry = confirmation(produced_by="query-bot", capabilities=["host_forensics"])
+        gate_failures("findings", entry, registry=registry)
+        assert registry.capabilities_for("query-bot") == frozenset({"clickhouse_query"})
+
+
+class TestAttestation:
+    """A named human, not a role and not the agent."""
+
+    def test_missing_attestation_is_refused(self, registry):
+        entry = confirmed()
+        del entry["confirmation"]["attested_by"]
+        assert UNATTESTED in codes(gate_failures("findings", entry, registry=registry))
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "AI Assistant",  # the athf hunt new default — a placeholder by shipping
+            "agent",
+            "automation",
+            "n/a",
+            "unknown",
+            "the team",
+            "",
+            "   ",
+            True,
+            None,
+        ],
+    )
+    def test_placeholder_attestation_is_refused(self, registry, value):
+        entry = confirmation(attested_by=value)
+        assert UNATTESTED in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_named_human_passes(self, registry):
+        # The inverse, and a guard against a name-shaped regex rejecting people.
+        for name in ("Sydney Marrone", "J. Halloran", "sydney@nebulock.ai"):
+            entry = confirmation(attested_by=name)
+            assert gate_failures("findings", entry, registry=registry) == [], name
+
+
+class TestProseDetailStillGated:
+    """Provenance adds a gate; it does not retire the circularity check."""
+
+    def test_circular_detail_is_still_refused(self, registry):
+        # A capable producer with a named attestor can still write a circular
+        # account, and it must still fail. Provenance says the work was possible,
+        # not that this sentence describes it.
+        entry = confirmation(detail="see telemetry above")
+        assert CIRCULAR_CONFIRMATION in codes(
+            gate_failures("findings", entry, registry=registry)
+        )
+
+    def test_missing_detail_is_refused(self, registry):
+        entry = confirmation(detail="n/a")
+        assert gate_failures("findings", entry, registry=registry) != []
+
+    def test_substantive_detail_passes(self, registry):
+        entry = confirmation(
+            detail="replayed the technique on a sacrificial host in the range"
+        )
+        assert gate_failures("findings", entry, registry=registry) == []
+
+
+class TestBackwardsCompatibility:
+    """Ships to PyPI. Existing files must not gain new meaning."""
+
+    def test_legacy_verdicts_are_never_promoted(self, registry):
+        for verdict in ("tp", "fp"):
+            failures = codes(gate_failures("findings", {"verdict": verdict}, registry=registry))
+            assert failures == {LEGACY_VERDICT}
+
+    def test_ungated_verdicts_are_untouched_by_provenance(self, registry):
+        entry = {
+            "subject": "build-runner-02",
+            "verdict": "attempted_not_vulnerable",
+            "reason": "execution blocked before the payload ran",
+            "control": "SELinux enforcing mode",
+        }
+        assert gate_failures("ruled_out", entry, registry=registry) == []
+
+    def test_registry_from_config_without_provenance_section(self):
+        # Every workspace on PyPI today. Must load, and must be restrictive.
+        reg = ProducerRegistry.from_config({"siem": "Splunk"})
+        assert reg.is_empty()
+        assert UNKNOWN_PRODUCER in codes(
+            gate_failures("findings", confirmed(), registry=reg)
+        )

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -29,10 +29,12 @@ from athf.core.verdicts import (
     LEGACY_VERDICT,
     METHOD_EXCEEDS_CAPABILITY,
     MISSING_PROVENANCE,
+    SELF_ATTESTED,
     SELF_DECLARED_CAPABILITY,
     UNATTESTED,
     UNKNOWN_PRODUCER,
     gate_failures,
+    tally_frontmatter_verdicts,
 )
 
 
@@ -244,6 +246,91 @@ class TestAttestation:
         for name in ("Sydney Marrone", "J. Halloran", "sydney@nebulock.ai"):
             entry = confirmation(attested_by=name)
             assert gate_failures("findings", entry, registry=registry) == [], name
+
+
+class TestAttestationIsIndependentOfTheProducer:
+    """A producer cannot vouch for itself.
+
+    ``attested_by`` exists so a second party is answerable for work that happened
+    outside the corpus. When the same name fills both fields, nobody independent
+    vouched for anything — the finding asserts "I did it, and I confirm I did it",
+    which is the self-declaration the whole design moves out of the payload.
+
+    Unlike the role-word denylist this is a closed rule: the producer name is
+    already in the finding, so the check is a comparison rather than an
+    enumeration, and it cannot be evaded by picking different vocabulary.
+    """
+
+    def test_producer_cannot_attest_to_itself(self, registry):
+        entry = confirmation(produced_by="analyst", attested_by="analyst")
+        assert SELF_ATTESTED in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_self_attestation_survives_case_and_padding(self, registry):
+        # The comparison has to normalize, or the rule is one shift key wide.
+        for spelling in ("Analyst", "  analyst  ", "ANALYST"):
+            entry = confirmation(produced_by="analyst", attested_by=spelling)
+            assert SELF_ATTESTED in codes(
+                gate_failures("findings", entry, registry=registry)
+            ), spelling
+
+    def test_another_registered_producer_cannot_attest(self, registry):
+        # A registered producer is a tool or a team in config, not a person who
+        # can be asked about it. Naming a *different* one is still not a human
+        # attestation, so the gate refuses it for the same reason.
+        entry = confirmation(produced_by="analyst", attested_by="query-bot")
+        assert SELF_ATTESTED in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_a_human_attesting_to_a_producer_still_passes(self, registry):
+        # The inverse, and the case the field is for: a person vouches for the
+        # tool's output. This must stay clean or the gate is unusable.
+        entry = confirmation(produced_by="analyst", attested_by="Sydney Marrone")
+        assert gate_failures("findings", entry, registry=registry) == []
+
+    def test_a_human_whose_name_is_not_in_config_passes(self, registry):
+        # Guard against implementing this as "attested_by must be absent from the
+        # registry" in a way that also rejects unregistered *tools*: the rule is
+        # about the producer relationship, not about registry membership per se.
+        entry = confirmation(produced_by="analyst", attested_by="J. Halloran")
+        assert gate_failures("findings", entry, registry=registry) == []
+
+    def test_self_attestation_is_refused_for_a_capable_producer(self, registry):
+        # The break as found: every other gate satisfied, capability real, detail
+        # substantive — and still refused, because the attestation is circular.
+        entry = confirmed(
+            confirmation={
+                "method": "host_forensics",
+                "produced_by": "analyst",
+                "attested_by": "analyst",
+                "detail": "host triage recovered the crontab entry for svc_deploy from disk",
+            }
+        )
+        assert SELF_ATTESTED in codes(gate_failures("findings", entry, registry=registry))
+
+    def test_self_attestation_is_not_counted_by_aggregation(self, registry):
+        # Validation and aggregation have diverged twice on this design. The tally
+        # must refuse what validate refuses, or the dashboard credits it anyway.
+        frontmatter = {
+            "findings": [
+                confirmed(
+                    confirmation={
+                        "method": "host_forensics",
+                        "produced_by": "analyst",
+                        "attested_by": "analyst",
+                        "detail": "recovered the launchd plist from the endpoint disk image",
+                    }
+                )
+            ]
+        }
+        counts = tally_frontmatter_verdicts(frontmatter, registry)
+        assert counts is not None
+        assert counts["confirmed"] == 0
+
+    def test_unattributable_placeholder_still_reports_unattested(self, registry):
+        # Two different problems keep two different reason codes: naming nobody is
+        # not the same as a producer naming itself, and the hunter needs the
+        # instruction that matches their mistake.
+        entry = confirmation(produced_by="analyst", attested_by="the team")
+        assert UNATTESTED in codes(gate_failures("findings", entry, registry=registry))
 
 
 class TestProseDetailStillGated:

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -22,6 +22,7 @@ import pytest
 from athf.core.provenance import (
     CORPUS_ONLY_CAPABILITIES,
     ProducerRegistry,
+    confirming_capabilities,
 )
 from athf.core.verdicts import (
     CIRCULAR_CONFIRMATION,
@@ -188,6 +189,75 @@ class TestCapabilityCeiling:
             assert CORPUS_ONLY_METHOD in codes(
                 gate_failures("findings", entry, registry=reg)
             ), f"{method} must not confirm"
+
+
+class TestTheOneProducerCollapse:
+    """A single all-capable producer turns the gate back into a typing exercise.
+
+    Small teams reach for this: one team does all the work, so they declare one
+    producer and give it everything true of the team collectively. The capability
+    check then never refuses anything, because there is no method the sole
+    producer cannot claim — the gate degrades to "did you spell a method word",
+    which is precisely the fill-in-the-field failure provenance replaced.
+
+    Nothing in code can distinguish an honest broad declaration from a careless
+    one, so this is not enforceable. What the framework owes an operator is the
+    warning at the point of the decision: producers are *surfaces* with different
+    reach, not an org chart. One team can, and usually should, declare several.
+    """
+
+    ALL_CAPABLE = {
+        "provenance": {
+            "producers": {
+                "deth": {
+                    "capabilities": [
+                        "clickhouse_query",
+                        "host_forensics",
+                        "configuration_review",
+                        "range_reproduction",
+                    ]
+                }
+            }
+        }
+    }
+
+    def test_one_all_capable_producer_refuses_nothing(self):
+        # Demonstrates the collapse rather than preventing it: every confirming
+        # method passes, so the capability ceiling has stopped being a ceiling.
+        reg = ProducerRegistry.from_config(self.ALL_CAPABLE)
+        for method in ("host_forensics", "configuration_review", "range_reproduction"):
+            entry = confirmation(produced_by="deth", method=method)
+            assert gate_failures("findings", entry, registry=reg) == [], method
+
+    def test_splitting_the_agent_out_restores_the_ceiling(self):
+        # The remedy, and the shape the stub has to teach: the same team, with
+        # its query-only agent declared as its own producer, is capped again.
+        split = {
+            "provenance": {
+                "producers": {
+                    "deth": {"capabilities": ["host_forensics", "configuration_review"]},
+                    "baseline-agent": {"capabilities": ["clickhouse_query"]},
+                }
+            }
+        }
+        reg = ProducerRegistry.from_config(split)
+        entry = confirmation(produced_by="baseline-agent", method="host_forensics")
+        assert METHOD_EXCEEDS_CAPABILITY in codes(
+            gate_failures("findings", entry, registry=reg)
+        )
+        assert not confirming_capabilities(reg, "baseline-agent")
+
+    def test_the_stub_warns_that_producers_are_surfaces(self):
+        # The only enforceable part: the guidance an operator reads before they
+        # make this decision must say it. A stub showing three producers without
+        # saying why lets a one-team org collapse them and think it equivalent.
+        from athf.commands.init import PROVENANCE_STUB
+
+        lowered = PROVENANCE_STUB.lower()
+        assert "surface" in lowered, "the stub must frame producers as surfaces"
+        assert "one team" in lowered or "same team" in lowered, (
+            "the stub must say a single team can declare several producers"
+        )
 
 
 class TestSelfDeclarationIsIgnored:

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -626,3 +626,98 @@ class TestConfigCannotBeShadowedFromInsideTheHuntTree:
         assert is_valid == bool(counted), (
             f"validate says valid={is_valid} but tally counted {counted}"
         )
+
+
+class TestWorkspaceUnderAnAncestorNamedHunts:
+    """An unrelated ancestor named ``hunts`` must not disable ``confirmed``.
+
+    ``load_registry`` walks up from a starting directory and skips anything
+    inside the workspace hunt tree, so a shadow config beside a hunt file can't
+    license itself. That skip used to test ``"hunts" in directory.parts`` against
+    the full absolute path — so a workspace living under any ancestor named
+    ``hunts`` (``/srv/hunts/athf-ws``) had every candidate directory from the
+    root upward skipped. The root ``.athfconfig.yaml`` was never read, the
+    registry came back empty, and ``confirmed`` became unreachable for the whole
+    workspace with no diagnostic. Anchoring the check to the workspace root fixes
+    it while keeping the shadow-config protection.
+    """
+
+    CONFIRMED_ENTRY = (
+        "findings:\n"
+        "  - subject: host dev-20\n"
+        "    verdict: confirmed\n"
+        "    evidence: process_activity rows show crontab spawned by curl\n"
+        "    confirmation:\n"
+        "      method: host_forensics\n"
+        "      produced_by: baseline-agent\n"
+        "      attested_by: Sydney Marrone\n"
+        "      detail: recovered the dropped binary from the imaged disk\n"
+    )
+
+    LOCK = "\n## LEARN\nx\n\n## OBSERVE\nx\n\n## CHECK\nx\n\n## KEEP\nx\n"
+
+    ROOT_CONFIG = (
+        "provenance:\n"
+        "  producers:\n"
+        "    baseline-agent:\n"
+        "      capabilities: [clickhouse_query, host_forensics]\n"
+    )
+
+    def _workspace(self, tmp_path):
+        """Workspace root sits below an ancestor directory named ``hunts``."""
+        workspace = tmp_path / "hunts" / "athf-ws"
+        (workspace).mkdir(parents=True)
+        (workspace / ".athfconfig.yaml").write_text(
+            self.ROOT_CONFIG, encoding="utf-8"
+        )
+        deep = workspace / "hunts" / "production" / "2026" / "Q2"
+        deep.mkdir(parents=True)
+        hunt = deep / "H-0042.md"
+        hunt.write_text(
+            "---\nhunt_id: H-0042\ntitle: Nested\nstatus: completed\n"
+            f"date: 2026-08-26\n{self.CONFIRMED_ENTRY}---\n{self.LOCK}",
+            encoding="utf-8",
+        )
+        return workspace, hunt
+
+    def test_root_config_licenses_confirmed(self, tmp_path):
+        from athf.core.hunt_parser import HuntParser
+
+        _, hunt = self._workspace(tmp_path)
+        parser = HuntParser(hunt)
+        parser.parse()
+        is_valid, errors = parser.validate()
+        assert is_valid, errors
+
+    def test_shadow_config_beside_hunt_still_ignored(self, tmp_path):
+        """The nested ancestor must not weaken the self-declaration ban."""
+        from athf.core.hunt_parser import HuntParser
+
+        workspace, hunt = self._workspace(tmp_path)
+        (workspace / ".athfconfig.yaml").unlink()
+        (hunt.parent / ".athfconfig.yaml").write_text(
+            self.ROOT_CONFIG, encoding="utf-8"
+        )
+        parser = HuntParser(hunt)
+        parser.parse()
+        _, errors = parser.validate()
+        assert any("baseline-agent" in e for e in errors), (
+            "a config inside the hunt tree must not declare a producer even when "
+            f"the workspace sits under a 'hunts' ancestor; got errors={errors!r}"
+        )
+
+    def test_validation_and_aggregation_agree(self, tmp_path):
+        from athf.core.hunt_manager import HuntManager
+        from athf.core.hunt_parser import HuntParser
+
+        workspace, hunt = self._workspace(tmp_path)
+        manager = HuntManager(workspace / "hunts")
+
+        parser = HuntParser(hunt)
+        parser.parse()
+        is_valid, _ = parser.validate()
+
+        counted = sum(h.get("confirmed", 0) for h in manager.list_hunts())
+        assert is_valid and counted == 1, (
+            f"validate valid={is_valid}, tally counted {counted}"
+        )

--- a/tests/core/test_verdicts.py
+++ b/tests/core/test_verdicts.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from athf.core.provenance import ProducerRegistry
 from athf.core.verdicts import (
     CIRCULAR_CONFIRMATION,
     CONFIRMED,
@@ -20,6 +21,42 @@ from athf.core.verdicts import (
     requires_evidence,
     tally_frontmatter_verdicts,
 )
+
+# Capabilities live in workspace config, never in the finding — an agent can emit
+# a confirmation mapping but cannot rewrite this. Shaped the way
+# ``.athfconfig.yaml`` supplies it so these tests exercise the real gate input.
+PRODUCER_CONFIG = {
+    "provenance": {
+        "producers": {
+            "analyst": {
+                "capabilities": [
+                    "clickhouse_query",
+                    "host_forensics",
+                    "range_reproduction",
+                ]
+            }
+        }
+    }
+}
+
+
+@pytest.fixture
+def registry():
+    return ProducerRegistry.from_config(PRODUCER_CONFIG)
+
+
+def provenance(detail: str, method: str = "host_forensics") -> dict:
+    """A confirmation mapping whose producer really declared ``method``.
+
+    ``detail`` still carries the prose account, so the circularity and deferral
+    checks apply to it exactly as they did to the old string field.
+    """
+    return {
+        "method": method,
+        "produced_by": "analyst",
+        "attested_by": "Sydney Marrone",
+        "detail": detail,
+    }
 
 
 class TestVocabulary:
@@ -358,6 +395,14 @@ class TestTheResidualIsAcknowledged:
     that made the gate worth routing around in the first place. Closing this needs
     provenance — what the producer was capable of, and who attests to it — not a
     fifteenth pattern.
+
+    Provenance moved this residual; it did not delete it. Prose on its own no
+    longer reaches ``confirmed`` at all, so the strings below can only slip
+    through inside a ``confirmation.detail`` whose producer was declared capable
+    of out-of-corpus work. What remains forgeable is that declaration — a human
+    editing ``.athfconfig.yaml`` — which is the accepted residual, because the lie
+    now lives in a separate file an auditor can read instead of in unfalsifiable
+    prose. These stay pinned so nobody tries to close the gap with more regex.
     """
 
     @pytest.mark.parametrize(
@@ -375,12 +420,19 @@ class TestTheResidualIsAcknowledged:
         assert cites_the_corpus(value) is False
         assert defers_confirmation(value) is False
 
-    def test_a_passing_confirmation_is_not_a_confirmed_verdict(self):
+    def test_a_passing_confirmation_is_not_a_confirmed_verdict(self, registry):
         """What the gate actually promises.
 
-        An empty failure list means no known bad phrasing was recognized. It does
-        not mean the confirmation happened. Anything reading `gate_failures` as
-        proof of rigor has the contract backwards.
+        An empty failure list means no known bad phrasing was recognized and the
+        producer was declared capable of the method it claimed. It does not mean
+        the confirmation happened. Anything reading `gate_failures` as proof of
+        rigor has the contract backwards.
+
+        The detail here describes a second query while the method claims host
+        forensics — the two contradict each other and the gate cannot see it,
+        because it reads capability from config and never audits the prose against
+        it. That is the residual provenance accepts, stated as a passing test so it
+        stays visible.
         """
         assert (
             gate_failures(
@@ -388,9 +440,11 @@ class TestTheResidualIsAcknowledged:
                 {
                     "verdict": "confirmed",
                     "evidence": "process_activity rows show crontab spawned by curl",
-                    "confirmation": "Cross-validated by running a second query "
-                    "against the same table.",
+                    "confirmation": provenance(
+                        "Cross-validated by running a second query against the same table."
+                    ),
                 },
+                registry=registry,
             )
             == []
         )
@@ -461,16 +515,28 @@ class TestGateDistinguishesCircularFromDeferred:
         assert DEFERRED_CONFIRMATION in codes
         assert CIRCULAR_CONFIRMATION not in codes
 
-    def test_real_confirmation_reports_nothing(self):
+    def test_real_confirmation_reports_nothing(self, registry):
+        """The inverse: genuine confirmation reports no failure at all.
+
+        The two tests above pass the prose as a string, which is the
+        pre-provenance shape — still checked for circularity and deferral so the
+        hunter gets the specific reason, then refused for carrying no producer.
+        Real confirmation has to come through the mapping, because that is the
+        only shape that says who did the work.
+        """
         assert (
             gate_failures(
                 "findings",
                 {
                     "verdict": "confirmed",
                     "evidence": "process_activity rows show crontab spawned by curl",
-                    "confirmation": "As documented in the range runbook, we replayed the "
-                    "technique on a sacrificial host and observed the same registry writes.",
+                    "confirmation": provenance(
+                        "As documented in the range runbook, we replayed the technique on a "
+                        "sacrificial host and observed the same registry writes.",
+                        method="range_reproduction",
+                    ),
                 },
+                registry=registry,
             )
             == []
         )
@@ -505,15 +571,18 @@ class TestEntryFailsGate:
     validate had just rejected. Both now consult this.
     """
 
-    def test_confirmed_entry_with_real_confirmation_passes(self):
+    def test_confirmed_entry_with_real_confirmation_passes(self, registry):
         assert (
             entry_fails_gate(
                 "findings",
                 {
                     "verdict": "confirmed",
                     "evidence": "process_activity rows show crontab spawned by curl",
-                    "confirmation": "host triage recovered the crontab entry from disk",
+                    "confirmation": provenance(
+                        "host triage recovered the crontab entry from disk"
+                    ),
                 },
+                registry=registry,
             )
             is False
         )
@@ -613,7 +682,7 @@ class TestTallyRespectsTheGate:
         )
         assert counts["confirmed"] == 0
 
-    def test_gated_and_ungated_entries_are_counted_separately(self):
+    def test_gated_and_ungated_entries_are_counted_separately(self, registry):
         counts = tally_frontmatter_verdicts(
             {
                 "findings": [
@@ -621,7 +690,9 @@ class TestTallyRespectsTheGate:
                         "subject": "host-a",
                         "verdict": "confirmed",
                         "evidence": "process_activity rows show crontab spawned by curl",
-                        "confirmation": "host triage recovered the crontab entry from disk",
+                        "confirmation": provenance(
+                            "host triage recovered the crontab entry from disk"
+                        ),
                     },
                     {
                         "subject": "host-b",
@@ -630,7 +701,8 @@ class TestTallyRespectsTheGate:
                         "confirmation": "n/a",
                     },
                 ]
-            }
+            },
+            registry,
         )
         assert counts["confirmed"] == 1
 

--- a/tests/core/test_verdicts.py
+++ b/tests/core/test_verdicts.py
@@ -9,8 +9,10 @@ from athf.core.verdicts import (
     VerdictError,
     counts_as_negative,
     counts_as_positive,
+    entry_fails_gate,
     normalize_verdict,
     requires_evidence,
+    tally_frontmatter_verdicts,
 )
 
 
@@ -91,3 +93,171 @@ class TestPrecisionBuckets:
         whole point of the ladder."""
         assert counts_as_positive(verdict) is False
         assert counts_as_negative(verdict) is False
+
+
+class TestEntryFailsGate:
+    """The single gate predicate shared by validation and aggregation.
+
+    `athf hunt validate` and the rollup previously answered "does this entry
+    count?" with two different pieces of code, so the tally credited entries
+    validate had just rejected. Both now consult this.
+    """
+
+    def test_confirmed_entry_with_real_confirmation_passes(self):
+        assert (
+            entry_fails_gate(
+                "findings",
+                {
+                    "verdict": "confirmed",
+                    "evidence": "process_activity rows show crontab spawned by curl",
+                    "confirmation": "host triage recovered the crontab entry from disk",
+                },
+            )
+            is False
+        )
+
+    def test_confirmed_entry_missing_confirmation_fails(self):
+        assert (
+            entry_fails_gate(
+                "findings",
+                {
+                    "verdict": "confirmed",
+                    "evidence": "process_activity rows show crontab spawned by curl",
+                },
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize("value", ["n/a", "ok", "tbd", "", "   ", True, 1, None])
+    def test_confirmed_entry_with_placeholder_confirmation_fails(self, value):
+        assert (
+            entry_fails_gate(
+                "findings",
+                {
+                    "verdict": "confirmed",
+                    "evidence": "process_activity rows show crontab spawned by curl",
+                    "confirmation": value,
+                },
+            )
+            is True
+        ), f"{value!r} slipped past the shared gate"
+
+    def test_misrouted_entry_fails(self):
+        """A confirmed entry parked in ruled_out must not be credited."""
+        assert (
+            entry_fails_gate(
+                "ruled_out",
+                {
+                    "verdict": "confirmed",
+                    "evidence": "process_activity rows show crontab spawned by curl",
+                    "confirmation": "host triage recovered the crontab entry from disk",
+                },
+            )
+            is True
+        )
+
+    def test_attempted_not_vulnerable_without_control_fails(self):
+        assert (
+            entry_fails_gate("ruled_out", {"verdict": "attempted_not_vulnerable"}) is True
+        )
+
+    def test_attempted_not_vulnerable_with_control_passes(self):
+        assert (
+            entry_fails_gate(
+                "ruled_out",
+                {"verdict": "attempted_not_vulnerable", "control": "SELinux enforcing, verified"},
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize("verdict", ["suspected", "benign", "inconclusive"])
+    def test_ungated_verdicts_pass_on_shape_alone(self, verdict):
+        """Inverse case: this fix must not quietly start gating other verdicts.
+
+        `benign` and `inconclusive` need their own referent rules, but that is a
+        separate change with its own migration cost. Sneaking it in here would
+        silently drop counts on the 127 existing ruled_out entries.
+        """
+        key = "findings" if verdict == "suspected" else "ruled_out"
+        assert entry_fails_gate(key, {"verdict": verdict}) is False
+
+    def test_unknown_verdict_fails(self):
+        assert entry_fails_gate("findings", {"verdict": "totally-pwned"}) is True
+
+    def test_legacy_verdict_inside_ladder_list_fails(self):
+        assert entry_fails_gate("findings", {"verdict": "tp"}) is True
+
+    def test_missing_verdict_fails(self):
+        assert entry_fails_gate("findings", {"subject": "host-a"}) is True
+
+    def test_non_mapping_fails(self):
+        assert entry_fails_gate("findings", "a string") is True
+
+
+class TestTallyRespectsTheGate:
+    def test_ungated_confirmed_entry_is_not_credited(self):
+        """The bug this fixes: validate rejected, the tally credited anyway."""
+        counts = tally_frontmatter_verdicts(
+            {
+                "findings": [
+                    {
+                        "subject": "host-a",
+                        "verdict": "confirmed",
+                        "evidence": "process_activity rows show crontab spawned by curl",
+                        "confirmation": "ok",
+                    }
+                ]
+            }
+        )
+        assert counts["confirmed"] == 0
+
+    def test_gated_and_ungated_entries_are_counted_separately(self):
+        counts = tally_frontmatter_verdicts(
+            {
+                "findings": [
+                    {
+                        "subject": "host-a",
+                        "verdict": "confirmed",
+                        "evidence": "process_activity rows show crontab spawned by curl",
+                        "confirmation": "host triage recovered the crontab entry from disk",
+                    },
+                    {
+                        "subject": "host-b",
+                        "verdict": "confirmed",
+                        "evidence": "process_activity rows show crontab spawned by curl",
+                        "confirmation": "n/a",
+                    },
+                ]
+            }
+        )
+        assert counts["confirmed"] == 1
+
+    def test_suspected_still_counted_without_confirmation(self):
+        """Inverse case: suspected is the honest ceiling, never gated."""
+        counts = tally_frontmatter_verdicts(
+            {"findings": [{"subject": "host-a", "verdict": "suspected", "evidence": "burst"}]}
+        )
+        assert counts["suspected"] == 1
+
+    def test_benign_still_counted(self):
+        """Inverse case: `benign` gating is a separate change, not this one."""
+        counts = tally_frontmatter_verdicts(
+            {"ruled_out": [{"subject": "svc_backup", "verdict": "benign"}]}
+        )
+        assert counts["benign"] == 1
+
+    def test_list_present_but_fully_ungated_does_not_fall_back_to_legacy(self):
+        """A rejected entry must not make the hunt look ladder-free.
+
+        Returning None here would hand the hunt back to the legacy counters and
+        let an ungated `confirmed` reappear as a legacy true positive.
+        """
+        counts = tally_frontmatter_verdicts(
+            {"findings": [{"subject": "host-a", "verdict": "confirmed", "confirmation": "ok"}]}
+        )
+        assert counts is not None
+        assert counts["confirmed"] == 0
+
+    def test_no_ladder_keys_still_returns_none(self):
+        """Inverse case: legacy hunts must keep falling back to their counters."""
+        assert tally_frontmatter_verdicts({"true_positives": 3}) is None

--- a/tests/core/test_verdicts.py
+++ b/tests/core/test_verdicts.py
@@ -3,13 +3,19 @@
 import pytest
 
 from athf.core.verdicts import (
+    CIRCULAR_CONFIRMATION,
     CONFIRMED,
+    DEFERRED_CONFIRMATION,
     LEGACY_VERDICTS,
     VERDICTS,
     VerdictError,
+    cites_the_corpus,
     counts_as_negative,
     counts_as_positive,
+    defers_confirmation,
     entry_fails_gate,
+    gate_failures,
+    is_substantive,
     normalize_verdict,
     requires_evidence,
     tally_frontmatter_verdicts,
@@ -93,6 +99,402 @@ class TestPrecisionBuckets:
         whole point of the ladder."""
         assert counts_as_positive(verdict) is False
         assert counts_as_negative(verdict) is False
+
+
+class TestCitesTheCorpus:
+    """Pointer phrasings that answer "how did you confirm?" with "look at the input".
+
+    Measured against a 100/128 labeled corpus. Every string below is quoted from
+    that measurement, so the numbers in the comments are reproducible rather than
+    asserted.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "see telemetry above",
+            "See the evidence above.",
+            "please see the query results above",
+            "same as evidence",
+            "same as above",
+            "per the query results",
+            "Per the telemetry, this is confirmed.",
+            "confirmed by the telemetry",
+            "Confirmation from the log data.",
+            "validated in the events we already have",
+        ],
+    )
+    def test_corpus_pointers_are_caught(self, value):
+        assert cites_the_corpus(value) is True, f"{value!r} pointed at the corpus and passed"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "- see telemetry above",
+            "* see the evidence above",
+            "**see above**",
+            "**See telemetry above.**",
+            "> see the query results above",
+            '"see telemetry above"',
+            "​see telemetry above",
+            "1. See telemetry above",
+            "[see above](#evidence)",
+            "_same as above_",
+            "(see telemetry above)",
+            "Reviewed the host configuration. Actually just see telemetry above.",
+        ],
+    )
+    def test_lead_in_evasions_are_normalized_away(self, value):
+        """A bullet, a bold marker, or a zero-width space used to buy a pass.
+
+        Twelve of the measured false negatives were this and nothing else — the
+        pattern was anchored at the string start and a single leading character
+        moved the pointer out of reach.
+        """
+        assert cites_the_corpus(value) is True, f"{value!r} evaded via its lead-in"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "As documented in the range runbook, we replayed the technique on a "
+            "sacrificial host and observed the same registry writes.",
+            "As described in incident report IR-2026-0431, the artifact was recovered "
+            "from disk by the forensics team.",
+            "As shown in the attached forensic timeline from the disk image, the file "
+            "predates the first execution.",
+            "As noted in the vendor's malware analysis report, the loader writes exactly "
+            "this persistence key.",
+            "As stated by the system administrator during the interview, no maintenance "
+            "window covered this activity.",
+            "See the attached forensic report IR-2026-0431 for the recovered crontab and "
+            "disk timeline.",
+            "See the attack range reproduction notes; the technique was detonated and the "
+            "artifact captured on disk.",
+            "The forensic image data confirms the artifact exists on disk independent of "
+            "the EDR telemetry.",
+        ],
+    )
+    def test_citing_outside_work_is_not_citing_the_corpus(self, value):
+        """These are the eight measured false positives — real corroboration, blocked.
+
+        Six came from one pattern that matched citation *grammar* (`^as shown`)
+        with no corpus noun anywhere in it. A hunter who writes up their range
+        detonation in a runbook and then cites the runbook has done the work; the
+        gate was punishing them for the sentence they chose to open with.
+        """
+        assert cites_the_corpus(value) is False, f"{value!r} is real work and was blocked"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "As shown in the telemetry above.",
+            "As described in the evidence above.",
+            "As noted in the query output.",
+            "As documented in the events listed above.",
+            "As detailed in the logs.",
+            "As stated in the evidence field.",
+            "​As shown in the telemetry above.",
+        ],
+    )
+    def test_citation_grammar_still_caught_when_it_names_the_corpus(self, value):
+        """The distinction the deleted pattern could not make.
+
+        `As documented in the range runbook` and `As documented in the events
+        above` share an opening and mean opposite things. Requiring the corpus
+        noun keeps the second blocked without punishing the first.
+        """
+        assert cites_the_corpus(value) is True, f"{value!r} cited the corpus and passed"
+
+    def test_possessive_corpus_still_counts(self):
+        """"Our telemetry confirms it" is the same claim as "the telemetry confirms it"."""
+        assert cites_the_corpus("Our telemetry independently confirms the finding.") is True
+
+    def test_naming_telemetry_alongside_outside_work_is_fine(self):
+        """Inverse case: the corroboration the ladder actually wants says both."""
+        assert (
+            cites_the_corpus(
+                "Forensic image of the host shows the crontab entry matching the "
+                "process_activity telemetry."
+            )
+            is False
+        )
+
+    def test_non_string_is_not_a_citation(self):
+        assert cites_the_corpus(None) is False
+        assert cites_the_corpus(True) is False
+
+
+class TestDefersConfirmation:
+    """Saying you did not do the confirmation, in a field asserting you did.
+
+    Distinct from citing the corpus: a deferral is honest about the gap. The
+    verdict is still wrong — this is `suspected` — but the message a hunter
+    should see is "downgrade it", not "you reasoned in a circle".
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Pending host forensics.",
+            "Pending forensic acquisition of the host.",
+            "Awaiting the host image from the endpoint team.",
+            "Independent confirmation is still outstanding.",
+            "Confirmation deferred to the IR team.",
+            "Planned: detonate in the attack range next sprint.",
+        ],
+    )
+    def test_temporal_deferral_is_caught(self, value):
+        assert defers_confirmation(value) is True, f"{value!r} deferred and passed"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Will confirm once the host is available.",
+            "To be confirmed after the range test.",
+            "Not yet independently verified.",
+            "Forensics requested but not yet returned.",
+            "Requires further validation by the IR team.",
+            "Interview with the admin has not happened yet.",
+        ],
+    )
+    def test_future_tense_deferral_is_caught(self, value):
+        assert defers_confirmation(value) is True, f"{value!r} deferred and passed"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "No independent confirmation performed.",
+            "No independent confirmation was possible.",
+            "No forensic artifacts were recovered.",
+            "Range reproduction not attempted.",
+            "We did not perform configuration review.",
+            "Host is offline, so no forensics were performed.",
+            "No out-of-band confirmation obtained.",
+            "Interviewed the administrator. She was unavailable, so this remains unconfirmed.",
+        ],
+    )
+    def test_negated_confirmation_is_caught(self, value):
+        assert defers_confirmation(value) is True, f"{value!r} negated itself and passed"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Could not validate.",
+            "Could not validate outside the log corpus.",
+            "Unable to confirm independently.",
+            "Unable to acquire the host before it was reimaged.",
+            "Confirmation attempt failed; the artifact had been deleted.",
+        ],
+    )
+    def test_incapacity_is_caught(self, value):
+        assert defers_confirmation(value) is True, f"{value!r} admitted incapacity and passed"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Assumed confirmed based on prior similar hunts.",
+            "Presumed malicious without further validation.",
+            "Inferred from the surrounding activity.",
+            "This is self-evident from the pattern.",
+        ],
+    )
+    def test_hedging_is_caught(self, value):
+        assert defers_confirmation(value) is True, f"{value!r} hedged and passed"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Out of scope for this hunt.",
+            "Deprioritized by the IR lead.",
+            "Accepted risk, no further work planned.",
+            "Closed without confirmation at the customer's request.",
+        ],
+    )
+    def test_declining_the_work_is_caught(self, value):
+        assert defers_confirmation(value) is True, f"{value!r} declined the work and passed"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Host forensics on WKSTN-4471 recovered the scheduled task XML under "
+            "C:\\Windows\\System32\\Tasks\\Updater, independently corroborating the "
+            "query results.",
+            "Validated in the attack range that the legitimate deployment tool cannot "
+            "produce this argument pattern, which rules out the benign explanation.",
+            "Confirmed with the on-call SRE that no maintenance was scheduled, ruling "
+            "out the change-management explanation.",
+            "Reviewed the IAM policy document and the role could not have assumed the "
+            "admin role before the change.",
+            "Detonated in the attack range; the sandbox report is attached.",
+        ],
+    )
+    def test_deferral_words_inside_real_work_still_pass(self, value):
+        """Inverse case, and the reason these patterns are narrowed.
+
+        A Windows scheduled task, a tool that *cannot* produce an argument, a
+        maintenance window that was not scheduled — the deferral vocabulary
+        collides with ordinary hunting prose. The first three are the measured
+        collateral damage from the unnarrowed patterns; blocking them would teach
+        hunters that the gate is noise and to route around it.
+        """
+        assert defers_confirmation(value) is False, f"{value!r} is real work and was blocked"
+
+    def test_non_string_is_not_a_deferral(self):
+        assert defers_confirmation(None) is False
+
+
+class TestTheResidualIsAcknowledged:
+    """Circular confirmations that no pattern set will ever catch.
+
+    These assert the gap on purpose. Every string below is a claim to have
+    confirmed a finding using nothing but the corpus, phrased with no pointer and
+    no admission. "Cross-validated by running a second query against the same
+    table" is grammatically indistinguishable from real corroboration; the only
+    thing that separates them is whether the analyst could have run anything but a
+    query, which is a fact about the analyst, not about the sentence.
+
+    Measured residual: 14 of 128, after false positives reached zero. The next
+    increment of recall costs precision on real hunting prose, which is the trade
+    that made the gate worth routing around in the first place. Closing this needs
+    provenance — what the producer was capable of, and who attests to it — not a
+    fifteenth pattern.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "The finding is supported by the telemetry we already collected.",
+            "I re-ran the query and got the same rows, which validates the finding.",
+            "Cross-validated by running a second query against the same table.",
+            "The volume of matching rows makes this conclusive.",
+            "The detection fired, which confirms the behavior.",
+            "Verified by reading the raw event JSON.",
+        ],
+    )
+    def test_undetectable_circularity_passes_the_prose_check(self, value):
+        assert cites_the_corpus(value) is False
+        assert defers_confirmation(value) is False
+
+    def test_a_passing_confirmation_is_not_a_confirmed_verdict(self):
+        """What the gate actually promises.
+
+        An empty failure list means no known bad phrasing was recognized. It does
+        not mean the confirmation happened. Anything reading `gate_failures` as
+        proof of rigor has the contract backwards.
+        """
+        assert (
+            gate_failures(
+                "findings",
+                {
+                    "verdict": "confirmed",
+                    "evidence": "process_activity rows show crontab spawned by curl",
+                    "confirmation": "Cross-validated by running a second query "
+                    "against the same table.",
+                },
+            )
+            == []
+        )
+
+
+class TestSubstantiveIsUnchanged:
+    """Inverse case: the floor and placeholder set were measured clean.
+
+    Both block 0 of 100 legitimate confirmations, so this change must leave them
+    exactly as they are. Pinned here because they are the cheapest thing to
+    "improve" while reintroducing false positives.
+    """
+
+    @pytest.mark.parametrize("value", ["n/a", "ok", "tbd", "pending", "none", "?", "-", ""])
+    def test_placeholders_still_rejected(self, value):
+        assert is_substantive(value) is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Detonated in range.",
+            "Crontab recovered.",
+            "IR-2026-0431 attached.",
+        ],
+    )
+    def test_short_but_real_confirmations_still_pass_the_floor(self, value):
+        assert is_substantive(value) is True
+
+    @pytest.mark.parametrize("value", [True, 1, None, {"method": "forensics"}, ["a"]])
+    def test_non_strings_still_rejected(self, value):
+        assert is_substantive(value) is False
+
+
+class TestGateDistinguishesCircularFromDeferred:
+    def test_corpus_citation_reports_circular(self):
+        codes = [
+            code
+            for code, _ in gate_failures(
+                "findings",
+                {
+                    "verdict": "confirmed",
+                    "evidence": "process_activity rows show crontab spawned by curl",
+                    "confirmation": "confirmed by the telemetry above",
+                },
+            )
+        ]
+        assert CIRCULAR_CONFIRMATION in codes
+        assert DEFERRED_CONFIRMATION not in codes
+
+    def test_deferral_reports_deferred(self):
+        """A different failure needs a different instruction.
+
+        Telling a hunter who wrote "pending host forensics" that they reasoned in
+        a circle is wrong and unhelpful — they know the gap; they need to be told
+        the verdict is `suspected` until it closes.
+        """
+        codes = [
+            code
+            for code, _ in gate_failures(
+                "findings",
+                {
+                    "verdict": "confirmed",
+                    "evidence": "process_activity rows show crontab spawned by curl",
+                    "confirmation": "Pending host forensics on the endpoint.",
+                },
+            )
+        ]
+        assert DEFERRED_CONFIRMATION in codes
+        assert CIRCULAR_CONFIRMATION not in codes
+
+    def test_real_confirmation_reports_nothing(self):
+        assert (
+            gate_failures(
+                "findings",
+                {
+                    "verdict": "confirmed",
+                    "evidence": "process_activity rows show crontab spawned by curl",
+                    "confirmation": "As documented in the range runbook, we replayed the "
+                    "technique on a sacrificial host and observed the same registry writes.",
+                },
+            )
+            == []
+        )
+
+    @pytest.mark.parametrize("verdict", ["suspected", "benign", "inconclusive"])
+    def test_only_confirmed_is_checked_for_deferral(self, verdict):
+        """Inverse case: `suspected` is where a deferral belongs.
+
+        "Pending host forensics" is the correct thing to write on a suspected
+        finding. Applying the deferral check to every verdict would punish
+        hunters for documenting the gap honestly.
+        """
+        key = "findings" if verdict == "suspected" else "ruled_out"
+        assert (
+            entry_fails_gate(
+                key,
+                {
+                    "verdict": verdict,
+                    "evidence": "authentication burst from a single source",
+                    "confirmation": "Pending host forensics.",
+                },
+            )
+            is False
+        )
 
 
 class TestEntryFailsGate:

--- a/tests/core/test_verdicts.py
+++ b/tests/core/test_verdicts.py
@@ -1,0 +1,93 @@
+"""Tests for the verdict ladder vocabulary."""
+
+import pytest
+
+from athf.core.verdicts import (
+    CONFIRMED,
+    LEGACY_VERDICTS,
+    VERDICTS,
+    VerdictError,
+    counts_as_negative,
+    counts_as_positive,
+    normalize_verdict,
+    requires_evidence,
+)
+
+
+class TestVocabulary:
+    def test_canonical_ladder(self):
+        assert VERDICTS == (
+            "confirmed",
+            "suspected",
+            "attempted_not_vulnerable",
+            "benign",
+            "inconclusive",
+        )
+
+    def test_legacy_verdicts_still_accepted(self):
+        assert set(LEGACY_VERDICTS) == {"tp", "fp"}
+
+
+class TestNormalize:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("confirmed", "confirmed"),
+            ("CONFIRMED", "confirmed"),
+            ("  Suspected  ", "suspected"),
+            ("attempted_not_vulnerable", "attempted_not_vulnerable"),
+            ("attempted-not-vulnerable", "attempted_not_vulnerable"),
+            ("benign", "benign"),
+            ("inconclusive", "inconclusive"),
+        ],
+    )
+    def test_canonical_values(self, raw, expected):
+        assert normalize_verdict(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["tp", "TP", "fp", "FP"])
+    def test_legacy_values_preserved_verbatim(self, raw):
+        """Legacy TP/FP normalize to lowercase but are NOT remapped onto the
+        ladder — a legacy TP never passed the evidence gate, so silently
+        promoting it to `confirmed` would fabricate rigor."""
+        assert normalize_verdict(raw) == raw.lower()
+
+    @pytest.mark.parametrize("raw", ["maybe", "", "   ", "confirmed_exploited", "true"])
+    def test_unknown_rejected(self, raw):
+        with pytest.raises(VerdictError):
+            normalize_verdict(raw)
+
+    def test_non_string_rejected(self):
+        with pytest.raises(VerdictError):
+            normalize_verdict(None)
+
+
+class TestEvidenceGate:
+    def test_confirmed_requires_evidence(self):
+        assert requires_evidence(CONFIRMED) is True
+
+    @pytest.mark.parametrize(
+        "verdict",
+        ["suspected", "attempted_not_vulnerable", "benign", "inconclusive", "tp", "fp"],
+    )
+    def test_other_tiers_do_not_require_evidence(self, verdict):
+        assert requires_evidence(verdict) is False
+
+
+class TestPrecisionBuckets:
+    @pytest.mark.parametrize("verdict", ["confirmed", "tp"])
+    def test_positive_bucket(self, verdict):
+        assert counts_as_positive(verdict) is True
+        assert counts_as_negative(verdict) is False
+
+    @pytest.mark.parametrize("verdict", ["benign", "fp"])
+    def test_negative_bucket(self, verdict):
+        assert counts_as_negative(verdict) is True
+        assert counts_as_positive(verdict) is False
+
+    @pytest.mark.parametrize("verdict", ["suspected", "attempted_not_vulnerable", "inconclusive"])
+    def test_ungraded_tiers_are_in_neither_bucket(self, verdict):
+        """`suspected` is not yet a positive and `attempted_not_vulnerable` is
+        not a false positive — keeping both out of the precision math is the
+        whole point of the ladder."""
+        assert counts_as_positive(verdict) is False
+        assert counts_as_negative(verdict) is False

--- a/tests/metrics/test_verdict_outcomes.py
+++ b/tests/metrics/test_verdict_outcomes.py
@@ -1,0 +1,51 @@
+"""Tests for verdict-ladder outcomes on the public recording API."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import athf.metrics as m
+from athf.core.verdicts import VerdictError
+
+
+def _read_events(workspace: Path) -> list[dict]:
+    path = workspace / "metrics" / "events.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+@pytest.mark.parametrize(
+    "outcome,expected",
+    [
+        ("confirmed", "confirmed"),
+        ("CONFIRMED", "confirmed"),
+        ("suspected", "suspected"),
+        ("attempted_not_vulnerable", "attempted_not_vulnerable"),
+        ("attempted-not-vulnerable", "attempted_not_vulnerable"),
+        ("benign", "benign"),
+        ("inconclusive", "inconclusive"),
+    ],
+)
+def test_ladder_verdicts_accepted(tmp_path: Path, outcome: str, expected: str) -> None:
+    m.record_hunt_outcome(hunt_id="H-1", outcome=outcome, workspace=tmp_path)
+    assert _read_events(tmp_path)[0]["outcome"] == expected
+
+
+@pytest.mark.parametrize("outcome", ["TP", "tp", "FP", "fp"])
+def test_legacy_outcomes_still_accepted_verbatim(tmp_path: Path, outcome: str) -> None:
+    m.record_hunt_outcome(hunt_id="H-1", outcome=outcome, workspace=tmp_path)
+    assert _read_events(tmp_path)[0]["outcome"] == outcome.lower()
+
+
+def test_unknown_outcome_raises_value_error(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        m.record_hunt_outcome(hunt_id="H-1", outcome="confirmed_exploited", workspace=tmp_path)
+
+
+def test_verdict_error_is_a_value_error(tmp_path: Path) -> None:
+    with pytest.raises(VerdictError):
+        m.record_hunt_outcome(hunt_id="H-1", outcome="maybe", workspace=tmp_path)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -604,7 +604,7 @@ class TestHuntValidateCommand:
 
         result = runner.invoke(hunt, ["validate", "H-9999"])
 
-        assert result.exit_code == 0  # Command runs but shows error message
+        assert result.exit_code != 0
         assert "not found" in result.output.lower()
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -60,6 +60,55 @@ class TestInitCommand:
         assert "edr" in config
         assert config["hunt_prefix"] == "H-"
 
+    def test_init_ships_provenance_stub_commented_out(self, runner, temp_workspace):
+        """A fresh workspace documents provenance without granting it.
+
+        The stub has to be inert: uncommenting is a deliberate act, because a
+        declared producer is a licence to write ``confirmed``. If init shipped a
+        live producer, whoever ran it would inherit the strongest verdict in the
+        ladder without choosing to.
+        """
+        from athf.core.provenance import load_registry
+
+        result = runner.invoke(init, ["--non-interactive"])
+        assert result.exit_code == 0
+
+        config_path = temp_workspace / "config" / ".athfconfig.yaml"
+        raw = config_path.read_text(encoding="utf-8")
+
+        assert "# provenance:" in raw, "operators need the shape to copy"
+        assert "capabilities" in raw
+
+        parsed = yaml.safe_load(raw)
+        assert "provenance" not in parsed, "the stub must not declare a live producer"
+        assert parsed["hunt_prefix"] == "H-", "trailing comment must not corrupt the config"
+
+        assert load_registry(temp_workspace).is_empty()
+
+    def test_init_provenance_stub_is_valid_yaml_once_uncommented(self, runner, temp_workspace):
+        """Stripping the comment markers must yield a working registry.
+
+        A stub that doesn't parse when uncommented is worse than no stub — the
+        operator's first contact with provenance would be a YAML error.
+        """
+        from athf.core.provenance import ProducerRegistry, confirming_capabilities
+
+        result = runner.invoke(init, ["--non-interactive"])
+        assert result.exit_code == 0
+
+        raw = (temp_workspace / "config" / ".athfconfig.yaml").read_text(encoding="utf-8")
+        block = raw[raw.index("# provenance:") :]
+        uncommented = "\n".join(
+            line[2:] for line in block.splitlines() if line.startswith("# ") or line == "#"
+        )
+
+        registry = ProducerRegistry.from_config(yaml.safe_load(uncommented))
+        assert not registry.is_empty()
+        assert confirming_capabilities(registry, "ir-team")
+        assert not confirming_capabilities(registry, "baseline-agent"), (
+            "the query-only example must stay capped at suspected"
+        )
+
     def test_init_creates_agents_file(self, runner, temp_workspace):
         """Test that init creates AGENTS.md."""
         result = runner.invoke(init, ["--non-interactive"])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,6 +3,7 @@ Tests for ATHF CLI commands using actual implementation.
 """
 
 import os
+import re
 
 import pytest
 import yaml
@@ -10,6 +11,7 @@ from click.testing import CliRunner
 
 from athf.commands.hunt import hunt
 from athf.commands.init import init
+from athf.core.verdicts import is_attributable
 
 
 @pytest.fixture
@@ -147,6 +149,18 @@ class TestInitCommand:
         assert (custom_path / "config" / ".athfconfig.yaml").exists()
 
 
+def _written_hunter(workspace):
+    """Read `hunter:` from the highest-numbered hunt file in the workspace.
+
+    Scraping the hunt ID out of `result.output` is unreliable — rich wraps the
+    digits in ANSI codes — so find the file the way the ID allocator does, by
+    number. `init` may have copied samples with lower IDs.
+    """
+    hunt_files = sorted((workspace / "hunts").rglob("H-*.md"), key=lambda p: p.stem)
+    content = hunt_files[-1].read_text(encoding="utf-8")
+    return re.search(r"^hunter:\s*(.*)$", content, re.MULTILINE).group(1).strip()
+
+
 class TestHuntNewCommand:
     """Test suite for athf hunt new command."""
 
@@ -192,6 +206,50 @@ class TestHuntNewCommand:
         assert "LSASS Memory Dumping" in content
         assert "T1003.001" in content
         assert "## LEARN" in content
+
+    def test_hunt_new_does_not_forge_a_hunter_name(self, runner, temp_workspace):
+        """An unset --hunter must not write a name nobody chose.
+
+        The old default put `hunter: AI Assistant` in a human's hunt file. That
+        name is on the unattributable list, so a hunter who copied it into
+        `attested_by` — the obvious move, it is right there in their own
+        frontmatter — got refused with nothing pointing at the default that
+        supplied it. Leaving the field visibly unfilled is the honest state.
+        """
+        runner.invoke(init, ["--non-interactive"])
+        result = runner.invoke(hunt, ["new", "--title", "No hunter given", "--non-interactive"])
+
+        assert result.exit_code == 0
+        hunter = _written_hunter(temp_workspace)
+        assert hunter != "AI Assistant"
+        # And whatever it does write must not pass attestation, or the blank is
+        # worse than the placeholder: silently forgeable instead of visibly empty.
+        assert not is_attributable(hunter), hunter
+
+    def test_hunt_new_honors_an_explicit_hunter(self, runner, temp_workspace):
+        """The inverse: a name the hunter supplied is written unchanged."""
+        runner.invoke(init, ["--non-interactive"])
+        runner.invoke(
+            hunt,
+            ["new", "--title", "Named", "--hunter", "Sydney Marrone", "--non-interactive"],
+        )
+
+        assert _written_hunter(temp_workspace) == "Sydney Marrone"
+
+    def test_hunt_new_uses_the_configured_hunter(self, runner, temp_workspace):
+        """A workspace-level hunter name spares typing it every hunt.
+
+        Unlike provenance capabilities this is safe to read from config: a name
+        is not a grant. It still has to clear attestation on its own merits.
+        """
+        runner.invoke(init, ["--non-interactive"])
+        config_path = temp_workspace / "config" / ".athfconfig.yaml"
+        config_path.write_text(
+            config_path.read_text() + "\nhunter: Sydney Marrone\n", encoding="utf-8"
+        )
+
+        runner.invoke(hunt, ["new", "--title", "From config", "--non-interactive"])
+        assert _written_hunter(temp_workspace) == "Sydney Marrone"
 
     def test_hunt_new_missing_title_non_interactive(self, runner, temp_workspace):
         """Test that hunt new fails without title in non-interactive mode."""


### PR DESCRIPTION
## What

Ships the **five-verdict ladder** and its evidence/provenance gate, and bumps the package to **0.20.0** for release to PyPI.

Replaces the legacy TP/FP model with five verdicts — `confirmed`, `suspected`, `attempted_not_vulnerable`, `benign`, `inconclusive` — and enforces, in code, the rule that **telemetry alone can never reach `confirmed`**.

### The gate (athf/core/verdicts.py, provenance.py)
- `confirmed` requires out-of-corpus confirmation (controlled reproduction, host forensics, or config review) expressed as a `confirmation` **mapping** (`method`, `produced_by`, `attested_by`, `detail`) — not prose.
- Producer capabilities are declared in `.athfconfig.yaml` `provenance.producers`, **never in the finding**. Self-declared capabilities are refused.
- A query-only producer is capped at `suspected` by construction. No provenance section ⇒ every `confirmed` is refused.
- `attested_by` must name a person, not a producer/role; self-attestation is refused. Config found inside `hunts/` is ignored (blocks self-certification beside a hunt file).
- Wired into `athf hunt validate` (exit-code enforced) and the verdict tally.

## Also in this PR (test-suite fixes, no ladder impact)
These only surfaced locally; CI was already green:
- **conftest** forces `NO_COLOR` so a dev shell exporting `FORCE_COLOR` (e.g. Ghostty) can't split rendered IDs like `I-0001` with ANSI codes and break substring assertions.
- **env.py** `env info` now catches `FileNotFoundError` alongside `CalledProcessError`, so a venv without a `pip` binary degrades gracefully instead of crashing.

## Testing
- `746 passed` locally (full suite).
- 232 ladder-specific tests (`test_verdicts.py`, `test_provenance.py`, `test_hunt_manager_verdicts.py`, `test_hunt_parser_verdicts.py`, `test_metrics_verdicts.py`) all pass.

## Release
On merge, cutting tag `v0.20.0` + publishing a GitHub Release triggers `publish.yml` → PyPI. The workflow asserts `__version__ == tag`; `athf/__version__.py` is set to `0.20.0`.

## Follow-ups (not in this PR)
- The local `.git/hooks/pre-push` was broken (bare `black --check .` swept `.claude/worktrees` + `real49/`, against a black version/py313-target the repo can't satisfy). Fixed locally to mirror CI's real gates, but the hook isn't version-controlled — worth adding a tracked `hooks/` + installer so the team shares the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added five verdict categories: confirmed, suspected, attempted-not-vulnerable, benign, and inconclusive.
  - Added evidence, provenance, attribution, and routing validation for hunt results.
  - Metrics now include per-verdict counts, precision, and workspace summaries.
  - Hunt exports support structured findings and ruled-out results.
  - Hunter attribution can come from configuration, command input, or remain unfilled.

- **Bug Fixes**
  - Improved handling of missing executables and malformed hunt data.
  - Preserved compatibility with legacy TP/FP outcomes and counters.

- **Documentation**
  - Updated templates, guides, and CLI references for the verdict workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->