### PR TITLE
fix(attack): pass tactic shortname not UUID to get_techniques_by_tactic (Closes #58)

### DIFF
--- a/athf/core/attack_matrix.py
+++ b/athf/core/attack_matrix.py
@@ -277,9 +277,11 @@ class StixProvider(AttackDataProvider):
             if not shortname:
                 continue
 
-            # Count techniques for this tactic
+            # Count techniques for this tactic. get_techniques_by_tactic filters
+            # on kill_chain_phases.phase_name, which is the tactic shortname;
+            # passing the STIX UUID here would never match (always 0).
             techniques = self._attack_data.get_techniques_by_tactic(
-                stix_tactic["id"], "enterprise-attack", remove_revoked_deprecated=True
+                shortname, "enterprise-attack", remove_revoked_deprecated=True
             )
 
             tactics[shortname] = TacticInfo(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,26 @@
 Pytest configuration and shared fixtures for ATHF tests.
 """
 
-import shutil
-import tempfile
-from pathlib import Path
+import os
 
-import pytest
+# Neutralize color-forcing env vars BEFORE any athf module (and its module-level
+# rich Console objects) is imported. rich honors FORCE_COLOR/CLICOLOR_FORCE and
+# injects ANSI escapes into the click test-runner's captured output; several CLI
+# tests assert on substrings like "Created H-0004", which break when color codes
+# split "H-" from the digits. CI has no FORCE_COLOR so it stays green, but a
+# developer whose terminal exports FORCE_COLOR (e.g. Ghostty sets FORCE_COLOR=3)
+# sees ~10 spurious failures. Forcing NO_COLOR here makes local runs match CI.
+# A rich Console reads color settings at construction, so this must happen at
+# conftest import time, not in a fixture (fixtures run after collection imports).
+os.environ.pop("FORCE_COLOR", None)
+os.environ.pop("CLICOLOR_FORCE", None)
+os.environ["NO_COLOR"] = "1"
+
+import shutil  # noqa: E402
+import tempfile  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/core/test_attack_matrix.py
+++ b/tests/core/test_attack_matrix.py
@@ -1,9 +1,71 @@
 """Tests for athf.core.attack_matrix - ATT&CK data provider abstraction."""
 
 import importlib
+import json
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _mk_id(stix_type: str) -> str:
+    return f"{stix_type}--{uuid.uuid4()}"
+
+
+def _write_synthetic_stix_bundle(path, tactics, techniques_per_tactic=3):
+    """Write a minimal STIX 2.x bundle exercising the StixProvider path.
+
+    Each tactic gets `techniques_per_tactic` attack-patterns whose
+    kill_chain_phases.phase_name matches the tactic shortname — the exact
+    field get_techniques_by_tactic filters on.
+    """
+    objects = []
+    for i, (name, shortname) in enumerate(tactics, start=1):
+        objects.append(
+            {
+                "type": "x-mitre-tactic",
+                "id": _mk_id("x-mitre-tactic"),
+                "spec_version": "2.1",
+                "name": name,
+                "x_mitre_shortname": shortname,
+                "external_references": [
+                    {"source_name": "mitre-attack", "external_id": f"TA{i:04d}"}
+                ],
+            }
+        )
+
+    counter = 1000
+    for name, shortname in tactics:
+        for _ in range(techniques_per_tactic):
+            counter += 1
+            objects.append(
+                {
+                    "type": "attack-pattern",
+                    "id": _mk_id("attack-pattern"),
+                    "spec_version": "2.1",
+                    "name": f"Technique {counter}",
+                    "external_references": [
+                        {
+                            "source_name": "mitre-attack",
+                            "external_id": f"T{counter}",
+                            "url": f"https://attack.mitre.org/techniques/T{counter}",
+                        }
+                    ],
+                    "kill_chain_phases": [
+                        {"kill_chain_name": "mitre-attack", "phase_name": shortname}
+                    ],
+                    "x_mitre_is_subtechnique": False,
+                }
+            )
+
+    bundle = {
+        "type": "bundle",
+        "id": _mk_id("bundle"),
+        "spec_version": "2.0",
+        "objects": objects,
+    }
+    path.write_text(json.dumps(bundle))
+    return len(tactics) * techniques_per_tactic
 
 
 # ---------------------------------------------------------------------------
@@ -283,3 +345,67 @@ class TestCachePaths:
         monkeypatch.chdir(tmp_path)
         cache_dir = _get_stix_cache_dir()
         assert "stix-data" in str(cache_dir)
+
+
+# ---------------------------------------------------------------------------
+# StixProvider tests (require mitreattack-python; use a synthetic bundle so no
+# network `attack update` is needed). Guards the regression where a STIX UUID
+# was passed to get_techniques_by_tactic instead of the tactic shortname,
+# making every technique_count == 0.
+# ---------------------------------------------------------------------------
+
+TACTICS = [
+    ("Credential Access", "credential-access"),
+    ("Execution", "execution"),
+    ("Persistence", "persistence"),
+]
+TECHNIQUES_PER_TACTIC = 3
+
+
+@pytest.mark.unit
+class TestStixProvider:
+    """Exercise the StixProvider path against a small synthetic STIX bundle."""
+
+    @pytest.fixture
+    def synthetic_provider(self, tmp_path):
+        pytest.importorskip(
+            "mitreattack",
+            reason="mitreattack-python not installed (optional [attack] extra)",
+        )
+        from athf.core.attack_matrix import StixProvider
+
+        bundle_path = tmp_path / "synthetic-enterprise-attack.json"
+        total = _write_synthetic_stix_bundle(
+            bundle_path, TACTICS, techniques_per_tactic=TECHNIQUES_PER_TACTIC
+        )
+        return StixProvider(stix_path=bundle_path), total
+
+    def test_tactics_have_nonzero_technique_count(self, synthetic_provider):
+        """Regression: every tactic must report technique_count > 0.
+
+        Pre-fix, a STIX UUID was passed to get_techniques_by_tactic (which
+        filters on the shortname), so every count was 0 and this assertion
+        would fail.
+        """
+        provider, _ = synthetic_provider
+        tactics = provider.get_tactics()
+
+        assert len(tactics) == len(TACTICS)
+        for shortname, info in tactics.items():
+            assert info["technique_count"] == TECHNIQUES_PER_TACTIC, (
+                f"{shortname} reported {info['technique_count']} techniques; "
+                "expected the shortname-filtered count"
+            )
+
+    def test_total_techniques_matches_bundle(self, synthetic_provider):
+        provider, total = synthetic_provider
+        assert provider.get_total_techniques() == total
+
+    def test_is_stix_true(self, synthetic_provider):
+        provider, _ = synthetic_provider
+        assert provider.is_stix() is True
+
+    def test_techniques_for_tactic_uses_shortname(self, synthetic_provider):
+        provider, _ = synthetic_provider
+        techniques = provider.get_techniques_for_tactic("credential-access")
+        assert len(techniques) == TECHNIQUES_PER_TACTIC


### PR DESCRIPTION
## What

Fixes #58. `StixProvider._build_tactics()` passed `stix_tactic["id"]` (a STIX UUID) to `get_techniques_by_tactic()`, which filters on `kill_chain_phases.phase_name` — the tactic **shortname** (e.g. `credential-access`). A UUID never matches, so every tactic reported `technique_count == 0` and `athf hunt coverage` silently under-reported whenever `[attack]` was installed with STIX data cached.

The fix passes the already-computed `shortname` (from two lines up).

## Why CI didn't catch it

CI never runs `athf attack update`, so no STIX bundle is cached and `_get_provider()` always falls back to `FallbackProvider`. The StixProvider path was never exercised and had **zero** test coverage.

## Tests

- New `TestStixProvider` suite exercises the provider against a **synthetic in-repo STIX bundle** (built in `tmp_path`, `pytest.importorskip("mitreattack")`) — no network `attack update` needed.
- Verified these tests **fail against the pre-fix code** (`assert 0 == 9`) and pass with the fix.
- Asserts non-zero `technique_count` per tactic, correct `get_total_techniques()`, and `is_stix()`.

## Second commit (test infra, not part of #58)

While validating locally, the full suite showed ~10 failures in hunt/investigate CLI tests that are green in CI. Root cause: `rich` honors `FORCE_COLOR`/`CLICOLOR_FORCE` and injects ANSI escapes into the click runner's captured output, splitting substrings like `Created H-0004` so the tests' regex can't match. A developer terminal that exports `FORCE_COLOR` (e.g. Ghostty sets `FORCE_COLOR=3`) trips this; CI has no such var. The conftest now neutralizes those vars at import time so local runs match CI. Full suite: **374 passed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected attack matrix tactic filtering to use the appropriate tactic identifiers, improving the accuracy of technique counts.
  - Ensured tactic-specific and overall technique totals are calculated consistently when working with STIX data.

- **Tests**
  - Added coverage for attack matrix counts, tactic filtering, and STIX data handling.
  - Improved test output consistency by preventing unwanted terminal color codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->